### PR TITLE
Fixed capture-preview naming behaviour

### DIFF
--- a/gphoto2/actions.c
+++ b/gphoto2/actions.c
@@ -973,7 +973,7 @@ _action_camera_capture_preview (GPParams *p, int viewasciiart)
 		return (r);
 	}
 
-	r = save_camera_file_to_file (NULL, "capture_preview", GP_FILE_TYPE_NORMAL, file, tmpfilename);
+	r = save_camera_file_to_file (NULL, "capture_preview", GP_FILE_TYPE_PREVIEW, file, tmpfilename);
 	gp_file_unref (file);
 	if (r < 0) {
 		unlink (tmpname);

--- a/gphoto2/main.c
+++ b/gphoto2/main.c
@@ -358,6 +358,14 @@ get_path_for_file (const char *folder, const char *name, CameraFileType type, Ca
 		}
 	}
 
+	/**
+	 * If the file is a capture_preview,
+	 * apply prefix over the calculated basename
+	 */
+	if (type == GP_FILE_TYPE_PREVIEW) {
+		return gp_file_get_name_by_type (file, s, type, path);
+	}
+
 	return (GP_OK);
 }
 


### PR DESCRIPTION
Launching gphoto2 as follows:

// And invoke capture-preview, saves the picture using "--filename" argument
gphoto2: {/tmp/pics} /> capture-preview
Saving file as pic.jpg

The prefix "thumb_" should be added in front of the "--filename" specified.

Without "--filename" argument:
cagphoto2: {/tmp/pics} /> capture-preview
Saving file as thumb_capture_preview.jpg

With "--filename" argument:
gphoto2: {/tmp/pics} /> capture-preview
Saving file as thumb_pic.jpg