### PR TITLE
add --bulb to manpage and correct meta data options

### DIFF
--- a/doc/gphoto2.1
+++ b/doc/gphoto2.1
@@ -63,7 +63,7 @@ gphoto2 \- command\-line gphoto2 client
 .br
 [\-\-get\-audio\-data\ \fIRANGE\ or\ NAME\fR] [\-\-get\-all\-audio\-data]
 .br
-[\-\-get\-meta\-data\ \fIRANGE\ or\ NAME\fR] [\-\-get\-all\-meta\-data] [\-\-upload\-meta\-data\ \fIFILENAME\fR]
+[\-\-get\-metadata\ \fIRANGE\ or\ NAME\fR] [\-\-get\-all\-metadata] [\-\-upload\-metadata\ \fIFILENAME\fR]
 .br
 [\-\-force\-overwrite]
 .br
@@ -78,6 +78,8 @@ gphoto2 \- command\-line gphoto2 client
 [\-\-get\-config\ \fICONFIGENTRY\fR] [\-\-set\-config\ \fICONFIGENTRY=CONFIGVALUE\fR] [\-\-set\-config\-index\ \fICONFIGENTRY=CONFIGINDEX\fR] [\-\-set\-config\-value\ \fICONFIGENTRY=CONFIGVALUE\fR] [\-\-reset]
 .br
 [\-\-capture\-preview] [\-\-show\-preview]
+.br
+[[\-B\ \fISECONDS\fR] | [\-\-bulb\ \fISECONDS\fR]]
 .br
 [[\-F\ \fICOUNT\fR] | [\-\-frames\ \fICOUNT\fR]] [[\-I\ \fISECONDS\fR] | [\-\-interval\ \fISECONDS\fR]]
 .br
@@ -385,17 +387,17 @@ Get audio data given in range\&.
 Get all audio data from folder\&.
 .RE
 .PP
-\fB\-\-upload\-meta\-data\fR \fIFILENAME\fR
+\fB\-\-upload\-metadata\fR \fIFILENAME\fR
 .RS 4
 Upload meta data for the specific file, taken from a file prefix with meta_ \&.
 .RE
 .PP
-\fB\-\-get\-meta\-data\fR \fIRANGE\fR
+\fB\-\-get\-metadata\fR \fIRANGE\fR
 .RS 4
 Get meta data given in range\&.
 .RE
 .PP
-\fB\-\-get\-all\-meta\-data\fR
+\fB\-\-get\-all\-metadata\fR
 .RS 4
 Get all meta data from folder\&.
 .RE
@@ -439,6 +441,11 @@ Capture a quick preview\&.
 \fB\-\-show\-preview\fR
 .RS 4
 Capture a quick preview and displays it in the terminal using Ascii Art (if aalib was used during build)\&.
+.RE
+.PP
+\fB\-B \fR\fB\fISECONDS\fR\fR, \fB\-\-bulb \fR\fB\fISECONDS\fR\fR
+.RS 4
+Set bulb exposure time in seconds\&.
 .RE
 .PP
 \fB\-F \fR\fB\fICOUNT\fR\fR, \fB\-\-frames \fR\fB\fICOUNT\fR\fR


### PR DESCRIPTION
The --bulb option was missing from the manpage. Also, the various metadata options were listed in the man page as, e.g. --get-meta-data but it seems that the actual options are spelt as, e.g. --get-metadata so this fixes the man page to match the actual options.

For what it's worth, I preferred the --help output as it used to be. It is now only usable on a terminal sized to be especially wide.