### PR TITLE
END sign after each configuration output, new shell flag, capture-pre…

### DIFF
--- a/gphoto2/actions.c
+++ b/gphoto2/actions.c
@@ -1732,6 +1732,8 @@ print_widget (GPParams *p, const char *name, CameraWidget *widget) {
 	case GP_WIDGET_BUTTON:
 		break;
 	}
+	
+	printf ("END\n");
 	return GP_OK;
 }
 

--- a/gphoto2/gp-params.h
+++ b/gphoto2/gp-params.h
@@ -36,7 +36,8 @@ typedef enum {
 	FLAGS_RESET_CAPTURE_INTERVAL = 1 << 7,
 	FLAGS_KEEP 		= 1 << 8,
 	FLAGS_KEEP_RAW 		= 1 << 9,
-	FLAGS_SKIP_EXISTING	= 1 << 10
+	FLAGS_SKIP_EXISTING	= 1 << 10,
+	FLAGS_SHELL	= 1 << 11
 } Flags;
 
 typedef enum {

--- a/gphoto2/main.c
+++ b/gphoto2/main.c
@@ -1546,7 +1546,9 @@ cb_arg_init (poptContext __unused__ ctx,
 	case ARG_VERSION:
 		params->p.r = print_version_action (&gp_params);
 		break;
-
+	case ARG_SHELL:
+		gp_params.flags |= FLAGS_SHELL;
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
Hi,

I have introduced the "END" mark for config output. Reason for this is that in shell mode, reading line-by-line the get-config output hangs. It is impossible to foresee how many lines a get-config output will be (menu and radio types). This allows the parser to know not to read the next line.

I have also created a new shell flag in order to add the ability to output capture-preview image via stdout. Alternative would be to let gphoto2 write image to a location on the disk, which is slower. In Linux FIFO pipe (fake files for interprocess communication) is fast though. But it is cleaner to use STDIN/OUT. I have been testing this and so far it works. But if you have time please have a look.

Best,
SarenT

