### PR TITLE
documentation: prepend configure command with ./

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ The man page is in the file doc/gphoto2.1
 ## How do I build it?
 ```
 autoreconf -is  #If using SVN source
-configure
+./configure
 make
 make install
 ```
 
-Out-of-tree builds are supported. `configure --help` may help.
+Out-of-tree builds are supported. `./configure --help` may help.
 
 To build gphoto2 you will need besides the common build tools:
 - The libgphoto2 library.


### PR DESCRIPTION
Current directory is not always in system path, so absolute path should be provided to execute the configure script.