### PR TITLE
Fix "implicit declaration of function 'basename'"

### DIFF
--- a/gphoto2/actions.c
+++ b/gphoto2/actions.c
@@ -28,6 +28,7 @@
 #include <signal.h>
 #endif
 
+#include <libgen.h>
 #include <string.h>
 #include <stdio.h>
 #ifdef HAVE_FCNTL_H


### PR DESCRIPTION
This PR fixes the following build error seen on macOS with Xcode 12 beta:

```
actions.c:105:8: error: implicit declaration of function 'basename' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                fn = basename (path);
                     ^
```
