### PR TITLE
simple parsable key value format for --list-files

### DIFF
--- a/gphoto2/actions.c
+++ b/gphoto2/actions.c
@@ -356,24 +356,52 @@ print_file_action (GPParams *p, const char *folder, const char *filename)
 	}
 
 	if (p->flags & FLAGS_QUIET)
-		printf ("%s/%s\n", folder, filename);
+        if (p->flags & FLAGS_PARSABLE) {
+            CameraFileInfo info;
+
+            printf ("FILENAME='%s/%s'", folder, filename);
+            if (gp_camera_file_get_info (p->camera, folder, filename,
+                             &info, NULL) == GP_OK) {
+                if (info.file.fields & GP_FILE_INFO_PERMISSIONS) {
+                    printf(" PERMS=%s%s",
+                           (info.file.permissions & GP_FILE_PERM_READ) ? "r" : "-",
+                           (info.file.permissions & GP_FILE_PERM_DELETE) ? "d" : "-");
+                }
+                if (info.file.fields & GP_FILE_INFO_SIZE)
+                    printf(" FILESIZE=%5ld", (unsigned long int)info.file.size);
+                if ((info.file.fields & GP_FILE_INFO_WIDTH) && +
+                    (info.file.fields & GP_FILE_INFO_HEIGHT)) {
+                    printf(" IMGWIDTH=%d", info.file.width);
+                    printf(" IMGHEIGHT=%d", info.file.height);
+                }
+                if (info.file.fields & GP_FILE_INFO_TYPE)
+                    printf(" FILETYPE=%s", info.file.type);
+                if (info.file.fields & GP_FILE_INFO_MTIME)
+                    printf(" FILEMTIME=%d", info.file.mtime);
+                printf("\n");
+            } else 
+                printf ("FILENAME='%s/%s'\n", folder, filename);
+        } else
+            printf ("%s/%s\n", folder, filename);
 	else {
 		CameraFileInfo info;
 		if (gp_camera_file_get_info (p->camera, folder, filename,
 					     &info, NULL) == GP_OK) {
 		    printf("#%-5i %-27s", x+1, filename);
 		    if (info.file.fields & GP_FILE_INFO_PERMISSIONS) {
-			printf("%s%s",
-			       (info.file.permissions & GP_FILE_PERM_READ) ? "r" : "-",
-			       (info.file.permissions & GP_FILE_PERM_DELETE) ? "d" : "-");
+                printf("%s%s",
+                       (info.file.permissions & GP_FILE_PERM_READ) ? "r" : "-",
+                       (info.file.permissions & GP_FILE_PERM_DELETE) ? "d" : "-");
 		    }
 		    if (info.file.fields & GP_FILE_INFO_SIZE)
-			printf(" %5ld KB", (unsigned long int)((info.file.size+1023) / 1024));
+                printf(" %5ld KB", (unsigned long int)((info.file.size+1023) / 1024));
 		    if ((info.file.fields & GP_FILE_INFO_WIDTH) && +
 			    (info.file.fields & GP_FILE_INFO_HEIGHT))
-			printf(" %4dx%-4d", info.file.width, info.file.height);
+                printf(" %4dx%-4d", info.file.width, info.file.height);
 		    if (info.file.fields & GP_FILE_INFO_TYPE)
-			printf(" %s", info.file.type);
+                printf(" %s", info.file.type);
+		    if (info.file.fields & GP_FILE_INFO_MTIME)
+                printf(" %d", info.file.mtime);
 		    putchar ('\n');
 		} else
 		    printf("#%-5i %s\n", x+1, filename);

--- a/gphoto2/gp-params.h
+++ b/gphoto2/gp-params.h
@@ -37,6 +37,7 @@ typedef enum {
 	FLAGS_KEEP 		= 1 << 8,
 	FLAGS_KEEP_RAW 		= 1 << 9,
 	FLAGS_SKIP_EXISTING	= 1 << 10,
+	FLAGS_PARSABLE		= 1 << 11,
 } Flags;
 
 typedef enum {

--- a/gphoto2/main.c
+++ b/gphoto2/main.c
@@ -1345,6 +1345,7 @@ typedef enum {
 	ARG_SHELL,
 	ARG_SHOW_EXIF,
 	ARG_SHOW_INFO,
+	ARG_PARSABLE,
 	ARG_SKIP_EXISTING,
 	ARG_SPEED,
 	ARG_STDOUT,
@@ -1508,6 +1509,11 @@ cb_arg_init (poptContext __unused__ ctx,
 
 	case ARG_QUIET:
 		gp_params.flags |= FLAGS_QUIET;
+		break;
+
+	case ARG_PARSABLE:
+		gp_params.flags |= FLAGS_QUIET;
+		gp_params.flags |= FLAGS_PARSABLE;
 		break;
 
 	case ARG_RESET_INTERVAL:
@@ -1986,6 +1992,8 @@ main (int argc, char **argv, char **envp)
 		 N_("Name of file to write debug info to"), N_("FILENAME")},
 		{"quiet", 'q', POPT_ARG_NONE, NULL, ARG_QUIET,
 		 N_("Quiet output (default=verbose)"), NULL},
+		{"parsable", '\0', POPT_ARG_NONE, NULL, ARG_PARSABLE,
+		 N_("Simple parsable output (implies quiet)"), NULL},
 		{"hook-script", '\0', POPT_ARG_STRING, NULL, ARG_HOOK_SCRIPT,
 		 N_("Hook script to call after downloads, captures, etc."),
 		 N_("FILENAME")},

--- a/po/az.po
+++ b/po/az.po
@@ -6,794 +6,934 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2-2.1.2\n"
-"POT-Creation-Date: 2003-08-10 20:58+0200\n"
+"Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2004-03-20 20:58+0200\n"
 "Last-Translator: Metin Amiroff <metin@karegen.com>\n"
 "Language-Team: Azerbaijani <translation-team-az@lists.sourceforge.net>\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Language: az\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: KBabel 1.0.2\n"
 
-#: gphoto2/actions.c:101
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr ""
 
-#: gphoto2/actions.c:122
-#, c-format
-msgid "There are no folders in folder '%s'."
-msgstr ""
+#: gphoto2/actions.c:201
+#, fuzzy, c-format
+msgid "There is %d folder in folder '%s'.\n"
+msgid_plural "There are %d folders in folder '%s'.\n"
+msgstr[0] "Qovluqdakı qovluqları göstər"
+msgstr[1] "Qovluqdakı qovluqları göstər"
 
-#: gphoto2/actions.c:126
-#, c-format
-msgid "There is one folder in folder '%s':"
-msgstr ""
+#: gphoto2/actions.c:250
+#, fuzzy, c-format
+msgid "There is no file in folder '%s'.\n"
+msgstr "Qovluqdakı faylları göstər"
 
-#: gphoto2/actions.c:130
-#, c-format
-msgid "There are %i folders in folder '%s':"
-msgstr ""
+#: gphoto2/actions.c:253
+#, fuzzy, c-format
+msgid "There is %d file in folder '%s'.\n"
+msgid_plural "There are %d files in folder '%s'.\n"
+msgstr[0] "Qovluqdakı faylları göstər"
+msgstr[1] "Qovluqdakı faylları göstər"
 
-#: gphoto2/actions.c:157 gphoto2/foreach.c:277
-#, c-format
-msgid "There are no files in folder '%s'."
-msgstr ""
-
-#: gphoto2/actions.c:162
-#, c-format
-msgid "There is one file in folder '%s':"
-msgstr ""
-
-#: gphoto2/actions.c:167
-#, c-format
-msgid "There are %i files in folder '%s':"
-msgstr ""
-
-#: gphoto2/actions.c:188
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr ""
 
-#: gphoto2/actions.c:190
+#: gphoto2/actions.c:277
+#, c-format
 msgid "File:\n"
 msgstr ""
 
-#: gphoto2/actions.c:192 gphoto2/actions.c:226 gphoto2/actions.c:242
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
+#, c-format
 msgid "  None available.\n"
 msgstr ""
 
-#: gphoto2/actions.c:195
-#, c-format
-msgid "  Name:        '%s'\n"
-msgstr ""
-
-#: gphoto2/actions.c:197 gphoto2/actions.c:229
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr ""
 
-#: gphoto2/actions.c:199 gphoto2/actions.c:231
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
-msgid "  Size:        %li byte(s)\n"
+msgid "  Size:        %lu byte(s)\n"
 msgstr ""
 
-#: gphoto2/actions.c:201 gphoto2/actions.c:233
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr ""
 
-#: gphoto2/actions.c:203 gphoto2/actions.c:235
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr ""
 
-#: gphoto2/actions.c:205 gphoto2/actions.c:237
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:206 gphoto2/actions.c:238 gphoto2/actions.c:250
-#: gphoto2/actions.c:548 gphoto2/actions.c:550 gphoto2/actions.c:567
-#: gphoto2/actions.c:570 gphoto2/actions.c:573 gphoto2/actions.c:576
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "bəli"
 
-#: gphoto2/actions.c:206 gphoto2/actions.c:238 gphoto2/actions.c:250
-#: gphoto2/actions.c:548 gphoto2/actions.c:550 gphoto2/actions.c:567
-#: gphoto2/actions.c:570 gphoto2/actions.c:573 gphoto2/actions.c:576
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "xeyir"
 
-#: gphoto2/actions.c:208
+#: gphoto2/actions.c:293
+#, c-format
 msgid "  Permissions: "
 msgstr ""
 
-#: gphoto2/actions.c:211
+#: gphoto2/actions.c:296
+#, c-format
 msgid "read/delete"
 msgstr ""
 
-#: gphoto2/actions.c:213
+#: gphoto2/actions.c:298
+#, c-format
 msgid "read"
 msgstr ""
 
-#: gphoto2/actions.c:215
+#: gphoto2/actions.c:300
+#, c-format
 msgid "delete"
 msgstr "sil"
 
-#: gphoto2/actions.c:217
+#: gphoto2/actions.c:302
+#, c-format
 msgid "none"
 msgstr "heç biri"
 
-#: gphoto2/actions.c:221
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr ""
 
-#: gphoto2/actions.c:224
+#: gphoto2/actions.c:309
+#, c-format
 msgid "Thumbnail:\n"
 msgstr ""
 
-#: gphoto2/actions.c:240
+#: gphoto2/actions.c:325
+#, c-format
 msgid "Audio data:\n"
 msgstr ""
 
-#: gphoto2/actions.c:245
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr ""
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:332
 #, c-format
-msgid "  Size:       %li byte(s)\n"
+msgid "  Size:       %lu byte(s)\n"
 msgstr ""
 
-#: gphoto2/actions.c:249
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:380
+#: gphoto2/actions.c:504
 msgid "Could not parse EXIF data."
 msgstr ""
 
-#: gphoto2/actions.c:384
+#: gphoto2/actions.c:508
+#, c-format
 msgid "EXIF tags:"
 msgstr ""
 
-#: gphoto2/actions.c:387
+#: gphoto2/actions.c:511
 msgid "Tag"
 msgstr "Təq"
 
-#: gphoto2/actions.c:389
+#: gphoto2/actions.c:513
 msgid "Value"
 msgstr "Qiymət"
 
-#: gphoto2/actions.c:410
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr ""
 
-#: gphoto2/actions.c:419
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr ""
 
-#: gphoto2/actions.c:437
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr ""
 
-#: gphoto2/actions.c:439
+#: gphoto2/actions.c:549
+#, c-format
 msgid "Supported cameras:\n"
 msgstr ""
 
-#: gphoto2/actions.c:452
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr ""
 
-#: gphoto2/actions.c:455
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr ""
 
-#: gphoto2/actions.c:460
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:488
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr ""
 
-#: gphoto2/actions.c:489
+#: gphoto2/actions.c:615
+#, c-format
 msgid ""
 "Path                             Description\n"
 "--------------------------------------------------------------\n"
 msgstr ""
 
-#: gphoto2/actions.c:528 gphoto2/actions.c:533
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:528
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Model"
 
-#: gphoto2/actions.c:528
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Port"
 
-#: gphoto2/actions.c:529
+#: gphoto2/actions.c:649
+#, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:546
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:547
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:549
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:552
+#: gphoto2/actions.c:673
+#, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr ""
 
-#: gphoto2/actions.c:554
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr ""
 
-#: gphoto2/actions.c:557
+#: gphoto2/actions.c:678
+#, c-format
 msgid "Capture choices                  :\n"
 msgstr ""
 
-#: gphoto2/actions.c:559
+#: gphoto2/actions.c:680
+#, c-format
 msgid "                                 : Image\n"
 msgstr ""
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:684
+#, c-format
 msgid "                                 : Video\n"
 msgstr ""
 
-#: gphoto2/actions.c:563
+#: gphoto2/actions.c:688
+#, c-format
 msgid "                                 : Audio\n"
 msgstr ""
 
-#: gphoto2/actions.c:565
+#: gphoto2/actions.c:692
+#, c-format
 msgid "                                 : Preview\n"
 msgstr ""
 
-#: gphoto2/actions.c:566
+#: gphoto2/actions.c:696
+#, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr ""
+
+#: gphoto2/actions.c:700
+#, c-format
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:568
+#: gphoto2/actions.c:704
 #, c-format
-msgid "Delete files on camera support   : %s\n"
+msgid "Delete selected files on camera  : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:571
+#: gphoto2/actions.c:707
+#, fuzzy, c-format
+msgid "Delete all files on camera       : %s\n"
+msgstr "Qovluqdakı bütün faylları sil"
+
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:574
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:591
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
 msgstr ""
 
-#: gphoto2/actions.c:630
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
 msgstr ""
 
-#: gphoto2/actions.c:668
+#: gphoto2/actions.c:797
+#, c-format
 msgid "About the camera driver:"
 msgstr ""
 
-#: gphoto2/actions.c:682
+#: gphoto2/actions.c:810
+#, c-format
 msgid "Camera summary:"
 msgstr ""
 
-#: gphoto2/actions.c:696
+#: gphoto2/actions.c:823
+#, c-format
 msgid "Camera manual:"
 msgstr ""
 
-#: gphoto2/actions.c:712
+#: gphoto2/actions.c:840
+#, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr ""
 
-#: gphoto2/actions.c:763
+#: gphoto2/actions.c:890
+msgid "OS/2 port by Bart van Leeuwen\n"
+msgstr ""
+
+#: gphoto2/actions.c:894
 #, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-2003 Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 
-#: gphoto2/actions.c:776
-msgid "OS/2 port by Bart van Leeuwen\n"
+#: gphoto2/actions.c:1015
+msgid "Could not open 'movie.mjpg'."
 msgstr ""
 
-#: gphoto2/actions.c:890
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr ""
-
-#: gphoto2/foreach.c:254
+#: gphoto2/actions.c:1022
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
+msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/foreach.c:283
+#: gphoto2/actions.c:1026
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
+msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1031
+#, c-format
+msgid "Capturing %d preview frames as movie to '%s'.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1047
+msgid "Movie capture error... Exiting."
+msgstr ""
+
+#: gphoto2/actions.c:1053
+#, c-format
+msgid "Movie capture error... Unhandled MIME type '%s'."
+msgstr ""
+
+#: gphoto2/actions.c:1060
+#, c-format
+msgid "Ctrl-C pressed ... Exiting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1074
+#, c-format
+msgid "Movie capture finished (%d frames)\n"
+msgstr ""
+
+#: gphoto2/actions.c:1106
+#, c-format
+msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1112
+#, c-format
+msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1117
+#, c-format
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1122
+#, c-format
+msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1125
+#, c-format
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1129
+#, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
+#, c-format
+msgid "event found, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
+#, fuzzy
+msgid "Could not set folder."
+msgstr "Quraşdırma seçilə bilmədi:"
+
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
+#, fuzzy
+msgid "Could not get image."
+msgstr "Quraşdırma seçilə bilmədi:"
+
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
+msgid "Buggy libcanon.so?"
+msgstr ""
+
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
+msgid "Could not delete image."
+msgstr ""
+
+#: gphoto2/actions.c:1300
+#, c-format
+msgid "Getting storage information not supported for this camera.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1315
+#, c-format
+msgid "Read-Write"
+msgstr ""
+
+#: gphoto2/actions.c:1318
+#, c-format
+msgid "Read-Only"
+msgstr ""
+
+#: gphoto2/actions.c:1321
+#, c-format
+msgid "Read-only with delete"
+msgstr ""
+
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
+#, c-format
+msgid "Unknown"
+msgstr ""
+
+#: gphoto2/actions.c:1337
+#, c-format
+msgid "Fixed ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1340
+#, c-format
+msgid "Removable ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1343
+#, c-format
+msgid "Fixed RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1346
+#, c-format
+msgid "Removable RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1356
+#, c-format
+msgid "Undefined"
+msgstr ""
+
+#: gphoto2/actions.c:1359
+#, c-format
+msgid "Generic Flat"
+msgstr ""
+
+#: gphoto2/actions.c:1362
+#, c-format
+msgid "Generic Hierarchical"
+msgstr ""
+
+#: gphoto2/actions.c:1365
+#, c-format
+msgid "Camera layout (DCIM)"
+msgstr ""
+
+#: gphoto2/actions.c:1406
+#, c-format
+msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
+msgstr ""
+
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+
+#: gphoto2/actions.c:1489
+#, c-format
+msgid "%s has been compiled with the following options:"
+msgstr ""
+
+#: gphoto2/actions.c:1629
+#, fuzzy, c-format
+msgid "%s not found in configuration tree."
+msgstr "Quraşdırma seçilə bilmədi:"
+
+#: gphoto2/actions.c:1681
+#, c-format
+msgid "Failed to retrieve value of text widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1698
+#, c-format
+msgid "Failed to retrieve values of range widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1710
+#, c-format
+msgid "Failed to retrieve values of toggle widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1722
+#, c-format
+msgid "Failed to retrieve values of date/time widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1753
+#, c-format
+msgid "Failed to retrieve values of radio widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1799
+#, c-format
+msgid "Property %s is read only."
+msgstr ""
+
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
+#, c-format
+msgid "Failed to set the value of text widget %s to %s."
+msgstr ""
+
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
+#, c-format
+msgid "The passed value %s is not a floating point value."
+msgstr ""
+
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
+#, c-format
+msgid "The passed value %f is not within the expected range %f - %f."
+msgstr ""
+
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
+#, c-format
+msgid "Failed to set the value of range widget %s to %f."
+msgstr ""
+
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
+msgid "off"
+msgstr ""
+
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
+msgid "false"
+msgstr ""
+
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
+#, fuzzy
+msgid "on"
+msgstr "Bze"
+
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
+msgid "true"
+msgstr ""
+
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
+#, c-format
+msgid "The passed value %s is not a valid toggle value."
+msgstr ""
+
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
+#, c-format
+msgid "Failed to set values %s of toggle widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
+#, fuzzy
+msgid "now"
+msgstr "xeyir"
+
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
+#, c-format
+msgid "The passed value %s is neither a valid time nor an integer."
+msgstr ""
+
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
+#, c-format
+msgid "Failed to set new time of date/time widget %s to %s."
+msgstr ""
+
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
+#, c-format
+msgid "Choice %s not found within list of choices."
+msgstr ""
+
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
+#, c-format
+msgid "The %s widget is not configurable."
+msgstr ""
+
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
+#, c-format
+msgid "Failed to set new configuration value %s for configuration entry %s."
+msgstr ""
+
+#: gphoto2/actions.c:2019
+#, c-format
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+
+#: gphoto2/foreach.c:260
+#, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+
+#: gphoto2/foreach.c:285
+#, c-format
+msgid "There are no files in folder '%s'."
 msgstr ""
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'.Please obtain a valid file number from a file listing first."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
 msgstr ""
 
-#: gphoto2/gp-params.c:53
+#: gphoto2/foreach.c:299
+#, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+
+#: gphoto2/gp-params.c:70
+#, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Xəta ***              \n"
 
-#: gphoto2/gp-params.c:220
+#: gphoto2/gp-params.c:243
+#, c-format
 msgid "Press any key to continue.\n"
 msgstr "Davam etmək üçün bir düyməyə basın.\n"
 
-#: gphoto2/gp-params.c:237
+#: gphoto2/gp-params.c:266
+#, c-format
 msgid "Not enough memory."
 msgstr "Yaddaş çatışmır."
 
-#: gphoto2/gphoto2-cmd-capture.c:201
+#: gphoto2/gphoto2-cmd-capture.c:211
 msgid "Operation cancelled"
 msgstr "Əməliyyat ləğv edildi"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Davam Et"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Ləğv Et"
 
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Xəta"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Quraşdırma seçilə bilmədi:"
 
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Çıx"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Geri"
 
-#: gphoto2/gphoto2-cmd-config.c:253
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Saat: "
 
-#: gphoto2/gphoto2-cmd-config.c:312 gphoto2/gphoto2-cmd-config.c:340
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Qiymət: "
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Bəli"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Xeyir"
 
-#: gphoto2/main.c:161 gphoto2/main.c:1461
-msgid "Turn on debugging"
-msgstr "Xəta ayırmasını fəallaşdır"
-
-#: gphoto2/main.c:162 gphoto2/main.c:1463
-msgid "Quiet output (default=verbose)"
-msgstr "Gizli yekun (ön qurğulusu=verbose)"
-
-#: gphoto2/main.c:166 gphoto2/main.c:1467
-msgid "Display version and exit"
-msgstr "Buraxılışı göstər və çıx"
-
-#: gphoto2/main.c:167
-msgid "Displays this help screen"
-msgstr "Bu yardım ekranını göstər"
-
-#: gphoto2/main.c:168 gphoto2/main.c:1469
-msgid "List supported camera models"
-msgstr "DƏstəklənən kamera modellərini göstər"
-
-#: gphoto2/main.c:169 gphoto2/main.c:1471
-msgid "List supported port devices"
-msgstr "Dəstəklənən port avadanlıqlarını göstər"
-
-#: gphoto2/main.c:170 gphoto2/main.c:1473
-msgid "Send file to stdout"
-msgstr "Faylı stdout-a göndər"
-
-#: gphoto2/main.c:171 gphoto2/main.c:1475
-msgid "Print filesize before data"
-msgstr "Datadan əvvəl fayl böyüklüyünü göstər"
-
-#: gphoto2/main.c:172 gphoto2/main.c:1477
-msgid "List auto-detected cameras"
-msgstr "Avtomatik tapılan kameraları göstər"
-
-#: gphoto2/main.c:175 gphoto2/main.c:1479
-msgid "Specify port device"
-msgstr "Port avadanlığını bildir"
-
-#: gphoto2/main.c:176 gphoto2/main.c:1481
-msgid "Specify serial transfer speed"
-msgstr "Serial transfer sür'ətini bildir"
-
-#: gphoto2/main.c:177 gphoto2/main.c:1483
-msgid "Specify camera model"
-msgstr "Kamera modelini bildir"
-
-#: gphoto2/main.c:178 gphoto2/main.c:1485
-msgid "Specify a filename"
-msgstr "Fayl adı bildir"
-
-#: gphoto2/main.c:179 gphoto2/main.c:1487
-msgid "(expert only) Override USB IDs"
-msgstr ""
-
-#: gphoto2/main.c:182 gphoto2/main.c:1489
-msgid "Display camera abilities"
-msgstr "Kamera bacarıqlarını göstər"
-
-#: gphoto2/main.c:183 gphoto2/main.c:1491
-msgid "Specify camera folder (default=\"/\")"
-msgstr ""
-
-#: gphoto2/main.c:184 gphoto2/main.c:1493
-msgid "Recursion (default for download)"
-msgstr ""
-
-#: gphoto2/main.c:185 gphoto2/main.c:1495
-msgid "No recursion (default for deletion)"
-msgstr ""
-
-#: gphoto2/main.c:186 gphoto2/main.c:1497
-msgid "List folders in folder"
-msgstr "Qovluqdakı qovluqları göstər"
-
-#: gphoto2/main.c:187 gphoto2/main.c:1499
-msgid "List files in folder"
-msgstr "Qovluqdakı faylları göstər"
-
-#: gphoto2/main.c:188 gphoto2/main.c:189
-msgid "name"
-msgstr "ad"
-
-#: gphoto2/main.c:188 gphoto2/main.c:1501
-msgid "Create a directory"
-msgstr "Cərgə yarat"
-
-#: gphoto2/main.c:189 gphoto2/main.c:1503
-msgid "Remove a directory"
-msgstr "Cərgəni sil"
-
-#: gphoto2/main.c:190 gphoto2/main.c:1505
-msgid "Display number of files"
-msgstr "Fayl ədədini göstər"
-
-#: gphoto2/main.c:191 gphoto2/main.c:1507
-msgid "Get files given in range"
-msgstr "Verilən aralıqdakı faylları al"
-
-#: gphoto2/main.c:192 gphoto2/main.c:1509
-msgid "Get all files from folder"
-msgstr "Qovluqdakı bütün faylları al"
-
-#: gphoto2/main.c:193 gphoto2/main.c:1511
-msgid "Get thumbnails given in range"
-msgstr "Verilən aralıqdakı dırnaq görünüşlərini al"
-
-#: gphoto2/main.c:194 gphoto2/main.c:1514
-msgid "Get all thumbnails from folder"
-msgstr "Qovluqdakı dırnaq görünüşlərini al"
-
-#: gphoto2/main.c:195 gphoto2/main.c:1517
-msgid "Get raw data given in range"
-msgstr "Verilən aralıqdakı xam faylları al"
-
-#: gphoto2/main.c:196 gphoto2/main.c:1520
-msgid "Get all raw data from folder"
-msgstr "Qovluqdakı bütün xam faylları al"
-
-#: gphoto2/main.c:197 gphoto2/main.c:1523
-msgid "Get audio data given in range"
-msgstr "Verilən aralıqdakı səs fayllarını al"
-
-#: gphoto2/main.c:198 gphoto2/main.c:1526
-msgid "Get all audio data from folder"
-msgstr "Qovluqdakı bütün səs fayllarını al"
-
-#: gphoto2/main.c:199 gphoto2/main.c:1528
-msgid "Delete files given in range"
-msgstr "Verilən aralıqdakı faylları sil"
-
-#: gphoto2/main.c:200 gphoto2/main.c:1530
-msgid "Delete all files in folder"
-msgstr "Qovluqdakı bütün faylları sil"
-
-#: gphoto2/main.c:201 gphoto2/main.c:1532
-msgid "Upload a file to camera"
-msgstr "Faylı kameraya yolla"
-
-#: gphoto2/main.c:203 gphoto2/main.c:1535
-msgid "Configure"
-msgstr "Quraşdır"
-
-#: gphoto2/main.c:205 gphoto2/main.c:1539
-msgid "Capture a quick preview"
-msgstr "Sür'ətli nümayiş yaxala"
-
-#: gphoto2/main.c:206 gphoto2/main.c:1541
-msgid "Capture an image"
-msgstr "Rəsm yaxala"
-
-#: gphoto2/main.c:207
-msgid "Capture a movie "
-msgstr "Film yaxala "
-
-#: gphoto2/main.c:208 gphoto2/main.c:1545
-msgid "Capture an audio clip"
-msgstr "Səs klipi yaxala"
-
-#: gphoto2/main.c:210 gphoto2/main.c:1548 gphoto2/shell.c:113
-msgid "Show EXIF information"
-msgstr "EXIF mə'lumatını göstər"
-
-#: gphoto2/main.c:212 gphoto2/main.c:1551 gphoto2/shell.c:109
-msgid "Show info"
-msgstr "Mə'lumatı göstər"
-
-#: gphoto2/main.c:213
-msgid "Summary of camera status"
-msgstr "Kamera vəziyyətinin icmalı"
-
-#: gphoto2/main.c:214
-msgid "Camera driver manual"
-msgstr "Kamera sürücüsü əl kitabı"
-
-#: gphoto2/main.c:215
-msgid "About the camera driver"
-msgstr "Kamera sürücüsü haqqında"
-
-#: gphoto2/main.c:216 gphoto2/main.c:1559
-msgid "gPhoto shell"
-msgstr "gPhoto qabığı"
-
-#: gphoto2/main.c:343 gphoto2/main.c:1192
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr ""
-
-#: gphoto2/main.c:466
-msgid "Jan"
-msgstr "Yan"
-
-#: gphoto2/main.c:466
-msgid "January"
-msgstr "Yanvar"
-
-#: gphoto2/main.c:467
-msgid "Feb"
-msgstr "Fev"
-
-#: gphoto2/main.c:467
-msgid "February"
-msgstr "Fevral"
-
-#: gphoto2/main.c:468
-msgid "Mar"
-msgstr "Mar"
-
-#: gphoto2/main.c:468
-msgid "March"
-msgstr "Mart"
-
-#: gphoto2/main.c:469
-msgid "Apr"
-msgstr "Apr"
-
-#: gphoto2/main.c:469
-msgid "April"
-msgstr "Aprel"
-
-#: gphoto2/main.c:470
-msgid "May"
-msgstr "May"
-
-#: gphoto2/main.c:471
-msgid "Jun"
-msgstr "İyn"
-
-#: gphoto2/main.c:471
-msgid "June"
-msgstr "İyun"
-
-#: gphoto2/main.c:472
-msgid "Jul"
-msgstr "İyl"
-
-#: gphoto2/main.c:472
-msgid "July"
-msgstr "İyul"
-
-#: gphoto2/main.c:473
-msgid "Aug"
-msgstr "Avq"
-
-#: gphoto2/main.c:473
-msgid "August"
-msgstr "Avqust"
-
-#: gphoto2/main.c:474
-msgid "Sep"
-msgstr "Sen"
-
-#: gphoto2/main.c:474
-msgid "September"
-msgstr "Sentyabr"
-
-#: gphoto2/main.c:475
-msgid "Oct"
-msgstr "Okt"
-
-#: gphoto2/main.c:475
-msgid "October"
-msgstr "Oktyabr"
-
-#: gphoto2/main.c:476
-msgid "Nov"
-msgstr "Noy"
-
-#: gphoto2/main.c:476
-msgid "November"
-msgstr "Noyabr"
-
-#: gphoto2/main.c:477
-msgid "Dec"
-msgstr "Dek"
-
-#: gphoto2/main.c:477
-msgid "December"
-msgstr "Dekabr"
-
-#: gphoto2/main.c:484
-msgid "Sun"
-msgstr "Baz"
-
-#: gphoto2/main.c:484
-msgid "Sunday"
-msgstr "Bazar"
-
-#: gphoto2/main.c:485
-msgid "Mon"
-msgstr "Bze"
-
-#: gphoto2/main.c:485
-msgid "Monday"
-msgstr "Bazar ertəsi"
-
-#: gphoto2/main.c:486
-msgid "Tue"
-msgstr "Çax"
-
-#: gphoto2/main.c:486
-msgid "Tuesday"
-msgstr "Çərşənbə axşamı"
-
-#: gphoto2/main.c:487
-msgid "Wed"
-msgstr "Çrş"
-
-#: gphoto2/main.c:487
-msgid "Wednesday"
-msgstr "Çərşənbə"
-
-#: gphoto2/main.c:488
-msgid "Thu"
-msgstr "Cax"
-
-#: gphoto2/main.c:488
-msgid "Thursday"
-msgstr "Cümə axşamı"
-
-#: gphoto2/main.c:489
-msgid "Fri"
-msgstr "Cüm"
-
-#: gphoto2/main.c:489
-msgid "Friday"
-msgstr "Cümə"
-
-#: gphoto2/main.c:490
-msgid "Sat"
-msgstr "Şnb"
-
-#: gphoto2/main.c:490
-msgid "Saturday"
-msgstr "Şənbə"
-
-#: gphoto2/main.c:552
+#: gphoto2/main.c:220
 #, c-format
-msgid "You cannot use '%n' in combination with non-persistent files!"
+msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr ""
 
-#: gphoto2/main.c:575
+#: gphoto2/main.c:229
+#, c-format
+msgid "You cannot use %%n zero padding without a precision value!"
+msgstr ""
+
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr ""
 
-#: gphoto2/main.c:654
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr ""
 
-#: gphoto2/main.c:701
+#: gphoto2/main.c:386 gphoto2/main.c:592
+#, fuzzy, c-format
+msgid "Skip existing file %s\n"
+msgstr "Fayl %s adı ilə qeyd edilir\n"
+
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "%s faylı mövcuddur. Üstündən yazılsın? [b|x] "
 
-#: gphoto2/main.c:712
+#: gphoto2/main.c:410
+#, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Yeni fayl adı seçilsin? [b|x] "
 
-#: gphoto2/main.c:721
+#: gphoto2/main.c:422
+#, c-format
 msgid "Enter new filename: "
 msgstr "Yeni fayl adı bildirin: "
 
-#: gphoto2/main.c:726
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Fayl %s adı ilə qeyd edilir\n"
 
-#: gphoto2/main.c:918
+#: gphoto2/main.c:630
+msgid "Permission denied"
+msgstr ""
+
+#: gphoto2/main.c:800
+msgid "Could not trigger capture."
+msgstr ""
+
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Yeni fayl kamerada %s%s%s mövqeyindədir\n"
 
-#: gphoto2/main.c:1050
+#: gphoto2/main.c:847 gphoto2/main.c:878
+#, fuzzy, c-format
+msgid "Keeping file %s%s%s on the camera\n"
+msgstr "Yeni fayl kamerada %s%s%s mövqeyindədir\n"
+
+#: gphoto2/main.c:868
+#, fuzzy, c-format
+msgid "Deleting file %s%s%s on the camera\n"
+msgstr "Yeni fayl kamerada %s%s%s mövqeyindədir\n"
+
+#: gphoto2/main.c:911
+#, c-format
+msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:916
+#, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:926
+#, c-format
+msgid "Event UNKNOWN %s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:932
+#, c-format
+msgid "Unknown event type %d during bulb wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:950
+#, fuzzy
+msgid "Could not get capabilities?"
+msgstr "Quraşdırma seçilə bilmədi:"
+
+#: gphoto2/main.c:958
+#, c-format
+msgid "Time-lapse mode enabled (interval: %ds).\n"
+msgstr ""
+
+#: gphoto2/main.c:961
+#, c-format
+msgid "Standing by waiting for SIGUSR1 to capture.\n"
+msgstr ""
+
+#: gphoto2/main.c:967
+#, c-format
+msgid "Bulb mode enabled (exposure time: %ds).\n"
+msgstr ""
+
+#: gphoto2/main.c:975
+#, c-format
+msgid "Capturing frame #%d...\n"
+msgstr ""
+
+#: gphoto2/main.c:977
+#, c-format
+msgid "Capturing frame #%d/%d...\n"
+msgstr ""
+
+#: gphoto2/main.c:987
+#, c-format
+msgid "Could not set bulb capture, result %d."
+msgstr ""
+
+#: gphoto2/main.c:1001
+msgid "Could not end capture (bulb mode)."
+msgstr ""
+
+#: gphoto2/main.c:1014
+msgid "Could not trigger image capture."
+msgstr ""
+
+#: gphoto2/main.c:1021
+#, fuzzy
+msgid "Could not capture image."
+msgstr "Rəsm yaxala"
+
+#: gphoto2/main.c:1028
+#, c-format
+msgid "Capture failed (auto-focus problem?)...\n"
+msgstr ""
+
+#: gphoto2/main.c:1039
+msgid "Could not capture."
+msgstr ""
+
+#: gphoto2/main.c:1074
+#, c-format
+msgid "Waiting for next capture slot %ld seconds...\n"
+msgstr ""
+
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
+#, c-format
+msgid "Awakened by SIGUSR1...\n"
+msgstr ""
+
+#: gphoto2/main.c:1096
+#, c-format
+msgid "not sleeping (%ld seconds behind schedule)\n"
+msgstr ""
+
+#: gphoto2/main.c:1240
+#, c-format
 msgid "ERROR: "
 msgstr "XƏTA: "
 
-#: gphoto2/main.c:1073
+#: gphoto2/main.c:1263
+#, c-format
 msgid ""
 "\n"
 "Aborting...\n"
@@ -801,11 +941,13 @@ msgstr ""
 "\n"
 "Ləğv edilir...\n"
 
-#: gphoto2/main.c:1079
+#: gphoto2/main.c:1269
+#, c-format
 msgid "Aborted.\n"
 msgstr "Ləğv edildi.\n"
 
-#: gphoto2/main.c:1084
+#: gphoto2/main.c:1274
+#, c-format
 msgid ""
 "\n"
 "Cancelling...\n"
@@ -813,15 +955,30 @@ msgstr ""
 "\n"
 "Ləğv edilir...\n"
 
-#: gphoto2/main.c:1291
+#: gphoto2/main.c:1426
+#, c-format
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 CDK dəstəyi olmadan dərlənibdir."
 
-#: gphoto2/main.c:1404
+#: gphoto2/main.c:1879
+#, c-format
 msgid "Operation cancelled.\n"
 msgstr "Əməliyyat ləğv edildi.\n"
 
-#: gphoto2/main.c:1408
+#: gphoto2/main.c:1883
+#, c-format
+msgid ""
+"*** Error: No camera found. ***\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -830,7 +987,8 @@ msgstr ""
 "*** Xəta (%i: '%s') ***       \n"
 "\n"
 
-#: gphoto2/main.c:1412
+#: gphoto2/main.c:1890
+#, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
 "Debugging messages may help finding a solution to your problem.\n"
@@ -840,237 +998,832 @@ msgid ""
 "\n"
 msgstr ""
 
-#: gphoto2/main.c:1465
-msgid "Overwrite files without asking."
-msgstr "Məzmunu soruşmadan əvəz et"
+#: gphoto2/main.c:1911
+#, c-format
+msgid ""
+"Please make sure there is sufficient quoting around the arguments.\n"
+"\n"
+msgstr ""
 
-#: gphoto2/main.c:1479
-msgid "path"
-msgstr "cığır"
+#: gphoto2/main.c:1978
+msgid "Print complete help message on program usage"
+msgstr ""
 
-#: gphoto2/main.c:1481
-msgid "speed"
-msgstr "sür'ət"
+#: gphoto2/main.c:1980
+msgid "Print short message on program usage"
+msgstr ""
 
-#: gphoto2/main.c:1483
-msgid "model"
-msgstr "model"
+#: gphoto2/main.c:1982
+msgid "Turn on debugging"
+msgstr "Xəta ayırmasını fəallaşdır"
 
-#: gphoto2/main.c:1485
-msgid "filename"
-msgstr "fayl adı"
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
 
-#: gphoto2/main.c:1487
-msgid "usbid"
-msgstr "usbid"
+#: gphoto2/main.c:1986
+msgid "Name of file to write debug info to"
+msgstr ""
 
-#: gphoto2/main.c:1491
-msgid "folder"
-msgstr "qovluq"
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
+msgid "FILENAME"
+msgstr ""
 
-#: gphoto2/main.c:1543
+#: gphoto2/main.c:1988
+msgid "Quiet output (default=verbose)"
+msgstr "Gizli yekun (ön qurğulusu=verbose)"
+
+#: gphoto2/main.c:1990
+msgid "Hook script to call after downloads, captures, etc."
+msgstr ""
+
+#: gphoto2/main.c:1997
+#, fuzzy
+msgid "Specify device port"
+msgstr "Port avadanlığını bildir"
+
+#: gphoto2/main.c:1999
+msgid "Specify serial transfer speed"
+msgstr "Serial transfer sür'ətini bildir"
+
+#: gphoto2/main.c:1999
+msgid "SPEED"
+msgstr ""
+
+#: gphoto2/main.c:2001
+msgid "Specify camera model"
+msgstr "Kamera modelini bildir"
+
+#: gphoto2/main.c:2001
+msgid "MODEL"
+msgstr ""
+
+#: gphoto2/main.c:2003
+msgid "(expert only) Override USB IDs"
+msgstr ""
+
+#: gphoto2/main.c:2003
+msgid "USBIDs"
+msgstr ""
+
+#: gphoto2/main.c:2009
+msgid "Display version and exit"
+msgstr "Buraxılışı göstər və çıx"
+
+#: gphoto2/main.c:2011
+msgid "List supported camera models"
+msgstr "DƏstəklənən kamera modellərini göstər"
+
+#: gphoto2/main.c:2013
+msgid "List supported port devices"
+msgstr "Dəstəklənən port avadanlıqlarını göstər"
+
+#: gphoto2/main.c:2015
+msgid "Display the camera/driver abilities in the libgphoto2 database"
+msgstr ""
+
+#: gphoto2/main.c:2022
+msgid "Configure"
+msgstr "Quraşdır"
+
+#: gphoto2/main.c:2025
+#, fuzzy
+msgid "List configuration tree"
+msgstr "Quraşdırma seçilə bilmədi:"
+
+#: gphoto2/main.c:2027
+msgid "Dump full configuration tree"
+msgstr ""
+
+#: gphoto2/main.c:2029
+#, fuzzy
+msgid "Get configuration value"
+msgstr "Quraşdırma seçilə bilmədi:"
+
+#: gphoto2/main.c:2031
+msgid "Set configuration value or index in choices"
+msgstr ""
+
+#: gphoto2/main.c:2033
+msgid "Set configuration value index in choices"
+msgstr ""
+
+#: gphoto2/main.c:2035
+#, fuzzy
+msgid "Set configuration value"
+msgstr "Quraşdırma seçilə bilmədi:"
+
+#: gphoto2/main.c:2037
+msgid "Reset device port"
+msgstr ""
+
+#: gphoto2/main.c:2043
+msgid "Keep images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2045
+msgid "Keep RAW images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2047
+msgid "Remove images from camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2049
+msgid "Wait for event(s) from camera"
+msgstr ""
+
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
+
+#: gphoto2/main.c:2051
+msgid "Wait for event(s) from the camera and download new images"
+msgstr ""
+
+#: gphoto2/main.c:2054
+msgid "Capture a quick preview"
+msgstr "Sür'ətli nümayiş yaxala"
+
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
+
+#: gphoto2/main.c:2059
+msgid "Set bulb exposure time in seconds"
+msgstr ""
+
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
+msgid "SECONDS"
+msgstr ""
+
+#: gphoto2/main.c:2061
+msgid "Set number of frames to capture (default=infinite)"
+msgstr ""
+
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr ""
+
+#: gphoto2/main.c:2063
+msgid "Set capture interval in seconds"
+msgstr ""
+
+#: gphoto2/main.c:2065
+msgid "Reset capture interval on signal (default=no)"
+msgstr ""
+
+#: gphoto2/main.c:2067
+msgid "Capture an image"
+msgstr "Rəsm yaxala"
+
+#: gphoto2/main.c:2069
+#, fuzzy
+msgid "Trigger capture of an image"
+msgstr "Rəsm yaxala"
+
+#: gphoto2/main.c:2071
+#, fuzzy
+msgid "Capture an image and download it"
+msgstr "Rəsm yaxala"
+
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Film yaxala"
 
-#: gphoto2/main.c:1553
-msgid "Show summary"
+#: gphoto2/main.c:2073
+msgid "COUNT or SECONDS"
+msgstr ""
+
+#: gphoto2/main.c:2075
+msgid "Capture an audio clip"
+msgstr "Səs klipi yaxala"
+
+#: gphoto2/main.c:2077
+msgid "Wait for shutter release on the camera and download"
+msgstr ""
+
+#: gphoto2/main.c:2083
+msgid "List folders in folder"
+msgstr "Qovluqdakı qovluqları göstər"
+
+#: gphoto2/main.c:2085
+msgid "List files in folder"
+msgstr "Qovluqdakı faylları göstər"
+
+#: gphoto2/main.c:2087
+msgid "Create a directory"
+msgstr "Cərgə yarat"
+
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
+msgid "DIRNAME"
+msgstr ""
+
+#: gphoto2/main.c:2089
+msgid "Remove a directory"
+msgstr "Cərgəni sil"
+
+#: gphoto2/main.c:2091
+msgid "Display number of files"
+msgstr "Fayl ədədini göstər"
+
+#: gphoto2/main.c:2093
+msgid "Get files given in range"
+msgstr "Verilən aralıqdakı faylları al"
+
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
+msgid "RANGE"
+msgstr ""
+
+#: gphoto2/main.c:2095
+msgid "Get all files from folder"
+msgstr "Qovluqdakı bütün faylları al"
+
+#: gphoto2/main.c:2097
+msgid "Get thumbnails given in range"
+msgstr "Verilən aralıqdakı dırnaq görünüşlərini al"
+
+#: gphoto2/main.c:2100
+msgid "Get all thumbnails from folder"
+msgstr "Qovluqdakı dırnaq görünüşlərini al"
+
+#: gphoto2/main.c:2102
+#, fuzzy
+msgid "Get metadata given in range"
+msgstr "Verilən aralıqdakı xam faylları al"
+
+#: gphoto2/main.c:2104
+#, fuzzy
+msgid "Get all metadata from folder"
+msgstr "Qovluqdakı bütün xam faylları al"
+
+#: gphoto2/main.c:2106
+msgid "Upload metadata for file"
+msgstr ""
+
+#: gphoto2/main.c:2109
+msgid "Get raw data given in range"
+msgstr "Verilən aralıqdakı xam faylları al"
+
+#: gphoto2/main.c:2112
+msgid "Get all raw data from folder"
+msgstr "Qovluqdakı bütün xam faylları al"
+
+#: gphoto2/main.c:2115
+msgid "Get audio data given in range"
+msgstr "Verilən aralıqdakı səs fayllarını al"
+
+#: gphoto2/main.c:2118
+msgid "Get all audio data from folder"
+msgstr "Qovluqdakı bütün səs fayllarını al"
+
+#: gphoto2/main.c:2120
+msgid "Delete files given in range"
+msgstr "Verilən aralıqdakı faylları sil"
+
+#: gphoto2/main.c:2122
+#, fuzzy
+msgid "Delete all files in folder (--no-recurse by default)"
+msgstr "Qovluqdakı bütün faylları sil"
+
+#: gphoto2/main.c:2124
+msgid "Upload a file to camera"
+msgstr "Faylı kameraya yolla"
+
+#: gphoto2/main.c:2126
+#, fuzzy
+msgid "Specify a filename or filename pattern"
+msgstr "Fayl adı bildir"
+
+#: gphoto2/main.c:2126
+msgid "FILENAME_PATTERN"
+msgstr ""
+
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
+msgid "Specify camera folder (default=\"/\")"
+msgstr ""
+
+#: gphoto2/main.c:2130
+msgid "FOLDER"
+msgstr ""
+
+#: gphoto2/main.c:2132
+msgid "Recursion (default for download)"
+msgstr ""
+
+#: gphoto2/main.c:2134
+msgid "No recursion (default for deletion)"
+msgstr ""
+
+#: gphoto2/main.c:2136
+msgid "Process new files only"
+msgstr ""
+
+#: gphoto2/main.c:2138
+#, fuzzy
+msgid "Overwrite files without asking"
+msgstr "Məzmunu soruşmadan əvəz et"
+
+#: gphoto2/main.c:2140
+msgid "Skip existing files"
+msgstr ""
+
+#: gphoto2/main.c:2146
+msgid "Send file to stdout"
+msgstr "Faylı stdout-a göndər"
+
+#: gphoto2/main.c:2148
+msgid "Print filesize before data"
+msgstr "Datadan əvvəl fayl böyüklüyünü göstər"
+
+#: gphoto2/main.c:2150
+msgid "List auto-detected cameras"
+msgstr "Avtomatik tapılan kameraları göstər"
+
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
+msgstr "EXIF mə'lumatını göstər"
+
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
+
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "İcmalı göstər"
 
-#: gphoto2/main.c:1555
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Kamera sürücüsü əl kitabını göstər"
 
-#: gphoto2/main.c:1557
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Kamera sürücüsü əl kitabı haqqında"
 
-#: gphoto2/main.c:1784
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
+#, fuzzy
+msgid "Show storage information"
+msgstr "EXIF mə'lumatını göstər"
+
+#: gphoto2/main.c:2167
+msgid "gPhoto shell"
+msgstr "gPhoto qabığı"
+
+#: gphoto2/main.c:2173
+msgid "Common options"
 msgstr ""
 
-#: gphoto2/main.c:1794
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#: gphoto2/main.c:2175
+msgid "Miscellaneous options (unsorted)"
 msgstr ""
 
-#: gphoto2/options.c:181
-msgid "Usage:\n"
-msgstr "İstifadə qaydası:\n"
-
-#: gphoto2/options.c:184
-msgid ""
-"Short/long options (& argument)        Description\n"
-"--------------------------------------------------------------------------------\n"
+#: gphoto2/main.c:2177
+msgid "Get information on software and host system (not from the camera)"
 msgstr ""
 
-#: gphoto2/options.c:209
-#, c-format
-msgid "%-38s %s\n"
-msgstr "%-38s %s\n"
+#: gphoto2/main.c:2179
+#, fuzzy
+msgid "Specify the camera to use"
+msgstr "Kamera modelini bildir"
 
-#: gphoto2/options.c:214
-msgid ""
-"--------------------------------------------------------------------------------\n"
-"[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
+#: gphoto2/main.c:2181
+#, fuzzy
+msgid "Camera and software configuration"
+msgstr "Quraşdırma seçilə bilmədi:"
+
+#: gphoto2/main.c:2183
+#, fuzzy
+msgid "Capture an image from or on the camera"
+msgstr "Kameradakı cərgəyə keç"
+
+#: gphoto2/main.c:2185
+msgid "Downloading, uploading and manipulating files"
 msgstr ""
 
-#: gphoto2/range.c:103 gphoto2/range.c:157
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
 "Image IDs must be a number greater than zero."
 msgstr ""
 
-#: gphoto2/range.c:109 gphoto2/range.c:163
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
 "Image ID %i too high."
 msgstr ""
 
-#: gphoto2/range.c:125
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
 "Ranges must be separated by ','."
 msgstr ""
 
-#: gphoto2/range.c:139
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
 "Ranges need to start with a number."
 msgstr ""
 
-#: gphoto2/range.c:179
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
 "Unexpected character '%c'."
 msgstr ""
 
-#: gphoto2/range.c:202
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 
-#: gphoto2/shell.c:55
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Xəta (%i: '%s') ***"
 
-#: gphoto2/shell.c:98
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Kameradakı cərgəyə keç"
 
-#: gphoto2/shell.c:99 gphoto2/shell.c:101
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "cərgə"
 
-#: gphoto2/shell.c:100
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Yerli sürücüdəki cərgəyə keç"
 
-#: gphoto2/shell.c:102 gphoto2/shell.c:120 gphoto2/shell.c:121
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "gPhoto qabığından çıx"
 
-#: gphoto2/shell.c:103
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Faylı endir"
 
-#: gphoto2/shell.c:103 gphoto2/shell.c:106 gphoto2/shell.c:108
-#: gphoto2/shell.c:110 gphoto2/shell.c:111 gphoto2/shell.c:114
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[cərgə/]fayladı"
 
-#: gphoto2/shell.c:105
+#: gphoto2/shell.c:132
+#, fuzzy
+msgid "Upload a file"
+msgstr "Faylı endir"
+
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Dırnaq görünüşünü endir"
 
-#: gphoto2/shell.c:107
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Xam mə'lumatı endir"
 
-#: gphoto2/shell.c:111
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Sil"
 
-#: gphoto2/shell.c:116 gphoto2/shell.c:122
+#: gphoto2/shell.c:140
+#, fuzzy
+msgid "Create Directory"
+msgstr "Cərgə yarat"
+
+#: gphoto2/shell.c:141
+#, fuzzy
+msgid "Remove Directory"
+msgstr "Cərgəni sil"
+
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Əmrin istifadə qaydasını göstər"
 
-#: gphoto2/shell.c:117 gphoto2/shell.c:122
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[əmr]"
 
-#: gphoto2/shell.c:118
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Hazırkı cərgənin məzmununu göstər"
 
-#: gphoto2/shell.c:119
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[cərgə/]"
 
-#: gphoto2/shell.c:421
+#: gphoto2/shell.c:152
+msgid "List configuration variables"
+msgstr ""
+
+#: gphoto2/shell.c:153
+msgid "Get configuration variable"
+msgstr ""
+
+#: gphoto2/shell.c:153
+msgid "name"
+msgstr "ad"
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+msgid "Set configuration variable"
+msgstr ""
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+msgid "name=value"
+msgstr ""
+
+#: gphoto2/shell.c:155
+msgid "Set configuration variable index"
+msgstr ""
+
+#: gphoto2/shell.c:155
+msgid "name=valueindex"
+msgstr ""
+
+#: gphoto2/shell.c:157
+msgid "Triggers the capture of a single image"
+msgstr ""
+
+#: gphoto2/shell.c:158
+#, fuzzy
+msgid "Capture a single image"
+msgstr "Rəsm yaxala"
+
+#: gphoto2/shell.c:159
+msgid "Capture a single image and download it"
+msgstr ""
+
+#: gphoto2/shell.c:160
+#, fuzzy
+msgid "Capture a preview image"
+msgstr "Rəsm yaxala"
+
+#: gphoto2/shell.c:161
+msgid "Wait for an event"
+msgstr ""
+
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
+msgid "count or seconds"
+msgstr ""
+
+#: gphoto2/shell.c:162
+msgid "Wait for images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:163
+msgid "Wait for events and images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Hökmsüz əmr."
 
-#: gphoto2/shell.c:430
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "'%s' əmrinə arqument verilməlidir."
 
-#: gphoto2/shell.c:483
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Hökmsüz cığır."
 
-#: gphoto2/shell.c:529
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr ""
 
-#: gphoto2/shell.c:537
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr ""
 
-#: gphoto2/shell.c:540
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr ""
 
-#: gphoto2/shell.c:578
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr ""
 
-#: gphoto2/shell.c:734
+#: gphoto2/shell.c:874
+#, c-format
+msgid "set-config needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:895
+#, c-format
+msgid "set-config-value needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:916
+#, c-format
+msgid "set-config-index needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
 msgstr ""
 
-#: gphoto2/shell.c:741
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "\"%s\" yardımı:"
 
-#: gphoto2/shell.c:743
+#: gphoto2/shell.c:988
+#, c-format
 msgid "Usage:"
 msgstr "İstifadə qaydası:"
 
-#: gphoto2/shell.c:747
+#: gphoto2/shell.c:991
+#, c-format
 msgid "Description:"
 msgstr "İzahat:"
 
-#: gphoto2/shell.c:749
+#: gphoto2/shell.c:993
+#, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr ""
 
-#: gphoto2/shell.c:770
+#: gphoto2/shell.c:1014
+#, c-format
 msgid "Available commands:"
 msgstr ""
 
-#: gphoto2/shell.c:775
+#: gphoto2/shell.c:1019
+#, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr ""
+
+#~ msgid "Displays this help screen"
+#~ msgstr "Bu yardım ekranını göstər"
+
+#~ msgid "Display camera abilities"
+#~ msgstr "Kamera bacarıqlarını göstər"
+
+#~ msgid "Capture a movie "
+#~ msgstr "Film yaxala "
+
+#~ msgid "Show info"
+#~ msgstr "Mə'lumatı göstər"
+
+#~ msgid "Summary of camera status"
+#~ msgstr "Kamera vəziyyətinin icmalı"
+
+#~ msgid "Camera driver manual"
+#~ msgstr "Kamera sürücüsü əl kitabı"
+
+#~ msgid "About the camera driver"
+#~ msgstr "Kamera sürücüsü haqqında"
+
+#~ msgid "Jan"
+#~ msgstr "Yan"
+
+#~ msgid "January"
+#~ msgstr "Yanvar"
+
+#~ msgid "Feb"
+#~ msgstr "Fev"
+
+#~ msgid "February"
+#~ msgstr "Fevral"
+
+#~ msgid "Mar"
+#~ msgstr "Mar"
+
+#~ msgid "March"
+#~ msgstr "Mart"
+
+#~ msgid "Apr"
+#~ msgstr "Apr"
+
+#~ msgid "April"
+#~ msgstr "Aprel"
+
+#~ msgid "May"
+#~ msgstr "May"
+
+#~ msgid "Jun"
+#~ msgstr "İyn"
+
+#~ msgid "June"
+#~ msgstr "İyun"
+
+#~ msgid "Jul"
+#~ msgstr "İyl"
+
+#~ msgid "July"
+#~ msgstr "İyul"
+
+#~ msgid "Aug"
+#~ msgstr "Avq"
+
+#~ msgid "August"
+#~ msgstr "Avqust"
+
+#~ msgid "Sep"
+#~ msgstr "Sen"
+
+#~ msgid "September"
+#~ msgstr "Sentyabr"
+
+#~ msgid "Oct"
+#~ msgstr "Okt"
+
+#~ msgid "October"
+#~ msgstr "Oktyabr"
+
+#~ msgid "Nov"
+#~ msgstr "Noy"
+
+#~ msgid "November"
+#~ msgstr "Noyabr"
+
+#~ msgid "Dec"
+#~ msgstr "Dek"
+
+#~ msgid "December"
+#~ msgstr "Dekabr"
+
+#~ msgid "Sun"
+#~ msgstr "Baz"
+
+#~ msgid "Sunday"
+#~ msgstr "Bazar"
+
+#~ msgid "Monday"
+#~ msgstr "Bazar ertəsi"
+
+#~ msgid "Tue"
+#~ msgstr "Çax"
+
+#~ msgid "Tuesday"
+#~ msgstr "Çərşənbə axşamı"
+
+#~ msgid "Wed"
+#~ msgstr "Çrş"
+
+#~ msgid "Wednesday"
+#~ msgstr "Çərşənbə"
+
+#~ msgid "Thu"
+#~ msgstr "Cax"
+
+#~ msgid "Thursday"
+#~ msgstr "Cümə axşamı"
+
+#~ msgid "Fri"
+#~ msgstr "Cüm"
+
+#~ msgid "Friday"
+#~ msgstr "Cümə"
+
+#~ msgid "Sat"
+#~ msgstr "Şnb"
+
+#~ msgid "Saturday"
+#~ msgstr "Şənbə"
+
+#~ msgid "path"
+#~ msgstr "cığır"
+
+#~ msgid "speed"
+#~ msgstr "sür'ət"
+
+#~ msgid "model"
+#~ msgstr "model"
+
+#~ msgid "filename"
+#~ msgstr "fayl adı"
+
+#~ msgid "usbid"
+#~ msgstr "usbid"
+
+#~ msgid "folder"
+#~ msgstr "qovluq"
+
+#~ msgid "Usage:\n"
+#~ msgstr "İstifadə qaydası:\n"
+
+#, c-format
+#~ msgid "%-38s %s\n"
+#~ msgstr "%-38s %s\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,22 +7,24 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.4.2\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2008-06-22 18:31+0200\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2008-10-12 12:00+0200\n"
 "Last-Translator: Miloslav Trmac <mitr@volny.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%100/10==1 ? 2 : n%10==1 ? 0 : (n+9)%10>3 ? 2 : 1;\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Plural-Forms: nplurals=3; plural=n%100/10==1 ? 2 : n%10==1 ? 0 : (n"
+"+9)%10>3 ? 2 : 1;\n"
 
-#: gphoto2/actions.c:167
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Počet souborů v adresáři '%s': %i\n"
 
-#: gphoto2/actions.c:187
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
@@ -30,12 +32,12 @@ msgstr[0] "V adresáři '%2$s' je %1$d adresář.\n"
 msgstr[1] "V adresáři '%2$s' jsou %1$d adresáře.\n"
 msgstr[2] "V adresáři '%2$s' je %1$d adresářů.\n"
 
-#: gphoto2/actions.c:227
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "V adresáři '%s' není žádný soubor.\n"
 
-#: gphoto2/actions.c:230
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
@@ -43,177 +45,172 @@ msgstr[0] "V adresáři '%2$s' je %1$d soubor.\n"
 msgstr[1] "V adresáři '%2$s' jsou %1$d soubory.\n"
 msgstr[2] "V adresáři '%2$s' je %1$d souborů.\n"
 
-#: gphoto2/actions.c:251
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Informace o souboru '%s' (adresář '%s'):\n"
 
-#: gphoto2/actions.c:253
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Soubor:\n"
 
-#: gphoto2/actions.c:255 gphoto2/actions.c:289 gphoto2/actions.c:305
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Žádný není k dispozici.\n"
 
-#: gphoto2/actions.c:258
-#, c-format
-msgid "  Name:        '%s'\n"
-msgstr "  Název:       '%s'\n"
-
-#: gphoto2/actions.c:260 gphoto2/actions.c:292
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Typ mime:    '%s'\n"
 
-#: gphoto2/actions.c:262 gphoto2/actions.c:294
-#, c-format
-msgid "  Size:        %li byte(s)\n"
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#, fuzzy, c-format
+msgid "  Size:        %lu byte(s)\n"
 msgstr "  Velikost:    %li bajtů\n"
 
-#: gphoto2/actions.c:264 gphoto2/actions.c:296
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Šířka:       %i pixelů\n"
 
-#: gphoto2/actions.c:266 gphoto2/actions.c:298
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Výška:       %i pixelů\n"
 
-#: gphoto2/actions.c:268 gphoto2/actions.c:300
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Staženo:     %s\n"
 
-#: gphoto2/actions.c:269 gphoto2/actions.c:301 gphoto2/actions.c:313
-#: gphoto2/actions.c:663 gphoto2/actions.c:665 gphoto2/actions.c:693
-#: gphoto2/actions.c:696 gphoto2/actions.c:699 gphoto2/actions.c:702
-#: gphoto2/actions.c:705 gphoto2/actions.c:1512
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "ano"
 
-#: gphoto2/actions.c:269 gphoto2/actions.c:301 gphoto2/actions.c:313
-#: gphoto2/actions.c:663 gphoto2/actions.c:665 gphoto2/actions.c:693
-#: gphoto2/actions.c:696 gphoto2/actions.c:699 gphoto2/actions.c:702
-#: gphoto2/actions.c:705 gphoto2/actions.c:1506
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "ne"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Oprávnění:   "
 
-#: gphoto2/actions.c:274
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "čtení/odstranění"
 
-#: gphoto2/actions.c:276
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "čtení"
 
-#: gphoto2/actions.c:278
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "odstranění"
 
-#: gphoto2/actions.c:280
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "žádné"
 
-#: gphoto2/actions.c:284
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Čas:         %s"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Miniatura:\n"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Zvuková data:\n"
 
-#: gphoto2/actions.c:308
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Typ mime:   '%s'\n"
 
-#: gphoto2/actions.c:310
-#, c-format
-msgid "  Size:       %li byte(s)\n"
+#: gphoto2/actions.c:332
+#, fuzzy, c-format
+msgid "  Size:       %lu byte(s)\n"
 msgstr "  Velikost:   %li bajtů\n"
 
-#: gphoto2/actions.c:312
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Staženo:    %s\n"
 
-#: gphoto2/actions.c:488
+#: gphoto2/actions.c:504
 msgid "Could not parse EXIF data."
 msgstr "Nemohu zpracovat data EXIF."
 
-#: gphoto2/actions.c:492
+#: gphoto2/actions.c:508
 #, c-format
 msgid "EXIF tags:"
 msgstr "Značky EXIF:"
 
-#: gphoto2/actions.c:495
+#: gphoto2/actions.c:511
 msgid "Tag"
 msgstr "Značka"
 
-#: gphoto2/actions.c:497
+#: gphoto2/actions.c:513
 msgid "Value"
 msgstr "Hodnota"
 
-#: gphoto2/actions.c:518
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Data EXIF obsahují miniaturu (%i bajtů)."
 
-#: gphoto2/actions.c:527
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 bylo přeloženo bez podpory EXIF."
 
-#: gphoto2/actions.c:545
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Počet podporovaných fotoaparátů: %i\n"
 
-#: gphoto2/actions.c:546
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Podporované fotoaparáty:\n"
 
-#: gphoto2/actions.c:559
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (TESTOVÁNÍ)\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (EXPERIMENTÁLNÍ)\n"
 
-#: gphoto2/actions.c:567
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:611
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Nalezená zařízení: %i\n"
 
-#: gphoto2/actions.c:612
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -222,150 +219,169 @@ msgstr ""
 "Cesta                            Popis\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:642 gphoto2/actions.c:647
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:642
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Model"
 
-#: gphoto2/actions.c:642
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Port"
 
-#: gphoto2/actions.c:643
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Schopnosti fotoaparátu           : %s\n"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Podpora sériového portu          : %s\n"
 
-#: gphoto2/actions.c:664
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Podpora USB                      : %s\n"
 
-#: gphoto2/actions.c:667
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Podporované rychlosti přenosu    :\n"
 
-#: gphoto2/actions.c:669
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:672
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Možnosti zachycení               :\n"
 
-#: gphoto2/actions.c:674
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Obrázek\n"
 
-#: gphoto2/actions.c:678
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:682
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Náhled\n"
 
-#: gphoto2/actions.c:690
-#, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : Zachytávání nepodporováno ovladačem\n"
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:692
+#: gphoto2/actions.c:700
+#, c-format
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : Zachytávání nepodporováno ovladačem\n"
+
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Podpora konfigurace              : %s\n"
 
-#: gphoto2/actions.c:694
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Odstranit vybrané soubory z fotoaparátu: %s\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Odstranit všechny soubory z fotoaparátu: %s\n"
 
-#: gphoto2/actions.c:700
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Podpora náhledů souborů          : %s\n"
 
-#: gphoto2/actions.c:703
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Podpora ukládání souborů         : %s\n"
 
-#: gphoto2/actions.c:719
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Porty musí vypadat jako 'serial:/dev/ttyS0' nebo 'usb;', ale v '%s' chybí dvojtečka, takže budu hádat, co tím myslíte."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Porty musí vypadat jako 'serial:/dev/ttyS0' nebo 'usb;', ale v '%s' chybí "
+"dvojtečka, takže budu hádat, co tím myslíte."
 
-#: gphoto2/actions.c:753
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Port, který jste určili, ('%s'), nelze najít. Zadejte prosím jeden z portů nalezených 'gphoto2 --list-ports' a ujistěte se, že zápis je správný (např. s předponou 'serial:' nebo 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Port, který jste určili, ('%s'), nelze najít. Zadejte prosím jeden z portů "
+"nalezených 'gphoto2 --list-ports' a ujistěte se, že zápis je správný (např. "
+"s předponou 'serial:' nebo 'usb:')."
 
-#: gphoto2/actions.c:785
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "O ovladači fotoaparátu:"
 
-#: gphoto2/actions.c:798
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Shrnutí fotoaparátu:"
 
-#: gphoto2/actions.c:811
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Manuál fotoaparátu:"
 
-#: gphoto2/actions.c:826
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Můžete určovat rychlosti jen pro sériové porty."
 
-#: gphoto2/actions.c:879
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "OS/2 port napsal Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:883
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
@@ -377,212 +393,352 @@ msgstr ""
 "\n"
 "Tato verze gphoto2 používá následující verze a nastavení softwaru:\n"
 
-#: gphoto2/actions.c:1004
+#: gphoto2/actions.c:1015
+#, fuzzy
+msgid "Could not open 'movie.mjpg'."
+msgstr "Nemohu získat obrázek."
+
+#: gphoto2/actions.c:1022
+#, fuzzy, c-format
+msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
+msgstr "Čekám na události od fotoaparátu.  Přerušte stisknutím Ctrl-C.\n"
+
+#: gphoto2/actions.c:1026
+#, c-format
+msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1031
+#, c-format
+msgid "Capturing %d preview frames as movie to '%s'.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1047
+msgid "Movie capture error... Exiting."
+msgstr ""
+
+#: gphoto2/actions.c:1053
+#, c-format
+msgid "Movie capture error... Unhandled MIME type '%s'."
+msgstr ""
+
+#: gphoto2/actions.c:1060
+#, c-format
+msgid "Ctrl-C pressed ... Exiting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1074
+#, c-format
+msgid "Movie capture finished (%d frames)\n"
+msgstr ""
+
+#: gphoto2/actions.c:1106
+#, c-format
+msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
+msgstr "Čekám na události od fotoaparátu.  Přerušte stisknutím Ctrl-C.\n"
+
+#: gphoto2/actions.c:1112
+#, fuzzy, c-format
+msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
+msgstr "Čekám na události od fotoaparátu.  Přerušte stisknutím Ctrl-C.\n"
+
+#: gphoto2/actions.c:1117
+#, fuzzy, c-format
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr "Čekám na události od fotoaparátu.  Přerušte stisknutím Ctrl-C.\n"
+
+#: gphoto2/actions.c:1122
+#, fuzzy, c-format
+msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr "Čekám na události od fotoaparátu.  Přerušte stisknutím Ctrl-C.\n"
+
+#: gphoto2/actions.c:1125
+#, fuzzy, c-format
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr "Čekám na události od fotoaparátu.  Přerušte stisknutím Ctrl-C.\n"
+
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr "Čekám na události od fotoaparátu.  Přerušte stisknutím Ctrl-C.\n"
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
+#, c-format
+msgid "event found, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
+msgid "Could not set folder."
+msgstr "Nemohu nastavit adresář:"
+
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
+msgid "Could not get image."
+msgstr "Nemohu získat obrázek."
+
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
+msgid "Buggy libcanon.so?"
+msgstr "Chyba v libcanon.so?"
+
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
+msgid "Could not delete image."
+msgstr "Nemohu odstranit obrázek."
+
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr "Získávání informací o úložištinení pro tento fotoaparát podporováno.\n"
 
-#: gphoto2/actions.c:1019
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Čtení a zápis"
 
-#: gphoto2/actions.c:1022
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Jen čtení"
 
-#: gphoto2/actions.c:1025
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Jen čtení a odstraňování"
 
-#: gphoto2/actions.c:1028 gphoto2/actions.c:1038
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Neznámé"
 
-#: gphoto2/actions.c:1041
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "Pevná ROM"
 
-#: gphoto2/actions.c:1044
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "Výměnná ROM"
 
-#: gphoto2/actions.c:1047
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "Pevná RAM"
 
-#: gphoto2/actions.c:1050
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "Výměnná RAM"
 
-#: gphoto2/actions.c:1060
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Nedefinováno"
 
-#: gphoto2/actions.c:1063
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Obecné ploché"
 
-#: gphoto2/actions.c:1066
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Obecné hierarchické"
 
-#: gphoto2/actions.c:1069
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Rozložení kamery (DCIM)"
 
-#: gphoto2/actions.c:1107
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Nahrazuji USB id dodavatale/produktu 0x%x/0x%x s 0x%x/0x%x"
 
-#: gphoto2/actions.c:1171
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "PŘI POSÍLÁNÍ LADICÍCH ZPRÁV DO KONFERENCE VŽDY PŘILOŽTE NÁSLEDUJÍCÍ ŘÁDKY:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"PŘI POSÍLÁNÍ LADICÍCH ZPRÁV DO KONFERENCE VŽDY PŘILOŽTE NÁSLEDUJÍCÍ ŘÁDKY:"
 
-#: gphoto2/actions.c:1186
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s bylo přeloženo s následujícími přepínači:"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s nenalezeno ve stromu konfigurace."
 
-#: gphoto2/actions.c:1364
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Nemohu získat hodnotu textového widgetu %s."
 
-#: gphoto2/actions.c:1381
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Nemohu získat hodnotu widgetu rozsahu %s."
 
-#: gphoto2/actions.c:1393
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Nemohu získat hodnotu přepínacího widgetu %s."
 
-#: gphoto2/actions.c:1405
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Nemohu získat hodnotu widgetu data/času %s."
 
-#: gphoto2/actions.c:1435
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Nemohu získat hodnotu rádiového widgetu %s."
 
-#: gphoto2/actions.c:1476
+#: gphoto2/actions.c:1799
+#, c-format
+msgid "Property %s is read only."
+msgstr ""
+
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Nemohu nastavit hodnotu textového widgetu %s na %s."
 
-#: gphoto2/actions.c:1486
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Zadaná hodnota %s není hodnota s pohyblivou řádovou čárkou."
 
-#: gphoto2/actions.c:1491
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "Zadaná hodnota %f není v očekávaném rozsahu %f – %f."
 
-#: gphoto2/actions.c:1497
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Nemohu nastavit hodnotu widgetu rozsahu %s na %f."
 
-#: gphoto2/actions.c:1506
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "vypnuto"
 
-#: gphoto2/actions.c:1507
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "ne"
 
-#: gphoto2/actions.c:1512
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "zapnuto"
 
-#: gphoto2/actions.c:1513
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "ano"
 
-#: gphoto2/actions.c:1518
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Zadaná hodnota %s nená platná hodnota přepínače."
 
-#: gphoto2/actions.c:1524
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Nemohu nastavit hodnoty %s přepínacího widgetu %s."
 
-#: gphoto2/actions.c:1537
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
+#, fuzzy
+msgid "now"
+msgstr "ne"
+
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "Zadaná hodnota %s není platný čas ani celé číslo."
 
-#: gphoto2/actions.c:1544
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Nemohu nastavyt nový čas widgetu data/času %s na %s."
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Možnost %s nebyla nalezena v seznamu."
 
-#: gphoto2/actions.c:1589
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Widget %s nelze nastavovat."
 
-#: gphoto2/actions.c:1596
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr "Nemohu nastavit novou hodnotu nastavení %s položky nastavení %s."
 
-#: gphoto2/foreach.c:254
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Špatné číslo souboru. Zadali jste %1$i, ale v '%3$s' a jeho podadresářích je k dispozici jen '%2$i' souborů. Nejdříve prosím získejte ze seznamu souborů platné číslo souboru."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
 
-#: gphoto2/foreach.c:279
+#: gphoto2/foreach.c:260
+#, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Špatné číslo souboru. Zadali jste %1$i, ale v '%3$s' a jeho podadresářích je "
+"k dispozici jen '%2$i' souborů. Nejdříve prosím získejte ze seznamu souborů "
+"platné číslo souboru."
+
+#: gphoto2/foreach.c:285
 #, c-format
 msgid "There are no files in folder '%s'."
 msgstr "V adresáři '%s' nejsou žádné soubory."
 
-#: gphoto2/foreach.c:285
+#: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Špatné číslo souboru. Zadali jste %i, ale v '%s' je k dispozici jen jeden soubor."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Špatné číslo souboru. Zadali jste %i, ale v '%s' je k dispozici jen jeden "
+"soubor."
 
-#: gphoto2/foreach.c:293
+#: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Špatné číslo souboru. Zadali jste %1$i, ale v '%3$s' je k dispozici jen %2$i souborů. Nejdříve prosím získejte ze seznamu souborů platné číslo souboru."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Špatné číslo souboru. Zadali jste %1$i, ale v '%3$s' je k dispozici jen %2$i "
+"souborů. Nejdříve prosím získejte ze seznamu souborů platné číslo souboru."
 
 #: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Chyba ***              \n"
 
-#: gphoto2/gp-params.c:244
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Pokračujte stisknutím libovolné klávesy.\n"
@@ -596,182 +752,217 @@ msgstr "Nedostatek paměti."
 msgid "Operation cancelled"
 msgstr "Operace přerušena"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Pokračovat"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Zrušit"
 
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Chyba"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Nemohu nastavit konfiguraci:"
 
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Konec"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Zpět"
 
-#: gphoto2/gphoto2-cmd-config.c:254
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Čas: "
 
-#: gphoto2/gphoto2-cmd-config.c:313 gphoto2/gphoto2-cmd-config.c:341
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Hodnota: "
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Ano"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Ne"
 
-#: gphoto2/main.c:230
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "Doplňování čísel nulami v názvech souborů je možné jen s %%n."
 
-#: gphoto2/main.c:239
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "Nemůžete použít doplňování čísel nulami %%n bez hodnoty přesnosti!"
 
-#: gphoto2/main.c:255
-#, c-format
-msgid "You cannot use '%%n' in combination with non-persistent files!"
-msgstr "Nemůžete použít '%%n' v kombinaci s neperzistentními soubory!"
-
-#: gphoto2/main.c:286
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Název souboru dotaný fotoaparátem ('%s') neobsahuje příponu!"
 
-#: gphoto2/main.c:341
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Neplatný formát '%s' (chyba na pozici %i)."
 
-#: gphoto2/main.c:394
+#: gphoto2/main.c:386 gphoto2/main.c:592
+#, fuzzy, c-format
+msgid "Skip existing file %s\n"
+msgstr "Ukládám souboru jako %s\n"
+
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Soubor %s existuje. Přepsat? [y|n] "
 
-#: gphoto2/main.c:406
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Zadat nový název souboru? [y|n] "
 
-#: gphoto2/main.c:416
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Zadejte nový název souboru: "
 
-#: gphoto2/main.c:422
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Ukládám souboru jako %s\n"
 
-#: gphoto2/main.c:607
-#, c-format
-msgid "Time-lapse mode enabled (interval: %ds).\n"
-msgstr "Režim time-lapse povolen (interval: %ds).\n"
+#: gphoto2/main.c:630
+#, fuzzy
+msgid "Permission denied"
+msgstr "  Oprávnění:   "
 
-#: gphoto2/main.c:610
-#, c-format
-msgid "Standing by waiting for SIGUSR1 to capture.\n"
-msgstr "Pripraven, čekám na SIGUSR1 před zachytáváním.\n"
-
-#: gphoto2/main.c:619
-#, c-format
-msgid "Capturing frame #%d...\n"
-msgstr "Zachytávám políčko č. %d...\n"
-
-#: gphoto2/main.c:621
-#, c-format
-msgid "Capturing frame #%d/%d...\n"
-msgstr "Zachytávám políčko č. %d/%d...\n"
-
-#: gphoto2/main.c:628
-msgid "Could not capture."
+#: gphoto2/main.c:800
+#, fuzzy
+msgid "Could not trigger capture."
 msgstr "Nemohu zachytávat."
 
-#: gphoto2/main.c:637
-#, c-format
-msgid "Capture failed (auto-focus problem?)...\n"
-msgstr "Zachytávání selhalo (problém automatického zaostřování?)...\n"
-
-#: gphoto2/main.c:651
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Nový soubor je na fotoaparátu v umístění %s%s%s\n"
 
-#: gphoto2/main.c:660 gphoto2/main.c:797
-msgid "Could not set folder."
-msgstr "Nemohu nastavit adresář:"
+#: gphoto2/main.c:847 gphoto2/main.c:878
+#, fuzzy, c-format
+msgid "Keeping file %s%s%s on the camera\n"
+msgstr "Odstraňuji soubor %s%s%s z fotoaparátu\n"
 
-#: gphoto2/main.c:667 gphoto2/main.c:803
-msgid "Could not get image."
-msgstr "Nemohu získat obrázek."
-
-#: gphoto2/main.c:674 gphoto2/main.c:810
-msgid "Buggy libcanon.so?"
-msgstr "Chyba v libcanon.so?"
-
-#: gphoto2/main.c:680
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Odstraňuji soubor %s%s%s z fotoaparátu\n"
 
-#: gphoto2/main.c:685 gphoto2/main.c:819
-msgid "Could not delete image."
-msgstr "Nemohu odstranit obrázek."
-
-#: gphoto2/main.c:707
-msgid "Could not close camera connection."
-msgstr "Nemohu zavřít připojení k fotoaparátu."
-
-#: gphoto2/main.c:721
+#: gphoto2/main.c:911
 #, c-format
-msgid "Sleeping for %d second(s)...\n"
-msgstr "Spím na %d sekund...\n"
+msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
+msgstr ""
 
-#: gphoto2/main.c:726 gphoto2/main.c:754
+#: gphoto2/main.c:916
+#, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:926
+#, c-format
+msgid "Event UNKNOWN %s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:932
+#, c-format
+msgid "Unknown event type %d during bulb wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:950
+#, fuzzy
+msgid "Could not get capabilities?"
+msgstr "Nemohu získat obrázek."
+
+#: gphoto2/main.c:958
+#, c-format
+msgid "Time-lapse mode enabled (interval: %ds).\n"
+msgstr "Režim time-lapse povolen (interval: %ds).\n"
+
+#: gphoto2/main.c:961
+#, c-format
+msgid "Standing by waiting for SIGUSR1 to capture.\n"
+msgstr "Pripraven, čekám na SIGUSR1 před zachytáváním.\n"
+
+#: gphoto2/main.c:967
+#, fuzzy, c-format
+msgid "Bulb mode enabled (exposure time: %ds).\n"
+msgstr "Režim time-lapse povolen (interval: %ds).\n"
+
+#: gphoto2/main.c:975
+#, c-format
+msgid "Capturing frame #%d...\n"
+msgstr "Zachytávám políčko č. %d...\n"
+
+#: gphoto2/main.c:977
+#, c-format
+msgid "Capturing frame #%d/%d...\n"
+msgstr "Zachytávám políčko č. %d/%d...\n"
+
+#: gphoto2/main.c:987
+#, fuzzy, c-format
+msgid "Could not set bulb capture, result %d."
+msgstr "Nemohu zachytávat."
+
+#: gphoto2/main.c:1001
+#, fuzzy
+msgid "Could not end capture (bulb mode)."
+msgstr "Nemohu zachytávat."
+
+#: gphoto2/main.c:1014
+#, fuzzy
+msgid "Could not trigger image capture."
+msgstr "Nemohu získat obrázek."
+
+#: gphoto2/main.c:1021
+#, fuzzy
+msgid "Could not capture image."
+msgstr "Nemohu zachytávat."
+
+#: gphoto2/main.c:1028
+#, c-format
+msgid "Capture failed (auto-focus problem?)...\n"
+msgstr "Zachytávání selhalo (problém automatického zaostřování?)...\n"
+
+#: gphoto2/main.c:1039
+msgid "Could not capture."
+msgstr "Nemohu zachytávat."
+
+#: gphoto2/main.c:1074
+#, c-format
+msgid "Waiting for next capture slot %ld seconds...\n"
+msgstr ""
+
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Probuzen pomocí SIGUSR1...\n"
 
-#: gphoto2/main.c:729
-#, c-format
-msgid "not sleeping (%d seconds behind schedule)\n"
+#: gphoto2/main.c:1096
+#, fuzzy, c-format
+msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "nespím (%d sekund pozadu vůči plánu)\n"
 
-#: gphoto2/main.c:771
-#, c-format
-msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Čekám na události od fotoaparátu.  Přerušte stisknutím Ctrl-C.\n"
-
-#: gphoto2/main.c:791
-#, c-format
-msgid "New file %s/%s, downloading...\n"
-msgstr "Nový soubor %s/%s, stahuji...\n"
-
-#: gphoto2/main.c:915
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "CHYBA: "
 
-#: gphoto2/main.c:938
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -780,12 +971,12 @@ msgstr ""
 "\n"
 "Končím...\n"
 
-#: gphoto2/main.c:944
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Skončil jsem.\n"
 
-#: gphoto2/main.c:949
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -794,21 +985,33 @@ msgstr ""
 "\n"
 "Přerušuji...\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Použijte následující syntax a:b=c:d pro obsluhu libovolného zařízení detekovaného jako a:b místo toho jako c:d. a b c d by měly být šestnáctková čísla začínající '0x'.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Použijte následující syntax a:b=c:d pro obsluhu libovolného zařízení "
+"detekovaného jako a:b místo toho jako c:d. a b c d by měly být šestnáctková "
+"čísla začínající '0x'.\n"
 
-#: gphoto2/main.c:1245
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 bylo přeloženo bez podpory pro CDK."
 
-#: gphoto2/main.c:1433
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operace přerušena.\n"
 
-#: gphoto2/main.c:1437
+#: gphoto2/main.c:1883
+#, c-format
+msgid ""
+"*** Error: No camera found. ***\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -817,7 +1020,7 @@ msgstr ""
 "*** Chyba (%i: '%s') ***       \n"
 "\n"
 
-#: gphoto2/main.c:1441
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -834,332 +1037,418 @@ msgstr ""
 "spusťte prosím gphoto2 následovně:\n"
 "\n"
 
-#: gphoto2/main.c:1530
+#: gphoto2/main.c:1911
+#, c-format
+msgid ""
+"Please make sure there is sufficient quoting around the arguments.\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Vypsat úplnou zprávu nápovědy o používání programu"
 
-#: gphoto2/main.c:1532
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Vypsat krátkou zprávu o používání programu"
 
-#: gphoto2/main.c:1534
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Zapnout ladění"
 
-#: gphoto2/main.c:1536
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
+
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Název souboru, do kterého zapisovat ladicí informace"
 
-#: gphoto2/main.c:1536 gphoto2/main.c:1541 gphoto2/main.c:1547
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "NÁZEVSOUBORU"
 
-#: gphoto2/main.c:1538
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Tichý výstup (implicitní=podrobný)"
 
-#: gphoto2/main.c:1540
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Skript, který volat po stahování, zachytávání atd."
 
-#: gphoto2/main.c:1547
-msgid "Specify port device"
+#: gphoto2/main.c:1997
+#, fuzzy
+msgid "Specify device port"
 msgstr "Určení zařízení portu"
 
-#: gphoto2/main.c:1549
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Určení rychlosti sériového přenosu"
 
-#: gphoto2/main.c:1549
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "RYCHLOST"
 
-#: gphoto2/main.c:1551
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Určení modelu fotoaparátu"
 
-#: gphoto2/main.c:1551
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODEL"
 
-#: gphoto2/main.c:1553
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(jen pro experty) Přebít USB ID"
 
-#: gphoto2/main.c:1553
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBID"
 
-#: gphoto2/main.c:1559
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Zobrazit verzi a skončit"
 
-#: gphoto2/main.c:1561
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Vypsat podporované modly fotoaparátů"
 
-#: gphoto2/main.c:1563
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Vypsat podporovaná zařízení portu"
 
-#: gphoto2/main.c:1565
-msgid "Display camera/driver abilities"
+#: gphoto2/main.c:2015
+#, fuzzy
+msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Zobrazit schopnosti fotoaparátu/ovladače"
 
-#: gphoto2/main.c:1572
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Nastavit"
 
-#: gphoto2/main.c:1575
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Vypsat strom konfigurace"
 
-#: gphoto2/main.c:1577
+#: gphoto2/main.c:2027
+#, fuzzy
+msgid "Dump full configuration tree"
+msgstr "Vypsat strom konfigurace"
+
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Získat hodnotu konfigurace"
 
-#: gphoto2/main.c:1579
+#: gphoto2/main.c:2031
+#, fuzzy
+msgid "Set configuration value or index in choices"
+msgstr "Nastavit hodnotu konfigurace"
+
+#: gphoto2/main.c:2033
+#, fuzzy
+msgid "Set configuration value index in choices"
+msgstr "Nastavit hodnotu konfigurace"
+
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Nastavit hodnotu konfigurace"
 
-#: gphoto2/main.c:1585
-msgid "Wait for event from camera"
+#: gphoto2/main.c:2037
+msgid "Reset device port"
+msgstr ""
+
+#: gphoto2/main.c:2043
+msgid "Keep images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2045
+msgid "Keep RAW images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2047
+msgid "Remove images from camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2049
+#, fuzzy
+msgid "Wait for event(s) from camera"
 msgstr "Čekat na události od fotoaparátu"
 
-#: gphoto2/main.c:1588
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
+
+#: gphoto2/main.c:2051
+#, fuzzy
+msgid "Wait for event(s) from the camera and download new images"
+msgstr "Čekat na uvolnění závěrky fotoaparátu a stáhnout"
+
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Zachytit rychlý náhled"
 
-#: gphoto2/main.c:1590
-msgid "Set number of frames to capture (default=infinite)"
-msgstr "Nastavit počet políček, která zachytávat (implicitní=nekonečno)"
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
 
-#: gphoto2/main.c:1590
-msgid "COUNT"
-msgstr "POČET"
-
-#: gphoto2/main.c:1592
-msgid "Set capture interval in seconds"
+#: gphoto2/main.c:2059
+#, fuzzy
+msgid "Set bulb exposure time in seconds"
 msgstr "Nastavit interval zachytávání"
 
-#: gphoto2/main.c:1592
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SEKUND"
 
-#: gphoto2/main.c:1594
+#: gphoto2/main.c:2061
+msgid "Set number of frames to capture (default=infinite)"
+msgstr "Nastavit počet políček, která zachytávat (implicitní=nekonečno)"
+
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr "POČET"
+
+#: gphoto2/main.c:2063
+msgid "Set capture interval in seconds"
+msgstr "Nastavit interval zachytávání"
+
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Vynulovat interval zachytávání při signálu (implicitní=ne)"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Zachytit obrázek"
 
-#: gphoto2/main.c:1598
+#: gphoto2/main.c:2069
+#, fuzzy
+msgid "Trigger capture of an image"
+msgstr "Zachytit obrázek"
+
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Zachytit obrázek a stánout jej"
 
-#: gphoto2/main.c:1600
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Zachytit film"
 
-#: gphoto2/main.c:1602
+#: gphoto2/main.c:2073
+#, fuzzy
+msgid "COUNT or SECONDS"
+msgstr "SEKUND"
+
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Zachytit zvukový klip"
 
-#: gphoto2/main.c:1604
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Čekat na uvolnění závěrky fotoaparátu a stáhnout"
 
-#: gphoto2/main.c:1610
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Vypsat adresáře v adresáři"
 
-#: gphoto2/main.c:1612
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Vypsat soubory v adresáři"
 
-#: gphoto2/main.c:1614
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Vytvořit adresář"
 
-#: gphoto2/main.c:1614 gphoto2/main.c:1616
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "NÁZEVADRESÁŘE"
 
-#: gphoto2/main.c:1616
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Odstranit adresář"
 
-#: gphoto2/main.c:1618
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Zobrazit počet souborů"
 
-#: gphoto2/main.c:1620
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Získat soubory dané v rozsahu"
 
-#: gphoto2/main.c:1620 gphoto2/main.c:1624 gphoto2/main.c:1629
-#: gphoto2/main.c:1636 gphoto2/main.c:1642 gphoto2/main.c:1647
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "ROZSAH"
 
-#: gphoto2/main.c:1622
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Získat všechny soubory z adresáře"
 
-#: gphoto2/main.c:1624
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Získat miniatury dané v rozsahu"
 
-#: gphoto2/main.c:1627
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Získat všechny náhledy z adresáře"
 
-#: gphoto2/main.c:1629
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Získat metadata daná v rozsahu"
 
-#: gphoto2/main.c:1631
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Získat všechna metadata z adresáře"
 
-#: gphoto2/main.c:1633
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Uložit metadata souboru"
 
-#: gphoto2/main.c:1636
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Získat neupravená data daná v rozsahu"
 
-#: gphoto2/main.c:1639
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Získat neupravená data z adresáře"
 
-#: gphoto2/main.c:1642
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Získat zvuková data daná v rozsahu"
 
-#: gphoto2/main.c:1645
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Získat všechna zvuková data z adresáře"
 
-#: gphoto2/main.c:1647
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Odstranit soubory dané v rozsahu"
 
-#: gphoto2/main.c:1649
-msgid "Delete all files in folder"
+#: gphoto2/main.c:2122
+#, fuzzy
+msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Odstranit všechny soubory v adresáři"
 
-#: gphoto2/main.c:1651
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Uložit soubor do fotoaparátu"
 
-#: gphoto2/main.c:1651
-msgid "filename"
-msgstr "názevsouboru"
-
-#: gphoto2/main.c:1653
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Určení názvu souboru nebo vzoru názvů souborů"
 
-#: gphoto2/main.c:1653
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "VZOR_NÁZVŮ_SOUBORŮ"
 
-#: gphoto2/main.c:1655
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Určení adresáře fotoaparátu (implicitní=\"/\")"
 
-#: gphoto2/main.c:1655
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "ADRESÁŘ"
 
-#: gphoto2/main.c:1657
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Rekurze (implicitní pro stahování)"
 
-#: gphoto2/main.c:1659
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Žádná rekurze (implicitní pro odstraňování)"
 
-#: gphoto2/main.c:1661
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Zpracovávat jen nové soubory"
 
-#: gphoto2/main.c:1663
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Přepisovat soubory bez ptaní"
 
-#: gphoto2/main.c:1669
+#: gphoto2/main.c:2140
+msgid "Skip existing files"
+msgstr ""
+
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Poslat soubor na stdout"
 
-#: gphoto2/main.c:1671
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Vytisknout před daty velikost souboru"
 
-#: gphoto2/main.c:1673
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Vypsat automaticky detekované fotoaparáty"
 
-#: gphoto2/main.c:1677 gphoto2/shell.c:133
-msgid "Show EXIF information"
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
 msgstr "Zobrazit informace EXIF"
 
-#: gphoto2/main.c:1680 gphoto2/shell.c:127
-msgid "Show info"
-msgstr "Zobrazit informace"
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
 
-#: gphoto2/main.c:1682
-msgid "Show summary"
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "Zobrazit souhrn"
 
-#: gphoto2/main.c:1684
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Zobrazit manuál ovladače fotoaparátu"
 
-#: gphoto2/main.c:1686
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "O manuálu ovladače fotoaparátu"
 
-#: gphoto2/main.c:1688
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Zobrazit informace o úložišti"
 
-#: gphoto2/main.c:1690
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "shell gPhoto"
 
-#: gphoto2/main.c:1696
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Časté přepínače"
 
-#: gphoto2/main.c:1698
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Různé přepínače (netříděné)"
 
-#: gphoto2/main.c:1700
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "Získat informaci o software a hostitelském systému (ne z fotoaparátu)"
 
-#: gphoto2/main.c:1702
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Určení fotoaparátu, který používat"
 
-#: gphoto2/main.c:1704
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Nastavení fotoaparátu a software"
 
-#: gphoto2/main.c:1706
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Zachytit obrázek z nebo ve fotoaparátu"
 
-#: gphoto2/main.c:1708
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Stahování, ukládání a práce se soubory"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1168,7 +1457,7 @@ msgstr ""
 "%s\n"
 "ID obrázků musí být číslo větší než nula."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1177,7 +1466,7 @@ msgstr ""
 "%s\n"
 "ID obrázku %i příliš velké."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1186,7 +1475,7 @@ msgstr ""
 "%s\n"
 "Rozsahy musí být odděleny pomocí ','."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1195,7 +1484,7 @@ msgstr ""
 "%s\n"
 "Rozsahy musí začínat číslem."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1204,7 +1493,7 @@ msgstr ""
 "%s\n"
 "Neočekávaný znak '%c'."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -1213,177 +1502,254 @@ msgstr ""
 "%s\n"
 "Sestupné rozsahy nejsou povoleny. Zadali jste rozsah od %i do %i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Chyba (%i: '%s') ***"
 
-#: gphoto2/shell.c:116
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Přejít do adresáře ve fotoaparátu"
 
-#: gphoto2/shell.c:117 gphoto2/shell.c:119 gphoto2/shell.c:130
-#: gphoto2/shell.c:131
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "adresář"
 
-#: gphoto2/shell.c:118
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Přejít do adresáře na místním disku"
 
-#: gphoto2/shell.c:120 gphoto2/shell.c:145 gphoto2/shell.c:146
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Ukončit shell gPhoto"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Stáhnout soubor"
 
-#: gphoto2/shell.c:121 gphoto2/shell.c:122 gphoto2/shell.c:124
-#: gphoto2/shell.c:126 gphoto2/shell.c:128 gphoto2/shell.c:129
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[adresář/]názevsouboru"
 
-#: gphoto2/shell.c:122
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Uložit soubor"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Stáhnout náhled"
 
-#: gphoto2/shell.c:125
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Stáhnout neupravená data"
 
-#: gphoto2/shell.c:129
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Odstranit"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Vytvořit adresář"
 
-#: gphoto2/shell.c:131
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Odstranit adresář"
 
-#: gphoto2/shell.c:136 gphoto2/shell.c:147
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Zobrazí použití příkazů"
 
-#: gphoto2/shell.c:137 gphoto2/shell.c:147
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[příkaz]"
 
-#: gphoto2/shell.c:138
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Vypsat obsah aktuálního adresáře"
 
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[adresář/]"
 
-#: gphoto2/shell.c:140
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Vypsat proměnné konfigurace"
 
-#: gphoto2/shell.c:141
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Získat proměnnou konfigurace"
 
-#: gphoto2/shell.c:141
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "název"
 
-#: gphoto2/shell.c:142
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Nastavit proměnnou konfigurace"
 
-#: gphoto2/shell.c:142
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "název=hodnota"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:155
+#, fuzzy
+msgid "Set configuration variable index"
+msgstr "Nastavit proměnnou konfigurace"
+
+#: gphoto2/shell.c:155
+#, fuzzy
+msgid "name=valueindex"
+msgstr "název=hodnota"
+
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Zachytit jeden obrázek"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Zachytit jeden obrázek"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Zachytit jeden obrázek a stáhnout jej"
 
-#: gphoto2/shell.c:469
+#: gphoto2/shell.c:160
+#, fuzzy
+msgid "Capture a preview image"
+msgstr "Zachytit jeden obrázek"
+
+#: gphoto2/shell.c:161
+#, fuzzy
+msgid "Wait for an event"
+msgstr "Čekat na události od fotoaparátu"
+
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
+msgid "count or seconds"
+msgstr ""
+
+#: gphoto2/shell.c:162
+#, fuzzy
+msgid "Wait for images to be captured and download it"
+msgstr "Čekat na uvolnění závěrky fotoaparátu a stáhnout"
+
+#: gphoto2/shell.c:163
+#, fuzzy
+msgid "Wait for events and images to be captured and download it"
+msgstr "Zachytit obrázek a stánout jej"
+
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Neplatný příkaz."
 
-#: gphoto2/shell.c:478
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Příkaz '%s' vyžaduje argument."
 
-#: gphoto2/shell.c:531
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Neplatná cesta."
 
-#: gphoto2/shell.c:577
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Nemohu nalézt domovský adresář."
 
-#: gphoto2/shell.c:586
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Nemohu přejít do místního adresáře '%s'."
 
-#: gphoto2/shell.c:589
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Místní adresář je nyní '%s'."
 
-#: gphoto2/shell.c:627
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Vzdálený adresář je nyní '%s'."
 
-#: gphoto2/shell.c:843
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config potřebuje druhý prametr.\n"
 
-#: gphoto2/shell.c:877
+#: gphoto2/shell.c:895
+#, fuzzy, c-format
+msgid "set-config-value needs a second argument.\n"
+msgstr "set-config potřebuje druhý prametr.\n"
+
+#: gphoto2/shell.c:916
+#, fuzzy, c-format
+msgid "set-config-index needs a second argument.\n"
+msgstr "set-config potřebuje druhý prametr.\n"
+
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Příkaz '%s' nenalezen. Použijte 'help' pro získání seznamu dostupných příkazů."
+msgstr ""
+"Příkaz '%s' nenalezen. Použijte 'help' pro získání seznamu dostupných "
+"příkazů."
 
-#: gphoto2/shell.c:884
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Nápověda pro \"%s\":"
 
-#: gphoto2/shell.c:886
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Použití:"
 
-#: gphoto2/shell.c:889
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Popis:"
 
-#: gphoto2/shell.c:891
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Argumenty v hranatých závorkách [] jsou nepovinné"
 
-#: gphoto2/shell.c:912
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Dostupné příkazy:"
 
-#: gphoto2/shell.c:917
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Pro získání nápovědy o konkrétním příkazu napište 'help název-příkazu'."
+msgstr ""
+"Pro získání nápovědy o konkrétním příkazu napište 'help název-příkazu'."
+
+#, c-format
+#~ msgid "  Name:        '%s'\n"
+#~ msgstr "  Název:       '%s'\n"
+
+#, c-format
+#~ msgid "You cannot use '%%n' in combination with non-persistent files!"
+#~ msgstr "Nemůžete použít '%%n' v kombinaci s neperzistentními soubory!"
+
+#~ msgid "Could not close camera connection."
+#~ msgstr "Nemohu zavřít připojení k fotoaparátu."
+
+#, c-format
+#~ msgid "Sleeping for %d second(s)...\n"
+#~ msgstr "Spím na %d sekund...\n"
+
+#, c-format
+#~ msgid "New file %s/%s, downloading...\n"
+#~ msgstr "Nový soubor %s/%s, stahuji...\n"
+
+#~ msgid "filename"
+#~ msgstr "názevsouboru"
+
+#~ msgid "Show info"
+#~ msgstr "Zobrazit informace"
 
 #~ msgid "[name]"
 #~ msgstr "[název]"

--- a/po/da.po
+++ b/po/da.po
@@ -12,147 +12,147 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2-2.5.6\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2014-12-21 20:43+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2015-04-27 02:51+0200\n"
 "Last-Translator: Keld Simonsen <keld@keldix.com>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
 "Language: da\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Lokalize 1.5\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Antal filer i mappen '%s': %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "Der findes %d mappe i mappen '%s':\n"
 msgstr[1] "Der findes %d mapper i mappen '%s':\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Der findes ingen filer i mappen '%s':\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "Der findes %d fil i mappen '%s':\n"
 msgstr[1] "Der findes %d filer i mappen '%s':\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Information om filen '%s' (mappe '%s'):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Fil:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Ingen tilgængelige.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Mime-type:    '%s'\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Størrelse:     %lu byte\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Bredde:      %i punkter\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Højde:        %i punkter\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Hjemhentet:  %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:712
-#: gphoto2/actions.c:715 gphoto2/actions.c:718 gphoto2/actions.c:721
-#: gphoto2/actions.c:724 gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "ja"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:712
-#: gphoto2/actions.c:715 gphoto2/actions.c:718 gphoto2/actions.c:721
-#: gphoto2/actions.c:724 gphoto2/actions.c:1769 gphoto2/actions.c:2006
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "nej"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Rettigheder: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "læs/slet"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "læs"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "slet"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "ingen"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Tid:         %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Miniature: \n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Lyddata:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Mime-type:   '%s'\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Størrelse:    %lu byte\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Hjemhentet: %s\n"
@@ -174,46 +174,46 @@ msgstr "Mærke"
 msgid "Value"
 msgstr "Værdi"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "EXIF-data indeholder en miniature (%i byte)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 er oversat uden EXIF-understøttelse."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Antal understøttede kameraer: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Understøttede kameraer:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t'%s' (TESTER)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t'%s' (EKSPERIMENTEL)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t'%s'\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Enheder fundet: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -222,453 +222,505 @@ msgstr ""
 "Søgesti                           Beskrivelse\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Model"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Port"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Kameraets faciliteter            : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Serieportsunderstøttelse                   : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB-understøttelse                         : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Overføringshastigheder som understøttes    : \n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Optagelses-valg                   :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Billede\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Lyd\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Smugkig\n"
 
-#: gphoto2/actions.c:709
-#, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : Optagelse ikke understøttet af driveren\n"
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:711
+#: gphoto2/actions.c:700
+#, c-format
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : Optagelse ikke understøttet af driveren\n"
+
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Konfigurationsunderstøttelse               :%s\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Slet valgte filer på kamera      : %s\n"
 
-#: gphoto2/actions.c:716
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Slet alle filer på kamera        : %s\n"
 
-#: gphoto2/actions.c:719
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Fil-smugkig (miniature) understøttelse: %s\n"
 
-#: gphoto2/actions.c:722
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Filoplægnings-understøttelse     : %s\n"
 
-#: gphoto2/actions.c:739
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Porte skal se ud som 'serial:/dev/ttyS0' eller 'usb:', men '%s' mangler et kolon, så jeg vil gætte på hvad du mener."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Porte skal se ud som 'serial:/dev/ttyS0' eller 'usb:', men '%s' mangler et "
+"kolon, så jeg vil gætte på hvad du mener."
 
-#: gphoto2/actions.c:773
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Den port du specificerede ('%s') kan ikke findes. Vær venlig at specificere en af de porte som findes af 'gphoto2 --list-ports' og forsikr dig om at stavningen er korrekt (dvs med præfikset 'serial:' eller 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Den port du specificerede ('%s') kan ikke findes. Vær venlig at specificere "
+"en af de porte som findes af 'gphoto2 --list-ports' og forsikr dig om at "
+"stavningen er korrekt (dvs med præfikset 'serial:' eller 'usb:')."
 
-#: gphoto2/actions.c:806
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "Om kamera-drivrutinen:"
 
-#: gphoto2/actions.c:819
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Kamera-oversigt:"
 
-#: gphoto2/actions.c:832
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Kamera-manual:"
 
-#: gphoto2/actions.c:849
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Du kan kun specificere hastigheder for serielle porte."
 
-#: gphoto2/actions.c:899
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "OS/2-portering af Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:903
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
 "Copyright © 2000-%d Lutz Mueller og andre\n"
 "%s\n"
 "gphoto2 kommer UDEN GARANTI, så vidt som lov tillader. Du må\n"
-"videredistribuere kopier af gphoto2 under betingelserne i GNU General Public\n"
+"videredistribuere kopier af gphoto2 under betingelserne i GNU General "
+"Public\n"
 "License. For yderligere information, se filerne med navnet COPYING.\n"
 "\n"
 "Denne version af gphoto2 bruger følgende programversioner og tilvalg:\n"
 
-#: gphoto2/actions.c:1003
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Kunne ikke åbne 'movie.mjpg'."
 
-#: gphoto2/actions.c:1010
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Optager forhåndsvisningsbilleder som film til '%s'. Tryk Ctrl-C for at afbryde.\n"
+msgstr ""
+"Optager forhåndsvisningsbilleder som film til '%s'. Tryk Ctrl-C for at "
+"afbryde.\n"
 
-#: gphoto2/actions.c:1014
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr "Optager forhåndsvisningsbilleder som film til '%s' i %d sekunder.\n"
 
-#: gphoto2/actions.c:1019
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Optager %d forhåndsvisningsbilleder som film til '%s'.\n"
 
-#: gphoto2/actions.c:1029
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Fejl ved filmoptagelse...Afslutter."
 
-#: gphoto2/actions.c:1034
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Fejl ved filmoptagelse... Uhåndteret MIME-type '%s'."
 
-#: gphoto2/actions.c:1041
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ctrl-C trykket... Afslutter.\n"
 
-#: gphoto2/actions.c:1055
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Filmoptagelse afsluttet (%d billeder)\n"
 
-#: gphoto2/actions.c:1085
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "Venter på hændelser fra kamera. Tryk Ctrl-C for at afbryde.\n"
 
-#: gphoto2/actions.c:1091
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr "Venter på %d billeder fra kameraet. Tryk Ctrl-C for at afbryde.\n"
 
-#: gphoto2/actions.c:1096
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Venter i %d millisekunder på hændelser fra kameraet. Tryk Ctrl-C for at afbryde.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Venter i %d millisekunder på hændelser fra kameraet. Tryk Ctrl-C for at "
+"afbryde.\n"
 
-#: gphoto2/actions.c:1101
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Venter i %d sekunder på hændelser fra kamera. Tryk Ctrl-C for at afbryde.\n"
+msgstr ""
+"Venter i %d sekunder på hændelser fra kamera. Tryk Ctrl-C for at afbryde.\n"
 
-#: gphoto2/actions.c:1104
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
 msgstr "Venter på %d hændelser fra kamera. Tryk Ctrl-C for at afbryde.\n"
 
-#: gphoto2/actions.c:1108
-#, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
 msgstr "Venter på %s-hændelse fra kamera. Tryk Ctrl-C for at afbryde.\n"
 
-#: gphoto2/actions.c:1152 gphoto2/actions.c:1166 gphoto2/actions.c:1178
-#: gphoto2/actions.c:1216 gphoto2/actions.c:1224
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "Hændelse fundet, stopper ventning!\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "Hændelse fundet, stopper ventning!\n"
 
-#: gphoto2/actions.c:1188 gphoto2/main.c:824
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Kunne ikke sætte mappe."
 
-#: gphoto2/actions.c:1194 gphoto2/main.c:831
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Kunne ikke finde billede."
 
-#: gphoto2/actions.c:1201 gphoto2/main.c:838
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "Fejlbehæftet libcanon.so?"
 
-#: gphoto2/actions.c:1211 gphoto2/main.c:850
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Kunne ikke slette billede."
 
-#: gphoto2/actions.c:1243
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr "Hentning af lagringsinformation understøttes ikke for dette kamera.\n"
 
-#: gphoto2/actions.c:1258
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Læs-skriv"
 
-#: gphoto2/actions.c:1261
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Skrivebeskyttet"
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Skrivebeskyttet med sletning"
 
-#: gphoto2/actions.c:1267 gphoto2/actions.c:1277
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Ukendt"
 
-#: gphoto2/actions.c:1280
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "Fast ROM"
 
-#: gphoto2/actions.c:1283
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "Flytbar ROM"
 
-#: gphoto2/actions.c:1286
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "Fast RAM"
 
-#: gphoto2/actions.c:1289
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "Flytbar RAM"
 
-#: gphoto2/actions.c:1299
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Udefineret"
 
-#: gphoto2/actions.c:1302
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Generelt fladt"
 
-#: gphoto2/actions.c:1305
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Generelt hierarkisk"
 
-#: gphoto2/actions.c:1308
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Kameralayout (DCIM)"
 
-#: gphoto2/actions.c:1346
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Tilsidesætter USB-producent-id 0x%x/0x%x med 0x%x/0x%x"
 
-#: gphoto2/actions.c:1414
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "INKLUDÉR ALTID DE FØLGENDE LINJER NÅR DU SENDER FEJLSØGNINGSBESKEDER TIL POSTLISTEN:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"INKLUDÉR ALTID DE FØLGENDE LINJER NÅR DU SENDER FEJLSØGNINGSBESKEDER TIL "
+"POSTLISTEN:"
 
-#: gphoto2/actions.c:1429
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s er blevet oversat med de følgende valgmuligheder:"
 
-#: gphoto2/actions.c:1560
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s ikke fundet i konfigurationstræ."
 
-#: gphoto2/actions.c:1609
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Kunne ikke få fat på værdien af tekst-felt %s."
 
-#: gphoto2/actions.c:1626
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Kunne ikke få fat på værdier for interval-felt %s."
 
-#: gphoto2/actions.c:1638
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Kunne ikke få fat på værdier for afkrydsnings-felt %s."
 
-#: gphoto2/actions.c:1650
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Kunne ikke få fat på værdier for dato/tid-felt %s."
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "Brug 'nu' som den aktuelle tid ved indstilling.\n"
 
-#: gphoto2/actions.c:1681
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Kunne ikke få fat på værdier for radio-felt %s."
 
-#: gphoto2/actions.c:1725
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "Egenskaben %s er skrivebeskyttet."
 
-#: gphoto2/actions.c:1739 gphoto2/actions.c:1976
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Kunne ikke sætte værdien af tekst-felt %s til %s."
 
-#: gphoto2/actions.c:1749 gphoto2/actions.c:1986
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Den leverede værdi %s er ikke et komma-tal."
 
-#: gphoto2/actions.c:1754 gphoto2/actions.c:1991
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
-msgstr "Den leverede værdi %f er ikke inden for det forventede interval %f - %f."
+msgstr ""
+"Den leverede værdi %f er ikke inden for det forventede interval %f - %f."
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Kunne ikke sætte værdien af interval-felt %s til %f."
 
-#: gphoto2/actions.c:1769 gphoto2/actions.c:2006
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "fra"
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "falsk"
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "på"
 
-#: gphoto2/actions.c:1776 gphoto2/actions.c:2013
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "sand"
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Den leverede værdi %s er ikke en gyldig afkrydsningsværdi."
 
-#: gphoto2/actions.c:1787 gphoto2/actions.c:2024
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Kunne ikke sætte værdien af afkrydsnings-felt %s til %s."
 
-#: gphoto2/actions.c:1799
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "nu"
 
-#: gphoto2/actions.c:1811 gphoto2/actions.c:2037
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "Den leverede værdi %s er hverken et gyldigt tidspunkt eller et heltal."
 
-#: gphoto2/actions.c:1819 gphoto2/actions.c:2044
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Kunne ikke sætte værdien af dato/tids-felt %s til %s."
 
-#: gphoto2/actions.c:1866 gphoto2/actions.c:1930 gphoto2/actions.c:2074
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Valget %s blev ikke fundet i liste af muligheder."
 
-#: gphoto2/actions.c:1874 gphoto2/actions.c:2082
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "%s-feltet kan ikke konfigureres."
 
-#: gphoto2/actions.c:1881 gphoto2/actions.c:1949 gphoto2/actions.c:2089
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
-msgstr "Kunne ikke sætte ny konfigurationsværdi %s for konfigurationsindgang %s."
+msgstr ""
+"Kunne ikke sætte ny konfigurationsværdi %s for konfigurationsindgang %s."
 
-#: gphoto2/actions.c:1942
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "Widgetten %s har ingen indekseret liste over valg. Brug --set-config-value i stedet."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"Widgetten %s har ingen indekseret liste over valg. Brug --set-config-value i "
+"stedet."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Fejlagtigt filnummer. Du specificerede %i, men der fandtes kun %i filer tilgængelige i '%s' eller dets underkataloger. Skav venligst et gyldigt filnummer fra en filliste først."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Fejlagtigt filnummer. Du specificerede %i, men der fandtes kun %i filer "
+"tilgængelige i '%s' eller dets underkataloger. Skav venligst et gyldigt "
+"filnummer fra en filliste først."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -677,25 +729,33 @@ msgstr "Der findes ingen filer i mappen '%s'."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Fejlagtigt filnummer. Du specificerede %i, men der er kun 1 fil tilgængelig i '%s'."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Fejlagtigt filnummer. Du specificerede %i, men der er kun 1 fil tilgængelig "
+"i '%s'."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Dårligt filnummer. Du specificerede %i, men der er kun %i filer tilgængelige i '%s'. Skaf venligst et gyldigt filnummer fra en filliste først."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Dårligt filnummer. Du specificerede %i, men der er kun %i filer tilgængelige "
+"i '%s'. Skaf venligst et gyldigt filnummer fra en filliste først."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Fejl ***              \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Tryk på en tast for at fortsætte.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Ikke tilstrækkeligt med hukommelse."
@@ -704,206 +764,212 @@ msgstr "Ikke tilstrækkeligt med hukommelse."
 msgid "Operation cancelled"
 msgstr "Operationen afbrudt"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Fortsæt"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Annullér"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Fejl"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Kunne ikke sætte konfiguration:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Afslut"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Tilbage"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Tid: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Værdi: "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Ja"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Nej"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "Udfyldning med nuller i filnavne er kun muligt med %%n."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "Du kan ikke bruge %%n udfyldning med nuller uden en præcis værdi!"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Filnavnet leveret af kameraet ('%s') indeholder ikke en endelse!"
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Ugyldigt format '%s' (fejl i position %i)."
 
-#: gphoto2/main.c:382 gphoto2/main.c:585
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Overspring eksisterende fil %s\n"
 
-#: gphoto2/main.c:394
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Filen %s eksisterer. Overskriv? Ja/Nej [y|n] "
 
-#: gphoto2/main.c:406
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Specificér filnavn? Ja/Nej [y|n] "
 
-#: gphoto2/main.c:418
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Indtast nyt filnavn: "
 
-#: gphoto2/main.c:424
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Gem fil som %s\n"
 
-#: gphoto2/main.c:623
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Rettighed nægtet"
 
-#: gphoto2/main.c:785
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Kunne ikke udløse optagelse af billede."
 
-#: gphoto2/main.c:815
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Ny fil er på stedet %s%s%s på kameraet\n"
 
-#: gphoto2/main.c:845
-#, c-format
-msgid "Deleting file %s%s%s on the camera\n"
-msgstr "Sletter fil  %s%s%s på kameraet\n"
-
-#: gphoto2/main.c:855
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Beholder fil  %s%s%s på kameraet\n"
 
-#: gphoto2/main.c:888
+#: gphoto2/main.c:868
+#, c-format
+msgid "Deleting file %s%s%s on the camera\n"
+msgstr "Sletter fil  %s%s%s på kameraet\n"
+
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "Hændelse FOLDER_ADDED %s/%s ved ventning, ignorerer.\n"
 
-#: gphoto2/main.c:898
+#: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "Hændelse FOLDER_ADDED %s/%s ved ventning, ignorerer.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Hændelse UNKNOWN %s ved ventning, ignorerer.\n"
 
-#: gphoto2/main.c:904
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
-msgstr "Ukendt hændelsestype %d ved ventning på langtidseksponering, ignorerer.\n"
+msgstr ""
+"Ukendt hændelsestype %d ved ventning på langtidseksponering, ignorerer.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Kunne ikke få fat på faciliteter?"
 
-#: gphoto2/main.c:930
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Tilstand for medgået tid aktiveret (interval: %ds).\n"
 
-#: gphoto2/main.c:933
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Venter på SIGUSR1 for at optage.\n"
 
-#: gphoto2/main.c:939
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Langtidseksponering aktiveret (eksponeringstid: %ds).\n"
 
-#: gphoto2/main.c:952
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Optager ramme #%d...\n"
 
-#: gphoto2/main.c:954
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Optager ramme #%d/%d...\n"
 
-#: gphoto2/main.c:964
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Kunne ikke sætte langtidseksponering, resultat %d."
 
-#: gphoto2/main.c:978
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Kunne ikke afslutte optagelse (langtidseksponering)."
 
-#: gphoto2/main.c:991
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Kunne ikke udløse optagelse af billede."
 
-#: gphoto2/main.c:998
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Kunne ikke optage billede."
 
-#: gphoto2/main.c:1005
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Optagelse mislykkedes (autofokus-problem?)...\n"
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Kunne ikke optage."
 
-#: gphoto2/main.c:1048
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Venter på næste optagegelsestidspunkt %ld sekunder...\n"
 
-#: gphoto2/main.c:1057 gphoto2/main.c:1098
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Vækket af SIGUSR1...\n"
 
-#: gphoto2/main.c:1070
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "sover ikke (%ld sekunder bagefter planen)\n"
 
-#: gphoto2/main.c:1213
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "FEJL: "
 
-#: gphoto2/main.c:1236
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -912,12 +978,12 @@ msgstr ""
 "\n"
 "Afbryder...\n"
 
-#: gphoto2/main.c:1242
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Afbrudt.\n"
 
-#: gphoto2/main.c:1247
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -926,21 +992,26 @@ msgstr ""
 "\n"
 "Annullerer...\n"
 
-#: gphoto2/main.c:1397
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Brug den følgende syntaks a:b=c:d for at behandle en USB-enhed detekteret som a:b som c:d i stedet. a b c d skal være hexadecimale tal som begynder med '0x'.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Brug den følgende syntaks a:b=c:d for at behandle en USB-enhed detekteret "
+"som a:b som c:d i stedet. a b c d skal være hexadecimale tal som begynder "
+"med '0x'.\n"
 
-#: gphoto2/main.c:1570
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 er blevet oversat uden understøttelse for CDK."
 
-#: gphoto2/main.c:1834
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operationen annulleret.\n"
 
-#: gphoto2/main.c:1838
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -949,7 +1020,7 @@ msgstr ""
 "*** Fejl: Intet kamera fundet. ***\n"
 "\n"
 
-#: gphoto2/main.c:1840
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -958,7 +1029,7 @@ msgstr ""
 "*** Fejl (%i: '%s') ***       \n"
 "\n"
 
-#: gphoto2/main.c:1845
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -974,389 +1045,411 @@ msgstr ""
 "udviklernes postliste <gphoto-devel@lists.sourceforge.net>, så kør venligst\n"
 "gphoto2 som følger:\n"
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
 "\n"
-msgstr "Vær sikker på at der er tilstrækkeligt med anførselstegn omkring argumenterne.\n"
+msgstr ""
+"Vær sikker på at der er tilstrækkeligt med anførselstegn omkring "
+"argumenterne.\n"
 
-#: gphoto2/main.c:1933
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Udskriv komplet hjælpemeddelelse om brug"
 
-#: gphoto2/main.c:1935
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Udskriv kort meddelelse om brug"
 
-#: gphoto2/main.c:1937
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Aktivér fejlsøgning"
 
-#: gphoto2/main.c:1939
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Sæt fejlsøgnings-niveau [error|debug|data|all]"
 
-#: gphoto2/main.c:1941
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Navn på fil at skrive fejlsøgningsinformation til"
 
-#: gphoto2/main.c:1941 gphoto2/main.c:1946 gphoto2/main.c:1952
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "FILNAVN"
 
-#: gphoto2/main.c:1943
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Stille uddata (standard=snaksalig)"
 
-#: gphoto2/main.c:1945
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Hook-skript at kalde efter hentninger, optagelser, osv."
 
-#: gphoto2/main.c:1952
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Specificér portenhed"
 
-#: gphoto2/main.c:1954
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Specificér overføringshastighed"
 
-#: gphoto2/main.c:1954
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "GASTIGHED"
 
-#: gphoto2/main.c:1956
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Specificér kamera-model"
 
-#: gphoto2/main.c:1956
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODEL"
 
-#: gphoto2/main.c:1958
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(kun for eksperter) tilsidesæt USB ID'er"
 
-#: gphoto2/main.c:1958
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBID'er"
 
-#: gphoto2/main.c:1964
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Vis version og afslut"
 
-#: gphoto2/main.c:1966
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Lister understøttede kamera-modeller"
 
-#: gphoto2/main.c:1968
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Lister understøttede portenheder"
 
-#: gphoto2/main.c:1970
-msgid "Display camera/driver abilities"
+#: gphoto2/main.c:2015
+#, fuzzy
+msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Vis kamera/driver-faciliteter"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Konfigurér"
 
-#: gphoto2/main.c:1980
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Vís konfigurationstræ"
 
-#: gphoto2/main.c:1982
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Drop fuldt konfigurationstræ"
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Find konfigurationsværdi"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Sæt konfigurationsværdi eller indeks i valg"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Sæt konfigurationsværdi af indeks i valg"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Sæt konfigurationsværdi"
 
-#: gphoto2/main.c:1992
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Nulstíl portenhed"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Behold billeder på kameraet efter optagelse"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2045
+#, fuzzy
+msgid "Keep RAW images on camera after capturing"
+msgstr "Behold billeder på kameraet efter optagelse"
+
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Fjern billeder fra kameraet efter optagelse"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Vent på hændelser fra kamera"
 
-#: gphoto2/main.c:2002 gphoto2/main.c:2004 gphoto2/main.c:2011
-#: gphoto2/main.c:2027
-msgid "COUNT"
-msgstr "ANTAL"
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
 
-#: gphoto2/main.c:2004
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Vent på hændelser fra kameraet og hent nye billeder"
 
-#: gphoto2/main.c:2007
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Optag et hurtigt smugkig"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
+
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Sæt langtidseksponeringstid i sekunder"
 
-#: gphoto2/main.c:2009 gphoto2/main.c:2013
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SEKUNDER"
 
-#: gphoto2/main.c:2011
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Sæt antal billeder der skal optages (standard=uendelig)"
 
-#: gphoto2/main.c:2013
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr "ANTAL"
+
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Sæt optagelsesinterval i sekunder"
 
-#: gphoto2/main.c:2015
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Nulstil optageinterval ved signal (standard=nej)"
 
-#: gphoto2/main.c:2017
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Tag et billede"
 
-#: gphoto2/main.c:2019
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Udløs optagelse af et billede"
 
-#: gphoto2/main.c:2021
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Tag et billede og hjemhent det"
 
-#: gphoto2/main.c:2023
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Optag en film"
 
-#: gphoto2/main.c:2023
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "ANTAL eller SEKUNDER"
 
-#: gphoto2/main.c:2025
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Optag et lydafsnit"
 
-#: gphoto2/main.c:2027
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Vent på aftrykker på kameraet og hent"
 
-#: gphoto2/main.c:2029
-msgid "Trigger image capture"
-msgstr "Udløs optagelse af et billede"
-
-#: gphoto2/main.c:2035
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Vis mapper i mappen"
 
-#: gphoto2/main.c:2037
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "List filer i mappe"
 
-#: gphoto2/main.c:2039
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Opret et katalog"
 
-#: gphoto2/main.c:2039 gphoto2/main.c:2041
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "KATNAVN"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Fjern et katalog"
 
-#: gphoto2/main.c:2043
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Vis antal filer"
 
-#: gphoto2/main.c:2045
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Hent filer givet i interval"
 
-#: gphoto2/main.c:2045 gphoto2/main.c:2049 gphoto2/main.c:2054
-#: gphoto2/main.c:2061 gphoto2/main.c:2067 gphoto2/main.c:2072
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "INTERVAL"
 
-#: gphoto2/main.c:2047
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Hent alle filer fra mappen"
 
-#: gphoto2/main.c:2049
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Hent alle miniaturer i det givne interval"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Hent alle miniaturer i mappen"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Hent metadata i det givne interval"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Hent alle metadata fra mappe"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Oplæg metadata for fil"
 
-#: gphoto2/main.c:2061
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Hent rådata i det givne interval"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Hent alle rådata fra mappen"
 
-#: gphoto2/main.c:2067
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Hent lyddata i det givne interval"
 
-#: gphoto2/main.c:2070
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Hent alle lyddata fra mappen"
 
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Slet filer i det givne interval"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Slet alle filer i mappen (--no-recurse som standard)"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Oplæg fil på kamera"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Specificér et filnavn eller filnavnsmønster"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "FILNAVNSMØNSTER"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Specificér kameramappe (standard=\"/\")"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "MAPPE"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Rekursion (standard for hjemhentning)"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Ej rekursion (standard for sletning)"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Behand kun nye filer"
 
-#: gphoto2/main.c:2088
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Overskriv filer uden at spørge"
 
-#: gphoto2/main.c:2090
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Overspring eksisterende filer"
 
-#: gphoto2/main.c:2096
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Send fil til stdout"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Skriv filstørrelse før data"
 
-#: gphoto2/main.c:2100
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "List autodetekterede kameraer"
 
-#: gphoto2/main.c:2104 gphoto2/shell.c:138
-msgid "Show EXIF information"
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
 msgstr "Vis EXIF-information"
 
-#: gphoto2/main.c:2107 gphoto2/shell.c:132
-msgid "Show info"
-msgstr "Vis info"
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
 
-#: gphoto2/main.c:2109
-msgid "Show summary"
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "Vis oversigt"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Vis kameradrivrutinens manual"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Om kameradrivrutinens manual"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Vis lager-information"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "gPhoto skál"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Almindelige flag"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Diverse flag (usorterede)"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "Hent information om progbilleder og værtssystem (ikke fra kameraet)"
 
-#: gphoto2/main.c:2129
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Specificér kamera der skal bruges"
 
-#: gphoto2/main.c:2131
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Kamera- og program-konfiguration"
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Tag et billede fra eller på kameraet"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Henter, oplægger og manipulerer filer"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1365,7 +1458,7 @@ msgstr ""
 "%s\n"
 "Billed-ID'er skal være et tal større end nul."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1374,7 +1467,7 @@ msgstr ""
 "%s\n"
 "Billed-ID %i for høj."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1383,7 +1476,7 @@ msgstr ""
 "%s\n"
 "Interval skal separeres af ','."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1392,7 +1485,7 @@ msgstr ""
 "%s\n"
 "Interval skal starte med et tal."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1401,7 +1494,7 @@ msgstr ""
 "%s\n"
 "Uventet tegn '%c'."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -1410,215 +1503,228 @@ msgstr ""
 "%s\n"
 "Nedadgående intervaller er ikke tilladte. Du angav et interval fra %i til %i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Fejl (%i: '%s') ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Ændr til et katalog i kameraet"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "katalog"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Ændr til et katalog på den lokale disk"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Afslut gPhoto-skallen"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Hjemhent en fil"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[katalog/]filnavn"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Oplæg en fil"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Hjemhentning af en miniature"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Hjemhent rådata"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Slet"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Opret katalog"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Fjern katalog"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Viser kommandobrug"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[kommando]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "List indholdet af det nuværende katalog"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[katalog/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Vis konfigurationsvariable"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Find konfigurationsvariabel"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "navn"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Sæt konfigurationsvariabel"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "navn=værdi"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Sæt konfigurationsvariabelindeks"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "navn=værdiindex"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Udløs optagelse af et billede"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Tag et enkelt billede"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Tag et enkelt billede og hent det"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Tag et billede til forhåndsvisning"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Vent på en hændelse"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "antal eller sekunder"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Vent på, at billeder bliver taget, og hent dem"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Vent på hændelser og at billeder bliver taget, og hent dem"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Ugyldig kommando."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Kommandoen '%s' kræver et argument."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Ugyldig søgesti."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Kunne ikke finde hjemmekataloget."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Kunne ikke gå til lokalt katalog '%s'."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Lokalt katalog er nu '%s'."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Fjernkataloget er nu '%s'."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config behøver et argument nummer to.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "set-config-value behøver et argument nummer to.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "set-config-index behøver et argument nummer to.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Kommandoen '%s' ikke fundet. Brug 'help' for at få en liste af tilgængelige kommandoer."
+msgstr ""
+"Kommandoen '%s' ikke fundet. Brug 'help' for at få en liste af tilgængelige "
+"kommandoer."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Hjælp om \"%s\":"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Brug:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Beskrivelse:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Argumenter i klammer [] er valgfri"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Tilgængelige kommandoer:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr "For at få hjælp om en speciel kommando så skriv 'help kommando-navn'."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Udløs optagelse af et billede"
+
+#~ msgid "Show info"
+#~ msgstr "Vis info"
 
 #~ msgid "  Name:        '%s'\n"
 #~ msgstr "  Navn:        '%s'\n"

--- a/po/de.po
+++ b/po/de.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libexif 0.6.16\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2016-03-23 21:57+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2013-10-06 17:52+0200\n"
 "Last-Translator: Marcus Meissner\n"
 "Language-Team: German <kde-i18n-doc@kde.org>\n"
@@ -23,135 +23,135 @@ msgstr ""
 "X-Generator: Lokalize 1.4\n"
 "Plural-Forms: nplurals=2; plural=n == 1 ? 0 : 1;\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Anzahl der Dateien im Verzeichnis »%s«: %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "Es gibt %d Verzeichnis im Verzeichnis »%s«.\n"
 msgstr[1] "Es gibt %d Verzeichnisse im Verzeichnis »%s«.\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Es gibt keine Datei im Verzeichnis »%s«.\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "Es gibt %d Datei im Verzeichnis »%s«.\n"
 msgstr[1] "Es gibt %d Dateien im Verzeichnis »%s«.\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Informationen für Datei »%s« (Verzeichnis »%s«):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Datei:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Nicht verfügbar.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  MIME-Typ:   »%s«\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Größe:       %lu Byte(s)\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Breite:      %i Pixel\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Höhe:        %i pixel(s)\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "Heruntergeladen: »%s«\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1803 gphoto2/actions.c:2046
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "Ja"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1797 gphoto2/actions.c:2040
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "Nein"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Berechtigungen: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "Lesen/Löschen"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "Lesen"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "Löschen"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "Keine"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Zeit:        %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Vorschaubild:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Audiodaten:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  MIME-Typ:  »%s«\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Größe:      %lu Byte(s)\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Heruntergeladen: »%s«\n"
@@ -173,46 +173,46 @@ msgstr "Tag"
 msgid "Value"
 msgstr "Wert"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "EXIF-Daten enthalten ein Vorschaubild (%i Bytes)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 wurde ohne Unterstützung für EXIF kompiliert."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Anzahl der unterstützten Kameras: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Unterstützte Kameras:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t»%s« (IM TEST)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t»%s« (EXPERIMENTELL)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t»%s«\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Gefundene Geräte: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -221,80 +221,80 @@ msgstr ""
 "Pfad                             Beschreibung\n"
 "------------------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Modell"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Port"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Fähigkeiten für Kamera           : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Unterstützung für seriellen Port : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB-Unterstützung                : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Unterstützte Datenraten (seriell):\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Aufnahme machen (Auswahl)        :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Bild\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Audio\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Bildvorschau\n"
 
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, fuzzy, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
 msgid ""
 "                                 : Capture not supported by the driver\n"
@@ -302,32 +302,32 @@ msgstr ""
 "                                 : Aufnahme wird nicht durch Treiber "
 "unterstützt\n"
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Konfigurationsunterstützung      : %s\n"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Unterstützung für das Löschen einzelner Bilder: %s\n"
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Unterstützung für das Löschen aller Bilder   : %s\n"
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Unterstützung für Bildvorschau   : %s\n"
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Unterstützung für Bildhochladen  : %s\n"
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
 msgid ""
 "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
@@ -336,7 +336,7 @@ msgstr ""
 "Ports müssen als »serial:/dev/ttyS0« oder »usb:« angegeben werden, aber »%s« "
 "hat keinen Doppelpunkt. Es wird versucht, herauszufinden, was Sie meinen."
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
 msgid ""
 "The port you specified ('%s') can not be found. Please specify one of the "
@@ -348,36 +348,36 @@ msgstr ""
 "der von »gphoto2 --list-ports« gelisteten Ports an und stellen Sie sicher, \n"
 "daß die Schreibweise korrekt ist (mit Präfix »serial:« oder »usb:«)."
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "Über den Kameratreiber"
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Kamerazusammenfassung:"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Kameraanleitung:"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Nur mit seriellen Ports können Sie eine Datenrate setzen."
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "OS/2-Portierung von Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:907
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
@@ -399,56 +399,56 @@ msgstr ""
 "Diese Version von gphoto2 benutzt die folgenden Softwareversionen und "
 "Optionen:\n"
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Konnte 'movie.mjpg' nicht öffnen."
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
 msgstr ""
 "Nehme Vorschaubilder als Film in '%s' auf. Drücke Ctrl-C zum abbrechen.\n"
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr "Nehme Vorschaubilder als Film in '%s' für %d Sekunden auf.\n"
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Nehme %d Vorschaubilder als Film '%s' auf.\n"
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Film Aufnehme Fehler ... Beenden."
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Film Aufnahme Fehler... Unbekannter MIME Typ '%s'."
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ctrl-C gedrückt ... Beenden.\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Film Aufnahme beendet (%d Bilder)\n"
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "Warte auf Ereignisse von der Kamera. Drücke Ctrl-C zum abbrechen.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr "Warte auf %d Bilder von der Kamera. Drücke Ctrl-C zum abbrechen.\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
 msgid ""
 "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
@@ -456,117 +456,128 @@ msgstr ""
 "Warte %d Millisekunden auf Events von der Kamera. Drücke Ctrl-C zum "
 "abbrechen.\n"
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
 msgstr ""
 "Warte %d Sekunden auf Events von der Kamera. Drücke Ctrl-C zum abbrechen.\n"
 
-#: gphoto2/actions.c:1121
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
 msgstr "Warte auf %d Ereignisse von der Kamera. Drücke Ctrl-C zum abbrechen.\n"
 
-#: gphoto2/actions.c:1125
+#: gphoto2/actions.c:1129
 #, fuzzy, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
 msgstr "Warte auf %d Ereignisse von der Kamera. Drücke Ctrl-C zum abbrechen.\n"
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr ""
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Konnte Verzeichnis nicht setzen."
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Konnte Bild nicht holen."
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "Kaputte libcanon.so?"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Konnte Bild nicht löschen."
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr ""
 "Das Abfragen von Informationen über Speichergeräte ist bei dieser Kamera "
 "nicht unterstützt.\n"
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Lesen/Schreiben"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Nur Lesen"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Nur Lesen und Bilder löschen"
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "Fester ROM"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "Entfernbarer ROM"
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "Fester RAM"
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "Entfernbarer RAM"
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Unbekannt"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Flacher Speicher"
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Hierarchischer Speicher"
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Kamera Struktur (DCIM)"
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Ersetze USB Vendor/Product ID 0x%x/0x%x durch 0x%x/0x%x"
 
-#: gphoto2/actions.c:1435
+#: gphoto2/actions.c:1474
 msgid ""
 "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
 "MAILING LIST:"
@@ -574,128 +585,128 @@ msgstr ""
 "BITTE IMMER FOLGENDE ZEILE EINFÜGEN WENN DEBUG MESSAGES AN DIE MAILINGLISTE "
 "GESCHICKT WERDEN:"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s wurde mit den folgenden Optionen übersetzt:"
 
-#: gphoto2/actions.c:1590
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s wurde nicht in der Konfiguration gefunden."
 
-#: gphoto2/actions.c:1637
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Konnte den Inhalt des Textfeldes %s holen."
 
-#: gphoto2/actions.c:1654
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Konnte die Werte für den Bereiches %s nicht bestimmen."
 
-#: gphoto2/actions.c:1666
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Konnte die möglichen Werte der Auswahl %s nicht holen."
 
-#: gphoto2/actions.c:1678
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Konnte die Werte der Datum/Zeit Konfiguration %s nicht holen."
 
-#: gphoto2/actions.c:1687
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1709
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Konnte die Werte der Auswahl %s nicht holen."
 
-#: gphoto2/actions.c:1753
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "Property %s is nur lesbar."
 
-#: gphoto2/actions.c:1767 gphoto2/actions.c:2010
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Konnte den Inhalt des Textfeldes %s nicht auf %s setzen."
 
-#: gphoto2/actions.c:1777 gphoto2/actions.c:2020
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Der übergebene Wert %s ist kein Fließkomma Wert."
 
-#: gphoto2/actions.c:1782 gphoto2/actions.c:2025
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "Der übergebene Wert %f ist nicht im erwarteten Bereich %f - %f."
 
-#: gphoto2/actions.c:1788 gphoto2/actions.c:2031
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Konnte den Wert des Bereichs %s nicht auf %f setzen."
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2040
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "aus"
 
-#: gphoto2/actions.c:1798 gphoto2/actions.c:2041
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "falsch"
 
-#: gphoto2/actions.c:1803 gphoto2/actions.c:2046
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "an"
 
-#: gphoto2/actions.c:1804 gphoto2/actions.c:2047
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "wahr"
 
-#: gphoto2/actions.c:1809 gphoto2/actions.c:2052
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Der übergebene Wert %s ist kein zulässige Schalterwert."
 
-#: gphoto2/actions.c:1815 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Konnte den Schalter %s nicht auf den Wert %s setzen."
 
-#: gphoto2/actions.c:1827
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "jetzt"
 
-#: gphoto2/actions.c:1839 gphoto2/actions.c:2071
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr ""
 "Der übergebene Wert %s ist kein Integer oder wurde nicht als Zeitangabe "
 "erkannt."
 
-#: gphoto2/actions.c:1847 gphoto2/actions.c:2078
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Konnte %s nicht als neue Zeit im der Konfiguration %s setzen."
 
-#: gphoto2/actions.c:1894 gphoto2/actions.c:1961 gphoto2/actions.c:2108
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Wert %s wurde nicht in der Liste möglicher Werte gefunden."
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:2116
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Das Konfigurationssubmenü %s hat keinen änderbaren Wert."
 
-#: gphoto2/actions.c:1912 gphoto2/actions.c:1983 gphoto2/actions.c:2126
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr "Konnte den neuen Wert %s für die Konfiguration %s nicht setzen."
 
-#: gphoto2/actions.c:1973
+#: gphoto2/actions.c:2019
 #, c-format
 msgid ""
 "The %s widget has no indexed list of choices. Use --set-config-value instead."
@@ -736,17 +747,17 @@ msgstr ""
 "Fehlerhafte Dateinummer. Sie gaben %i an, aber es gibt nur %i Dateien in "
 "»%s«. Bitte holen Sie zuerst eine gültige Dateinummer aus einer Dateiliste."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Fehler ***      \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Eine beliebige Taste drücken um fortzusetzen.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Ungenügend Speicher."
@@ -755,208 +766,213 @@ msgstr "Ungenügend Speicher."
 msgid "Operation cancelled"
 msgstr "Operation abgebrochen"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Weitermachen"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Abbrechen"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Fehler"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Konnte Konfiguration nicht setzen:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Beenden"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Zurück"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Zeit: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Wert: "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Ja"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Nein"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "Das Angeben von führenden Nullen ist nur bei %%n möglich."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "Sie können »%%n« nicht Präzisionsangabe verwenden!"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr ""
 "Der von der Kamera gelieferte Filename (»%s«) enthält keine Dateiendung."
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Ungültiges Format »%s« (Fehler an Position %i)."
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, fuzzy, c-format
 msgid "Skip existing file %s\n"
 msgstr "Speichere Datei als %s\n"
 
 # !!! [y/n] !!! [CM]
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Datei %s existiert bereits. Überschreiben? [y|n] "
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Neuen Dateinamen angeben? [y|n] "
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Geben Sie einen neuen Dateinamen an: "
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Speichere Datei als %s\n"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Zugriff verweigert"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Konnte nicht aufnehmen."
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Neue Datei ist in %s%s%s auf der Kamera\n"
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Behalte Datei %s%s%s auf der Kamera\n"
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Lösche Datei %s%s%s auf der Kamera\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "Ereignis FOLDER_ADDED %s/%s, wird ignoriert.\n"
 
 #: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "Ereignis FOLDER_ADDED %s/%s, wird ignoriert.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Ereignis UNKOWN %s, wird ignoriert.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr "Unbekannter Ereignistyp %d, wird ignoriert.\n"
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Konnte Fähigkeiten der Kamera nicht holen?"
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Zeitlupen Modus aktiviert (Intervall: %ds).\n"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Warte auf SIGUSR1 um Aufnahme zu starten.\n"
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Bulb Modus aktiviert (Aufnahmedauer: %ds).\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Nehme Bild %d auf...\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Nehme Bild %d von %d auf...\n"
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Konnte Bulb Modus nicht setzen, Fehler %d."
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Konnte Bulb Modus nicht beenden."
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Konnte Bild Aufnahme nicht starten."
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Konnte Bild nicht aufnehmen."
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Aufnahme fehlgeschlagen (Auto Fokus Problem?)...\n"
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Konnte nicht aufnehmen."
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Warte %ld Sekunden auf den nächsten Aufnahme Slot...\n"
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Aufgeweckt durch SIGUSR1...\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "Keine Pause (%ld Sekunden zurück)\n"
 
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "FEHLER: "
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -965,12 +981,12 @@ msgstr ""
 "\n"
 "Harter Abbruch...\n"
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Abgebrochen.\n"
 
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -979,7 +995,7 @@ msgstr ""
 "\n"
 "Abbruch...\n"
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
 msgid ""
 "Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
@@ -989,16 +1005,16 @@ msgstr ""
 "»c:d« zu behandeln.\n"
 "a b c d sind hexadezimale Angaben, die mit »0x« beginnen müssen.\n"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 wurde ohne Unterstützung für CDK kompiliert."
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operation abgebrochen.\n"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -1007,7 +1023,7 @@ msgstr ""
 "*** Fehler: Keine Kamera gefunden. ***\n"
 "\n"
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -1016,7 +1032,7 @@ msgstr ""
 "*** Fehler (%i: »%s«) ***      \n"
 "\n"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -1033,7 +1049,7 @@ msgstr ""
 "so starten sie gphoto2 bitte wie folgt:\n"
 "\n"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
@@ -1043,398 +1059,403 @@ msgstr ""
 "sind.\n"
 "\n"
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Gebe kompletten Hilfstext zur Benutzung aus"
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Gebe kurzen Hilfstext zur Benutzung aus"
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Schalte Debugging ein"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr ""
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Dateinamen für Debug Informationen"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "DATEINAME"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Wenige Ausgaben (Vorgabe=gesprächig)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Hook-Skript, das nach Herunterladen, Aufnahme, etc. gestartet wird"
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Angabe des Port-Geräts"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Angabe der seriellen Datenrate"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "GESCHWINDIGKEIT"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Angabe des Kameramodells"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODELL"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(für Experten) Überschreibe USB-IDs"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBIDs"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Zeige Version und beende"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Zeige unterstützte Kameramodelle"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Liste unterstützte Port-Geräte"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 #, fuzzy
 msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Zeige Kamera-/Treiberfähigkeiten"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Konfigurieren"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Zeige Konfigurationsbaum"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Zeige vollen Konfigurationsbaum"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Hole Konfigurationswert"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Setze Konfigurationswert oder -Index im Menü"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Setze Konfigurationswert Index im Menü"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Setze Konfigurationswert"
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Reset des Ports"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Behalte Bilder auf der Kamera nach der Aufnahme"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 #, fuzzy
 msgid "Keep RAW images on camera after capturing"
 msgstr "Behalte Bilder auf der Kamera nach der Aufnahme"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Lösche Bilder von der Kamera nach der Aufnahme"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Warte auf Kameraereignisse"
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr ""
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Warte auf Ereignisse von der Kamera und lade neue Bilder herunter"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Mache eine Vorschaubild-Aufnahme"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr ""
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Setze die Zeit der Bulb Aufnahme in Sekunden"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SEKUNDEN"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Setze die Anzahl der aufzunehmenden Bilder (default=unendlich)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "ANZAHL"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Setze das Aufnahmeintervall in Sekunden"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Setze Aufnahmeinterval nach Signal zurück (default=nein)"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Eine Bildaufnahme machen"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Eine Bildaufnahme auslösen"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Eine Bildaufnahme machen und herunterladen"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Eine Filmaufnahme machen"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "ANZAHL oder SEKUNDEN"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Eine Audioaufnahme machen"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Warte auf Auslöserdruck an der Kamera und lade Bilder herunter"
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr "Starte Bildaufnahme"
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Liste Verzeichnisse in Verzeichnis"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Liste Dateien in Verzeichnis"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Verzeichnis anlegen"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "VERZEICHNIS"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Verzeichnis löschen"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Zeige Anzahl der Dateien"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Hole Dateien im angegebenen Bereich"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "BEREICH"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Hole alle Dateien im Verzeichnis"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Hole Vorschaubilder im angegebenen Bereich"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Hole alle Vorschaubilder im Verzeichnis"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Hole Metadaten im angegebenen Bereich"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Hole alle Metadaten im Verzeichnis"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Lade Metadaten herunter für Datei"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Hole Rohdaten im angegebenen Bereich"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Hole alle Rohdaten im Verzeichnis"
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Hole Audiodaten im angegebenen Bereich"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Hole alle Audiodaten im Verzeichnis"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Lösche Dateien im angegebenen Bereich"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Lösche alle Dateien im Verzeichnis (--no-recurse als default)"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Datei auf Kamera hochladen"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Geben Sie einen Dateinamen oder ein Dateinamensmuster an"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "DATEINAMENS_MUSTER"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Angabe des Kameraverzeichnisses (Vorgabe=\"/\")"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "VERZEICHNIS"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Rekursion (Vorgabe für das Herunterladen)"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Keine Rekursion (Vorgabe für das Löschen)"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Bearbeite nur neue Dateien"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Dateien ohne Nachfragen überschreiben"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr ""
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Sende Datei auf die Standardausgabe"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Dateigröße vor Daten ausgeben"
 
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Liste automatisch erkannte Kameras"
 
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 #, fuzzy
 msgid "Show EXIF information of JPEG images"
 msgstr "Zeige EXIF-Informationen"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
 msgstr ""
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 #, fuzzy
 msgid "Show camera summary"
 msgstr "Zusammenfassung zeigen"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Anleitung für Kameratreiber zeigen"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Die Kameratreiberhilfe anzeigen"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Zeige Speicher-Informationen"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "gPhoto-Shell"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Gebräuchliche Optionen"
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Weitere Optionen (unsortiert)"
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr ""
 "Frage Informationen über Software und Maschine ab (nicht von der Kamera)"
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Angabe der zu benutzenden Kamera"
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Konfiguration von Kamera und Software"
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Nehme ein Bild mit der Kamera auf"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Herunterladen, hochladen und manipulieren von Dateien"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1443,7 +1464,7 @@ msgstr ""
 "%s\n"
 "Bilder-IDs müssen größer als Null sein."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1452,7 +1473,7 @@ msgstr ""
 "%s\n"
 "Bild-ID %i zu groß."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1461,7 +1482,7 @@ msgstr ""
 "%s\n"
 "Bereiche müssen mittels »,« getrennt werden."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1470,7 +1491,7 @@ msgstr ""
 "%s\n"
 "Bereiche müssen mit einer Zahl beginnen."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1479,7 +1500,7 @@ msgstr ""
 "%s\n"
 "Unerwartetes Zeichen »%c«."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -1488,219 +1509,227 @@ msgstr ""
 "%s Absteigende Bereiche sind nicht erlaubt. Sie müssen einen Bereich\n"
 "von %i bis %i angeben."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Fehler (%i: »%s«) ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Wechsle in ein Verzeichnis auf der Kamera"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "Verzeichnis"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Wechsle in ein Verzeichnis auf der lokalen Festplatte."
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "gPhoto-Shell beenden"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Lade eine Datei herunter"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[Verzeichnis/]Dateiname"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Lade eine Datei hoch"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Lade ein Vorschaubild herunter"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Lade Rohdaten herunter"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Löschen"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Lege Verzeichnis an"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Verzeichnis löschen"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Zeige Befehlsverwendung"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[Befehl]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Zeige den Inhalt des aktuellen Verzeichnisses"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[Verzeichnis/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Zeige Konfigurationswerte an"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Frage einen Wert der Konfiguration ab"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "Name"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Setze einen Konfigurationswert"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "Name=Wert"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Setze den Index eines Konfigurationswerts"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "Name=Index"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Eine Bildaufnahme auslösen"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Eine Bildaufnahme machen"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Eine Bildaufnahme machen und herunter laden"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Eine Vorschau aufnehmen"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Warte auf ein Kameraereigniss"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "Anzahl oder Sekunden"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Warte auf Auslöserdruck an der Kamera und lade neue Bilder herunter"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Auf Ereignisse warten und dabei neu aufgenommene Bilder herunterladen"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Ungültiger Befehl."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Der Befehl »%s« erfordert ein Argument."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Ungültiger Pfad."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Konnte Heimverzeichnis nicht finden."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Konnte nicht in das lokale Verzeichnis »%s« wechseln."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Lokales Verzeichnis ist nun »%s«."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Entferntes Verzeichnis ist nun »%s«."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config benötigt ein zweites Argument.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "set-config-value benötigt ein zweites Argument.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "set-config-index benötigt ein zweites Argument.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
 msgstr ""
 "Befehl »%s« nicht gefunden. Verwenden Sie »help«, um eine Liste aller "
 "verfügbaren Befehle zu erhalten."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Hilfe für \"%s\":"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Verwendung:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Beschreibung:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Argumente in eckigen Klammern [] sind optional"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Verfügbare Befehle:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr ""
 "Um Hilfe zu einem bestimmten Befehl zu erhalten, verwenden Sie »help "
 "Befehlsname«."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Starte Bildaufnahme"
 
 #~ msgid "Show info"
 #~ msgstr "Zeige Info"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -6,208 +6,208 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.1.2\n"
-"POT-Creation-Date: 2003-08-10 20:58+0200\n"
+"Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2004-04-20 11:04-0400\n"
 "Last-Translator: Gareth Owen <gowen72@yahoo.com>\n"
 "Language-Team: English (British) <en_gb@li.org>\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 
-#: gphoto2/actions.c:101
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Number of files in folder '%s': %i\n"
 
-#: gphoto2/actions.c:122
-#, c-format
-msgid "There are no folders in folder '%s'."
-msgstr "There are no folders in folder '%s'."
+#: gphoto2/actions.c:201
+#, fuzzy, c-format
+msgid "There is %d folder in folder '%s'.\n"
+msgid_plural "There are %d folders in folder '%s'.\n"
+msgstr[0] "There is one folder in folder '%s':"
+msgstr[1] "There is one folder in folder '%s':"
 
-#: gphoto2/actions.c:126
-#, c-format
-msgid "There is one folder in folder '%s':"
-msgstr "There is one folder in folder '%s':"
-
-#: gphoto2/actions.c:130
-#, c-format
-msgid "There are %i folders in folder '%s':"
-msgstr "There are %i folders in folder '%s':"
-
-#: gphoto2/actions.c:157 gphoto2/foreach.c:277
-#, c-format
-msgid "There are no files in folder '%s'."
-msgstr "There are no files in folder '%s'."
-
-#: gphoto2/actions.c:162
-#, c-format
-msgid "There is one file in folder '%s':"
+#: gphoto2/actions.c:250
+#, fuzzy, c-format
+msgid "There is no file in folder '%s'.\n"
 msgstr "There is one file in folder '%s':"
 
-#: gphoto2/actions.c:167
-#, c-format
-msgid "There are %i files in folder '%s':"
-msgstr "There are %i files in folder '%s':"
+#: gphoto2/actions.c:253
+#, fuzzy, c-format
+msgid "There is %d file in folder '%s'.\n"
+msgid_plural "There are %d files in folder '%s'.\n"
+msgstr[0] "There is one file in folder '%s':"
+msgstr[1] "There is one file in folder '%s':"
 
-#: gphoto2/actions.c:188
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Information on file '%s' (folder '%s'):\n"
 
-#: gphoto2/actions.c:190
+#: gphoto2/actions.c:277
+#, c-format
 msgid "File:\n"
 msgstr "File:\n"
 
-#: gphoto2/actions.c:192 gphoto2/actions.c:226 gphoto2/actions.c:242
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
+#, c-format
 msgid "  None available.\n"
 msgstr "  None available.\n"
 
-#: gphoto2/actions.c:195
-#, c-format
-msgid "  Name:        '%s'\n"
-msgstr "  Name:        '%s'\n"
-
-#: gphoto2/actions.c:197 gphoto2/actions.c:229
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Mime type:   '%s'\n"
 
-#: gphoto2/actions.c:199 gphoto2/actions.c:231
-#, c-format
-msgid "  Size:        %li byte(s)\n"
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#, fuzzy, c-format
+msgid "  Size:        %lu byte(s)\n"
 msgstr "  Size:        %li byte(s)\n"
 
-#: gphoto2/actions.c:201 gphoto2/actions.c:233
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Width:       %i pixel(s)\n"
 
-#: gphoto2/actions.c:203 gphoto2/actions.c:235
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Height:      %i pixel(s)\n"
 
-#: gphoto2/actions.c:205 gphoto2/actions.c:237
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Downloaded:  %s\n"
 
-#: gphoto2/actions.c:206 gphoto2/actions.c:238 gphoto2/actions.c:250
-#: gphoto2/actions.c:548 gphoto2/actions.c:550 gphoto2/actions.c:567
-#: gphoto2/actions.c:570 gphoto2/actions.c:573 gphoto2/actions.c:576
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "yes"
 
-#: gphoto2/actions.c:206 gphoto2/actions.c:238 gphoto2/actions.c:250
-#: gphoto2/actions.c:548 gphoto2/actions.c:550 gphoto2/actions.c:567
-#: gphoto2/actions.c:570 gphoto2/actions.c:573 gphoto2/actions.c:576
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "no"
 
-#: gphoto2/actions.c:208
+#: gphoto2/actions.c:293
+#, c-format
 msgid "  Permissions: "
 msgstr "  Permissions: "
 
-#: gphoto2/actions.c:211
+#: gphoto2/actions.c:296
+#, c-format
 msgid "read/delete"
 msgstr "read/delete"
 
-#: gphoto2/actions.c:213
+#: gphoto2/actions.c:298
+#, c-format
 msgid "read"
 msgstr "read"
 
-#: gphoto2/actions.c:215
+#: gphoto2/actions.c:300
+#, c-format
 msgid "delete"
 msgstr "delete"
 
-#: gphoto2/actions.c:217
+#: gphoto2/actions.c:302
+#, c-format
 msgid "none"
 msgstr "none"
 
-#: gphoto2/actions.c:221
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Time:        %s"
 
-#: gphoto2/actions.c:224
+#: gphoto2/actions.c:309
+#, c-format
 msgid "Thumbnail:\n"
 msgstr "Thumbnail:\n"
 
-#: gphoto2/actions.c:240
+#: gphoto2/actions.c:325
+#, c-format
 msgid "Audio data:\n"
 msgstr "Audio data:\n"
 
-#: gphoto2/actions.c:245
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Mime type:  '%s'\n"
 
-#: gphoto2/actions.c:247
-#, c-format
-msgid "  Size:       %li byte(s)\n"
+#: gphoto2/actions.c:332
+#, fuzzy, c-format
+msgid "  Size:       %lu byte(s)\n"
 msgstr "  Size:       %li byte(s)\n"
 
-#: gphoto2/actions.c:249
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Downloaded: %s\n"
 
-#: gphoto2/actions.c:380
+#: gphoto2/actions.c:504
 msgid "Could not parse EXIF data."
 msgstr "Could not parse EXIF data."
 
-#: gphoto2/actions.c:384
+#: gphoto2/actions.c:508
+#, c-format
 msgid "EXIF tags:"
 msgstr "EXIF tags:"
 
-#: gphoto2/actions.c:387
+#: gphoto2/actions.c:511
 msgid "Tag"
 msgstr "Tag"
 
-#: gphoto2/actions.c:389
+#: gphoto2/actions.c:513
 msgid "Value"
 msgstr "Value"
 
-#: gphoto2/actions.c:410
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "EXIF data contains a thumbnail (%i bytes)."
 
-#: gphoto2/actions.c:419
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 has been compiled without EXIF support."
 
-#: gphoto2/actions.c:437
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Number of supported cameras: %i\n"
 
-#: gphoto2/actions.c:439
+#: gphoto2/actions.c:549
+#, c-format
 msgid "Supported cameras:\n"
 msgstr "Supported cameras:\n"
 
-#: gphoto2/actions.c:452
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (TESTING)\n"
 
-#: gphoto2/actions.c:455
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (EXPERIMENTAL)\n"
 
-#: gphoto2/actions.c:460
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:488
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Devices found: %i\n"
 
-#: gphoto2/actions.c:489
+#: gphoto2/actions.c:615
+#, c-format
 msgid ""
 "Path                             Description\n"
 "--------------------------------------------------------------\n"
@@ -215,125 +215,168 @@ msgstr ""
 "Path                             Description\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:528 gphoto2/actions.c:533
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:528
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Model"
 
-#: gphoto2/actions.c:528
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Port"
 
-#: gphoto2/actions.c:529
+#: gphoto2/actions.c:649
+#, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:546
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Abilities for camera             : %s\n"
 
-#: gphoto2/actions.c:547
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Serial port support              : %s\n"
 
-#: gphoto2/actions.c:549
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB support                      : %s\n"
 
-#: gphoto2/actions.c:552
+#: gphoto2/actions.c:673
+#, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Transfer speeds supported        :\n"
 
-#: gphoto2/actions.c:554
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:557
+#: gphoto2/actions.c:678
+#, c-format
 msgid "Capture choices                  :\n"
 msgstr "Capture choices                  :\n"
 
-#: gphoto2/actions.c:559
+#: gphoto2/actions.c:680
+#, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Image\n"
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:684
+#, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:563
+#: gphoto2/actions.c:688
+#, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Audio\n"
 
-#: gphoto2/actions.c:565
+#: gphoto2/actions.c:692
+#, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Preview\n"
 
-#: gphoto2/actions.c:566
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
+
+#: gphoto2/actions.c:700
+#, fuzzy, c-format
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr "                                 : Preview\n"
+
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Configuration support            : %s\n"
 
-#: gphoto2/actions.c:568
-#, c-format
-msgid "Delete files on camera support   : %s\n"
+#: gphoto2/actions.c:704
+#, fuzzy, c-format
+msgid "Delete selected files on camera  : %s\n"
 msgstr "Delete files on camera support   : %s\n"
 
-#: gphoto2/actions.c:571
+#: gphoto2/actions.c:707
+#, fuzzy, c-format
+msgid "Delete all files on camera       : %s\n"
+msgstr "Delete files on camera support   : %s\n"
+
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "File preview (thumbnail) support : %s\n"
 
-#: gphoto2/actions.c:574
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "File upload support              : %s\n"
 
-#: gphoto2/actions.c:591
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
 
-#: gphoto2/actions.c:630
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
 
-#: gphoto2/actions.c:668
+#: gphoto2/actions.c:797
+#, c-format
 msgid "About the camera driver:"
 msgstr "About the camera driver:"
 
-#: gphoto2/actions.c:682
+#: gphoto2/actions.c:810
+#, c-format
 msgid "Camera summary:"
 msgstr "Camera summary:"
 
-#: gphoto2/actions.c:696
+#: gphoto2/actions.c:823
+#, c-format
 msgid "Camera manual:"
 msgstr "Camera manual:"
 
-#: gphoto2/actions.c:712
+#: gphoto2/actions.c:840
+#, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "You can only specify speeds for serial ports."
 
-#: gphoto2/actions.c:763
-#, c-format
+#: gphoto2/actions.c:890
+msgid "OS/2 port by Bart van Leeuwen\n"
+msgstr "OS/2 port by Bart van Leeuwen\n"
+
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-2003 Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
@@ -341,469 +384,587 @@ msgstr ""
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"Licence. For more information about these matters, see the files named COPYING.\n"
+"Licence. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 
-#: gphoto2/actions.c:776
-msgid "OS/2 port by Bart van Leeuwen\n"
-msgstr "OS/2 port by Bart van Leeuwen\n"
+#: gphoto2/actions.c:1015
+msgid "Could not open 'movie.mjpg'."
+msgstr ""
 
-#: gphoto2/actions.c:890
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-
-#: gphoto2/foreach.c:254
+#: gphoto2/actions.c:1022
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
+msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
+msgstr ""
 
-#: gphoto2/foreach.c:283
+#: gphoto2/actions.c:1026
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Bad file number. You specified %i, but there is only 1 file available in '%s'."
+msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1031
+#, c-format
+msgid "Capturing %d preview frames as movie to '%s'.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1047
+msgid "Movie capture error... Exiting."
+msgstr ""
+
+#: gphoto2/actions.c:1053
+#, c-format
+msgid "Movie capture error... Unhandled MIME type '%s'."
+msgstr ""
+
+#: gphoto2/actions.c:1060
+#, c-format
+msgid "Ctrl-C pressed ... Exiting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1074
+#, c-format
+msgid "Movie capture finished (%d frames)\n"
+msgstr ""
+
+#: gphoto2/actions.c:1106
+#, c-format
+msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1112
+#, c-format
+msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1117
+#, c-format
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1122
+#, c-format
+msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1125
+#, c-format
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1129
+#, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
+#, c-format
+msgid "event found, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
+#, fuzzy
+msgid "Could not set folder."
+msgstr "Could not set configuration:"
+
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
+#, fuzzy
+msgid "Could not get image."
+msgstr "Could not set configuration:"
+
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
+msgid "Buggy libcanon.so?"
+msgstr ""
+
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
+#, fuzzy
+msgid "Could not delete image."
+msgstr "Could not find home directory."
+
+#: gphoto2/actions.c:1300
+#, c-format
+msgid "Getting storage information not supported for this camera.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1315
+#, c-format
+msgid "Read-Write"
+msgstr ""
+
+#: gphoto2/actions.c:1318
+#, c-format
+msgid "Read-Only"
+msgstr ""
+
+#: gphoto2/actions.c:1321
+#, c-format
+msgid "Read-only with delete"
+msgstr ""
+
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
+#, c-format
+msgid "Unknown"
+msgstr ""
+
+#: gphoto2/actions.c:1337
+#, c-format
+msgid "Fixed ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1340
+#, c-format
+msgid "Removable ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1343
+#, c-format
+msgid "Fixed RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1346
+#, c-format
+msgid "Removable RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1356
+#, c-format
+msgid "Undefined"
+msgstr ""
+
+#: gphoto2/actions.c:1359
+#, c-format
+msgid "Generic Flat"
+msgstr ""
+
+#: gphoto2/actions.c:1362
+#, c-format
+msgid "Generic Hierarchical"
+msgstr ""
+
+#: gphoto2/actions.c:1365
+#, c-format
+msgid "Camera layout (DCIM)"
+msgstr ""
+
+#: gphoto2/actions.c:1406
+#, c-format
+msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
+msgstr ""
+
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+
+#: gphoto2/actions.c:1489
+#, c-format
+msgid "%s has been compiled with the following options:"
+msgstr ""
+
+#: gphoto2/actions.c:1629
+#, fuzzy, c-format
+msgid "%s not found in configuration tree."
+msgstr "Could not set configuration:"
+
+#: gphoto2/actions.c:1681
+#, c-format
+msgid "Failed to retrieve value of text widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1698
+#, c-format
+msgid "Failed to retrieve values of range widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1710
+#, c-format
+msgid "Failed to retrieve values of toggle widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1722
+#, c-format
+msgid "Failed to retrieve values of date/time widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1753
+#, c-format
+msgid "Failed to retrieve values of radio widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1799
+#, c-format
+msgid "Property %s is read only."
+msgstr ""
+
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
+#, c-format
+msgid "Failed to set the value of text widget %s to %s."
+msgstr ""
+
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
+#, c-format
+msgid "The passed value %s is not a floating point value."
+msgstr ""
+
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
+#, c-format
+msgid "The passed value %f is not within the expected range %f - %f."
+msgstr ""
+
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
+#, c-format
+msgid "Failed to set the value of range widget %s to %f."
+msgstr ""
+
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
+msgid "off"
+msgstr ""
+
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
+msgid "false"
+msgstr ""
+
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
+#, fuzzy
+msgid "on"
+msgstr "Mon"
+
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
+msgid "true"
+msgstr ""
+
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
+#, c-format
+msgid "The passed value %s is not a valid toggle value."
+msgstr ""
+
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
+#, c-format
+msgid "Failed to set values %s of toggle widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
+#, fuzzy
+msgid "now"
+msgstr "no"
+
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
+#, c-format
+msgid "The passed value %s is neither a valid time nor an integer."
+msgstr ""
+
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
+#, c-format
+msgid "Failed to set new time of date/time widget %s to %s."
+msgstr ""
+
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
+#, c-format
+msgid "Choice %s not found within list of choices."
+msgstr ""
+
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
+#, c-format
+msgid "The %s widget is not configurable."
+msgstr ""
+
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
+#, c-format
+msgid "Failed to set new configuration value %s for configuration entry %s."
+msgstr ""
+
+#: gphoto2/actions.c:2019
+#, c-format
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+
+#: gphoto2/foreach.c:260
+#, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+
+#: gphoto2/foreach.c:285
+#, c-format
+msgid "There are no files in folder '%s'."
+msgstr "There are no files in folder '%s'."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'.Please obtain a valid file number from a file listing first."
-msgstr "Bad file number. You specified %i, but there are only %i files available in '%s'.Please obtain a valid file number from a file listing first."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
 
-#: gphoto2/gp-params.c:53
+#: gphoto2/foreach.c:299
+#, fuzzy, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'.Please obtain a valid file number from a file listing first."
+
+#: gphoto2/gp-params.c:70
+#, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Error ***              \n"
 
-#: gphoto2/gp-params.c:220
+#: gphoto2/gp-params.c:243
+#, c-format
 msgid "Press any key to continue.\n"
 msgstr "Press any key to continue.\n"
 
-#: gphoto2/gp-params.c:237
+#: gphoto2/gp-params.c:266
+#, c-format
 msgid "Not enough memory."
 msgstr "Not enough memory."
 
-#: gphoto2/gphoto2-cmd-capture.c:201
+#: gphoto2/gphoto2-cmd-capture.c:211
 msgid "Operation cancelled"
 msgstr "Operation cancelled"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Continue"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Cancel"
 
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Error"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Could not set configuration:"
 
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Exit"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Back"
 
-#: gphoto2/gphoto2-cmd-config.c:253
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Time: "
 
-#: gphoto2/gphoto2-cmd-config.c:312 gphoto2/gphoto2-cmd-config.c:340
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Value: "
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Yes"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "No"
 
-#: gphoto2/main.c:161 gphoto2/main.c:1461
-msgid "Turn on debugging"
-msgstr "Turn on debugging"
-
-#: gphoto2/main.c:162 gphoto2/main.c:1463
-msgid "Quiet output (default=verbose)"
-msgstr "Quiet output (default=verbose)"
-
-#: gphoto2/main.c:166 gphoto2/main.c:1467
-msgid "Display version and exit"
-msgstr "Display version and exit"
-
-#: gphoto2/main.c:167
-msgid "Displays this help screen"
-msgstr "Displays this help screen"
-
-#: gphoto2/main.c:168 gphoto2/main.c:1469
-msgid "List supported camera models"
-msgstr "List supported camera models"
-
-#: gphoto2/main.c:169 gphoto2/main.c:1471
-msgid "List supported port devices"
-msgstr "List supported port devices"
-
-#: gphoto2/main.c:170 gphoto2/main.c:1473
-msgid "Send file to stdout"
-msgstr "Send file to stdout"
-
-#: gphoto2/main.c:171 gphoto2/main.c:1475
-msgid "Print filesize before data"
-msgstr "Print filesize before data"
-
-#: gphoto2/main.c:172 gphoto2/main.c:1477
-msgid "List auto-detected cameras"
-msgstr "List auto-detected cameras"
-
-#: gphoto2/main.c:175 gphoto2/main.c:1479
-msgid "Specify port device"
-msgstr "Specify port device"
-
-#: gphoto2/main.c:176 gphoto2/main.c:1481
-msgid "Specify serial transfer speed"
-msgstr "Specify serial transfer speed"
-
-#: gphoto2/main.c:177 gphoto2/main.c:1483
-msgid "Specify camera model"
-msgstr "Specify camera model"
-
-#: gphoto2/main.c:178 gphoto2/main.c:1485
-msgid "Specify a filename"
-msgstr "Specify a filename"
-
-#: gphoto2/main.c:179 gphoto2/main.c:1487
-msgid "(expert only) Override USB IDs"
-msgstr "(expert only) Override USB IDs"
-
-#: gphoto2/main.c:182 gphoto2/main.c:1489
-msgid "Display camera abilities"
-msgstr "Display camera abilities"
-
-#: gphoto2/main.c:183 gphoto2/main.c:1491
-msgid "Specify camera folder (default=\"/\")"
-msgstr "Specify camera folder (default=\"/\")"
-
-#: gphoto2/main.c:184 gphoto2/main.c:1493
-msgid "Recursion (default for download)"
-msgstr "Recursion (default for download)"
-
-#: gphoto2/main.c:185 gphoto2/main.c:1495
-msgid "No recursion (default for deletion)"
-msgstr "No recursion (default for deletion)"
-
-#: gphoto2/main.c:186 gphoto2/main.c:1497
-msgid "List folders in folder"
-msgstr "List folders in folder"
-
-#: gphoto2/main.c:187 gphoto2/main.c:1499
-msgid "List files in folder"
-msgstr "List files in folder"
-
-#: gphoto2/main.c:188 gphoto2/main.c:189
-msgid "name"
-msgstr "name"
-
-#: gphoto2/main.c:188 gphoto2/main.c:1501
-msgid "Create a directory"
-msgstr "Create a directory"
-
-#: gphoto2/main.c:189 gphoto2/main.c:1503
-msgid "Remove a directory"
-msgstr "Remove a directory"
-
-#: gphoto2/main.c:190 gphoto2/main.c:1505
-msgid "Display number of files"
-msgstr "Display number of files"
-
-#: gphoto2/main.c:191 gphoto2/main.c:1507
-msgid "Get files given in range"
-msgstr "Get files given in range"
-
-#: gphoto2/main.c:192 gphoto2/main.c:1509
-msgid "Get all files from folder"
-msgstr "Get all files from folder"
-
-#: gphoto2/main.c:193 gphoto2/main.c:1511
-msgid "Get thumbnails given in range"
-msgstr "Get thumbnails given in range"
-
-#: gphoto2/main.c:194 gphoto2/main.c:1514
-msgid "Get all thumbnails from folder"
-msgstr "Get all thumbnails from folder"
-
-#: gphoto2/main.c:195 gphoto2/main.c:1517
-msgid "Get raw data given in range"
-msgstr "Get raw data given in range"
-
-#: gphoto2/main.c:196 gphoto2/main.c:1520
-msgid "Get all raw data from folder"
-msgstr "Get all raw data from folder"
-
-#: gphoto2/main.c:197 gphoto2/main.c:1523
-msgid "Get audio data given in range"
-msgstr "Get audio data given in range"
-
-#: gphoto2/main.c:198 gphoto2/main.c:1526
-msgid "Get all audio data from folder"
-msgstr "Get all audio data from folder"
-
-#: gphoto2/main.c:199 gphoto2/main.c:1528
-msgid "Delete files given in range"
-msgstr "Delete files given in range"
-
-#: gphoto2/main.c:200 gphoto2/main.c:1530
-msgid "Delete all files in folder"
-msgstr "Delete all files in folder"
-
-#: gphoto2/main.c:201 gphoto2/main.c:1532
-msgid "Upload a file to camera"
-msgstr "Upload a file to camera"
-
-#: gphoto2/main.c:203 gphoto2/main.c:1535
-msgid "Configure"
-msgstr "Configure"
-
-#: gphoto2/main.c:205 gphoto2/main.c:1539
-msgid "Capture a quick preview"
-msgstr "Capture a quick preview"
-
-#: gphoto2/main.c:206 gphoto2/main.c:1541
-msgid "Capture an image"
-msgstr "Capture an image"
-
-#: gphoto2/main.c:207
-msgid "Capture a movie "
-msgstr "Capture a movie "
-
-#: gphoto2/main.c:208 gphoto2/main.c:1545
-msgid "Capture an audio clip"
-msgstr "Capture an audio clip"
-
-#: gphoto2/main.c:210 gphoto2/main.c:1548 gphoto2/shell.c:113
-msgid "Show EXIF information"
-msgstr "Show EXIF information"
-
-#: gphoto2/main.c:212 gphoto2/main.c:1551 gphoto2/shell.c:109
-msgid "Show info"
-msgstr "Show info"
-
-#: gphoto2/main.c:213
-msgid "Summary of camera status"
-msgstr "Summary of camera status"
-
-#: gphoto2/main.c:214
-msgid "Camera driver manual"
-msgstr "Camera driver manual"
-
-#: gphoto2/main.c:215
-msgid "About the camera driver"
-msgstr "About the camera driver"
-
-#: gphoto2/main.c:216 gphoto2/main.c:1559
-msgid "gPhoto shell"
-msgstr "gPhoto shell"
-
-#: gphoto2/main.c:343 gphoto2/main.c:1192
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-
-#: gphoto2/main.c:466
-msgid "Jan"
-msgstr "Jan"
-
-#: gphoto2/main.c:466
-msgid "January"
-msgstr "January"
-
-#: gphoto2/main.c:467
-msgid "Feb"
-msgstr "Feb"
-
-#: gphoto2/main.c:467
-msgid "February"
-msgstr "February"
-
-#: gphoto2/main.c:468
-msgid "Mar"
-msgstr "Mar"
-
-#: gphoto2/main.c:468
-msgid "March"
-msgstr "March"
-
-#: gphoto2/main.c:469
-msgid "Apr"
-msgstr "Apr"
-
-#: gphoto2/main.c:469
-msgid "April"
-msgstr "April"
-
-#: gphoto2/main.c:470
-msgid "May"
-msgstr "May"
-
-#: gphoto2/main.c:471
-msgid "Jun"
-msgstr "Jun"
-
-#: gphoto2/main.c:471
-msgid "June"
-msgstr "June"
-
-#: gphoto2/main.c:472
-msgid "Jul"
-msgstr "Jul"
-
-#: gphoto2/main.c:472
-msgid "July"
-msgstr "July"
-
-#: gphoto2/main.c:473
-msgid "Aug"
-msgstr "Aug"
-
-#: gphoto2/main.c:473
-msgid "August"
-msgstr "August"
-
-#: gphoto2/main.c:474
-msgid "Sep"
-msgstr "Sep"
-
-#: gphoto2/main.c:474
-msgid "September"
-msgstr "September"
-
-#: gphoto2/main.c:475
-msgid "Oct"
-msgstr "Oct"
-
-#: gphoto2/main.c:475
-msgid "October"
-msgstr "October"
-
-#: gphoto2/main.c:476
-msgid "Nov"
-msgstr "Nov"
-
-#: gphoto2/main.c:476
-msgid "November"
-msgstr "November"
-
-#: gphoto2/main.c:477
-msgid "Dec"
-msgstr "Dec"
-
-#: gphoto2/main.c:477
-msgid "December"
-msgstr "December"
-
-#: gphoto2/main.c:484
-msgid "Sun"
-msgstr "Sun"
-
-#: gphoto2/main.c:484
-msgid "Sunday"
-msgstr "Sunday"
-
-#: gphoto2/main.c:485
-msgid "Mon"
-msgstr "Mon"
-
-#: gphoto2/main.c:485
-msgid "Monday"
-msgstr "Monday"
-
-#: gphoto2/main.c:486
-msgid "Tue"
-msgstr "Tue"
-
-#: gphoto2/main.c:486
-msgid "Tuesday"
-msgstr "Tuesday"
-
-#: gphoto2/main.c:487
-msgid "Wed"
-msgstr "Wed"
-
-#: gphoto2/main.c:487
-msgid "Wednesday"
-msgstr "Wednesday"
-
-#: gphoto2/main.c:488
-msgid "Thu"
-msgstr "Thu"
-
-#: gphoto2/main.c:488
-msgid "Thursday"
-msgstr "Thursday"
-
-#: gphoto2/main.c:489
-msgid "Fri"
-msgstr "Fri"
-
-#: gphoto2/main.c:489
-msgid "Friday"
-msgstr "Friday"
-
-#: gphoto2/main.c:490
-msgid "Sat"
-msgstr "Sat"
-
-#: gphoto2/main.c:490
-msgid "Saturday"
-msgstr "Saturday"
-
-#: gphoto2/main.c:552
+#: gphoto2/main.c:220
 #, c-format
-msgid "You cannot use '%n' in combination with non-persistent files!"
+msgid "Zero padding numbers in file names is only possible with %%n."
+msgstr ""
+
+#: gphoto2/main.c:229
+#, fuzzy, c-format
+msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "You cannot use '%n' in combination with non-persistent files!"
 
-#: gphoto2/main.c:575
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "The filename provided by the camera ('%s') does not contain a suffix!"
 
-#: gphoto2/main.c:654
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Invalid format '%s' (error at position %i)."
 
-#: gphoto2/main.c:701
+#: gphoto2/main.c:386 gphoto2/main.c:592
+#, fuzzy, c-format
+msgid "Skip existing file %s\n"
+msgstr "Saving file as %s\n"
+
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "File %s exists. Overwrite? [y|n] "
 
-#: gphoto2/main.c:712
+#: gphoto2/main.c:410
+#, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Specify new filename? [y|n] "
 
-#: gphoto2/main.c:721
+#: gphoto2/main.c:422
+#, c-format
 msgid "Enter new filename: "
 msgstr "Enter new filename: "
 
-#: gphoto2/main.c:726
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Saving file as %s\n"
 
-#: gphoto2/main.c:918
+#: gphoto2/main.c:630
+#, fuzzy
+msgid "Permission denied"
+msgstr "  Permissions: "
+
+#: gphoto2/main.c:800
+#, fuzzy
+msgid "Could not trigger capture."
+msgstr "Could not parse EXIF data."
+
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "New file is in location %s%s%s on the camera\n"
 
-#: gphoto2/main.c:1050
+#: gphoto2/main.c:847 gphoto2/main.c:878
+#, fuzzy, c-format
+msgid "Keeping file %s%s%s on the camera\n"
+msgstr "New file is in location %s%s%s on the camera\n"
+
+#: gphoto2/main.c:868
+#, fuzzy, c-format
+msgid "Deleting file %s%s%s on the camera\n"
+msgstr "New file is in location %s%s%s on the camera\n"
+
+#: gphoto2/main.c:911
+#, c-format
+msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:916
+#, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:926
+#, c-format
+msgid "Event UNKNOWN %s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:932
+#, c-format
+msgid "Unknown event type %d during bulb wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:950
+#, fuzzy
+msgid "Could not get capabilities?"
+msgstr "Could not set configuration:"
+
+#: gphoto2/main.c:958
+#, c-format
+msgid "Time-lapse mode enabled (interval: %ds).\n"
+msgstr ""
+
+#: gphoto2/main.c:961
+#, c-format
+msgid "Standing by waiting for SIGUSR1 to capture.\n"
+msgstr ""
+
+#: gphoto2/main.c:967
+#, c-format
+msgid "Bulb mode enabled (exposure time: %ds).\n"
+msgstr ""
+
+#: gphoto2/main.c:975
+#, c-format
+msgid "Capturing frame #%d...\n"
+msgstr ""
+
+#: gphoto2/main.c:977
+#, c-format
+msgid "Capturing frame #%d/%d...\n"
+msgstr ""
+
+#: gphoto2/main.c:987
+#, c-format
+msgid "Could not set bulb capture, result %d."
+msgstr ""
+
+#: gphoto2/main.c:1001
+msgid "Could not end capture (bulb mode)."
+msgstr ""
+
+#: gphoto2/main.c:1014
+#, fuzzy
+msgid "Could not trigger image capture."
+msgstr "Could not find home directory."
+
+#: gphoto2/main.c:1021
+#, fuzzy
+msgid "Could not capture image."
+msgstr "Capture an image"
+
+#: gphoto2/main.c:1028
+#, c-format
+msgid "Capture failed (auto-focus problem?)...\n"
+msgstr ""
+
+#: gphoto2/main.c:1039
+#, fuzzy
+msgid "Could not capture."
+msgstr "Could not parse EXIF data."
+
+#: gphoto2/main.c:1074
+#, c-format
+msgid "Waiting for next capture slot %ld seconds...\n"
+msgstr ""
+
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
+#, c-format
+msgid "Awakened by SIGUSR1...\n"
+msgstr ""
+
+#: gphoto2/main.c:1096
+#, c-format
+msgid "not sleeping (%ld seconds behind schedule)\n"
+msgstr ""
+
+#: gphoto2/main.c:1240
+#, c-format
 msgid "ERROR: "
 msgstr "ERROR: "
 
-#: gphoto2/main.c:1073
+#: gphoto2/main.c:1263
+#, c-format
 msgid ""
 "\n"
 "Aborting...\n"
@@ -811,11 +972,13 @@ msgstr ""
 "\n"
 "Aborting...\n"
 
-#: gphoto2/main.c:1079
+#: gphoto2/main.c:1269
+#, c-format
 msgid "Aborted.\n"
 msgstr "Aborted.\n"
 
-#: gphoto2/main.c:1084
+#: gphoto2/main.c:1274
+#, c-format
 msgid ""
 "\n"
 "Cancelling...\n"
@@ -823,15 +986,32 @@ msgstr ""
 "\n"
 "Cancelling...\n"
 
-#: gphoto2/main.c:1291
+#: gphoto2/main.c:1426
+#, c-format
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 has been compiled without support for CDK."
 
-#: gphoto2/main.c:1404
+#: gphoto2/main.c:1879
+#, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operation cancelled.\n"
 
-#: gphoto2/main.c:1408
+#: gphoto2/main.c:1883
+#, c-format
+msgid ""
+"*** Error: No camera found. ***\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -840,7 +1020,8 @@ msgstr ""
 "*** Error (%i: '%s') ***       \n"
 "\n"
 
-#: gphoto2/main.c:1412
+#: gphoto2/main.c:1890
+#, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
 "Debugging messages may help finding a solution to your problem.\n"
@@ -856,84 +1037,422 @@ msgstr ""
 "gphoto2 as follows:\n"
 "\n"
 
-#: gphoto2/main.c:1465
-msgid "Overwrite files without asking."
-msgstr "Overwrite files without asking."
+#: gphoto2/main.c:1911
+#, c-format
+msgid ""
+"Please make sure there is sufficient quoting around the arguments.\n"
+"\n"
+msgstr ""
 
-#: gphoto2/main.c:1479
-msgid "path"
-msgstr "path"
+#: gphoto2/main.c:1978
+msgid "Print complete help message on program usage"
+msgstr ""
 
-#: gphoto2/main.c:1481
-msgid "speed"
-msgstr "speed"
+#: gphoto2/main.c:1980
+msgid "Print short message on program usage"
+msgstr ""
 
-#: gphoto2/main.c:1483
-msgid "model"
-msgstr "model"
+#: gphoto2/main.c:1982
+msgid "Turn on debugging"
+msgstr "Turn on debugging"
 
-#: gphoto2/main.c:1485
-msgid "filename"
-msgstr "filename"
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
 
-#: gphoto2/main.c:1487
-msgid "usbid"
-msgstr "usbid"
+#: gphoto2/main.c:1986
+msgid "Name of file to write debug info to"
+msgstr ""
 
-#: gphoto2/main.c:1491
-msgid "folder"
-msgstr "folder"
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
+msgid "FILENAME"
+msgstr ""
 
-#: gphoto2/main.c:1543
+#: gphoto2/main.c:1988
+msgid "Quiet output (default=verbose)"
+msgstr "Quiet output (default=verbose)"
+
+#: gphoto2/main.c:1990
+msgid "Hook script to call after downloads, captures, etc."
+msgstr ""
+
+#: gphoto2/main.c:1997
+#, fuzzy
+msgid "Specify device port"
+msgstr "Specify port device"
+
+#: gphoto2/main.c:1999
+msgid "Specify serial transfer speed"
+msgstr "Specify serial transfer speed"
+
+#: gphoto2/main.c:1999
+msgid "SPEED"
+msgstr ""
+
+#: gphoto2/main.c:2001
+msgid "Specify camera model"
+msgstr "Specify camera model"
+
+#: gphoto2/main.c:2001
+msgid "MODEL"
+msgstr ""
+
+#: gphoto2/main.c:2003
+msgid "(expert only) Override USB IDs"
+msgstr "(expert only) Override USB IDs"
+
+#: gphoto2/main.c:2003
+msgid "USBIDs"
+msgstr ""
+
+#: gphoto2/main.c:2009
+msgid "Display version and exit"
+msgstr "Display version and exit"
+
+#: gphoto2/main.c:2011
+msgid "List supported camera models"
+msgstr "List supported camera models"
+
+#: gphoto2/main.c:2013
+msgid "List supported port devices"
+msgstr "List supported port devices"
+
+#: gphoto2/main.c:2015
+msgid "Display the camera/driver abilities in the libgphoto2 database"
+msgstr ""
+
+#: gphoto2/main.c:2022
+msgid "Configure"
+msgstr "Configure"
+
+#: gphoto2/main.c:2025
+#, fuzzy
+msgid "List configuration tree"
+msgstr "Could not set configuration:"
+
+#: gphoto2/main.c:2027
+msgid "Dump full configuration tree"
+msgstr ""
+
+#: gphoto2/main.c:2029
+#, fuzzy
+msgid "Get configuration value"
+msgstr "Could not set configuration:"
+
+#: gphoto2/main.c:2031
+msgid "Set configuration value or index in choices"
+msgstr ""
+
+#: gphoto2/main.c:2033
+msgid "Set configuration value index in choices"
+msgstr ""
+
+#: gphoto2/main.c:2035
+#, fuzzy
+msgid "Set configuration value"
+msgstr "Could not set configuration:"
+
+#: gphoto2/main.c:2037
+msgid "Reset device port"
+msgstr ""
+
+#: gphoto2/main.c:2043
+msgid "Keep images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2045
+msgid "Keep RAW images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2047
+msgid "Remove images from camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2049
+msgid "Wait for event(s) from camera"
+msgstr ""
+
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
+
+#: gphoto2/main.c:2051
+msgid "Wait for event(s) from the camera and download new images"
+msgstr ""
+
+#: gphoto2/main.c:2054
+msgid "Capture a quick preview"
+msgstr "Capture a quick preview"
+
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
+
+#: gphoto2/main.c:2059
+msgid "Set bulb exposure time in seconds"
+msgstr ""
+
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
+msgid "SECONDS"
+msgstr ""
+
+#: gphoto2/main.c:2061
+msgid "Set number of frames to capture (default=infinite)"
+msgstr ""
+
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr ""
+
+#: gphoto2/main.c:2063
+msgid "Set capture interval in seconds"
+msgstr ""
+
+#: gphoto2/main.c:2065
+msgid "Reset capture interval on signal (default=no)"
+msgstr ""
+
+#: gphoto2/main.c:2067
+msgid "Capture an image"
+msgstr "Capture an image"
+
+#: gphoto2/main.c:2069
+#, fuzzy
+msgid "Trigger capture of an image"
+msgstr "Capture an image"
+
+#: gphoto2/main.c:2071
+#, fuzzy
+msgid "Capture an image and download it"
+msgstr "Capture an image"
+
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Capture a movie"
 
-#: gphoto2/main.c:1553
-msgid "Show summary"
+#: gphoto2/main.c:2073
+msgid "COUNT or SECONDS"
+msgstr ""
+
+#: gphoto2/main.c:2075
+msgid "Capture an audio clip"
+msgstr "Capture an audio clip"
+
+#: gphoto2/main.c:2077
+msgid "Wait for shutter release on the camera and download"
+msgstr ""
+
+#: gphoto2/main.c:2083
+msgid "List folders in folder"
+msgstr "List folders in folder"
+
+#: gphoto2/main.c:2085
+msgid "List files in folder"
+msgstr "List files in folder"
+
+#: gphoto2/main.c:2087
+msgid "Create a directory"
+msgstr "Create a directory"
+
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
+msgid "DIRNAME"
+msgstr ""
+
+#: gphoto2/main.c:2089
+msgid "Remove a directory"
+msgstr "Remove a directory"
+
+#: gphoto2/main.c:2091
+msgid "Display number of files"
+msgstr "Display number of files"
+
+#: gphoto2/main.c:2093
+msgid "Get files given in range"
+msgstr "Get files given in range"
+
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
+msgid "RANGE"
+msgstr ""
+
+#: gphoto2/main.c:2095
+msgid "Get all files from folder"
+msgstr "Get all files from folder"
+
+#: gphoto2/main.c:2097
+msgid "Get thumbnails given in range"
+msgstr "Get thumbnails given in range"
+
+#: gphoto2/main.c:2100
+msgid "Get all thumbnails from folder"
+msgstr "Get all thumbnails from folder"
+
+#: gphoto2/main.c:2102
+#, fuzzy
+msgid "Get metadata given in range"
+msgstr "Get raw data given in range"
+
+#: gphoto2/main.c:2104
+#, fuzzy
+msgid "Get all metadata from folder"
+msgstr "Get all raw data from folder"
+
+#: gphoto2/main.c:2106
+msgid "Upload metadata for file"
+msgstr ""
+
+#: gphoto2/main.c:2109
+msgid "Get raw data given in range"
+msgstr "Get raw data given in range"
+
+#: gphoto2/main.c:2112
+msgid "Get all raw data from folder"
+msgstr "Get all raw data from folder"
+
+#: gphoto2/main.c:2115
+msgid "Get audio data given in range"
+msgstr "Get audio data given in range"
+
+#: gphoto2/main.c:2118
+msgid "Get all audio data from folder"
+msgstr "Get all audio data from folder"
+
+#: gphoto2/main.c:2120
+msgid "Delete files given in range"
+msgstr "Delete files given in range"
+
+#: gphoto2/main.c:2122
+#, fuzzy
+msgid "Delete all files in folder (--no-recurse by default)"
+msgstr "Delete all files in folder"
+
+#: gphoto2/main.c:2124
+msgid "Upload a file to camera"
+msgstr "Upload a file to camera"
+
+#: gphoto2/main.c:2126
+#, fuzzy
+msgid "Specify a filename or filename pattern"
+msgstr "Specify a filename"
+
+#: gphoto2/main.c:2126
+msgid "FILENAME_PATTERN"
+msgstr ""
+
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
+msgid "Specify camera folder (default=\"/\")"
+msgstr "Specify camera folder (default=\"/\")"
+
+#: gphoto2/main.c:2130
+msgid "FOLDER"
+msgstr ""
+
+#: gphoto2/main.c:2132
+msgid "Recursion (default for download)"
+msgstr "Recursion (default for download)"
+
+#: gphoto2/main.c:2134
+msgid "No recursion (default for deletion)"
+msgstr "No recursion (default for deletion)"
+
+#: gphoto2/main.c:2136
+msgid "Process new files only"
+msgstr ""
+
+#: gphoto2/main.c:2138
+#, fuzzy
+msgid "Overwrite files without asking"
+msgstr "Overwrite files without asking."
+
+#: gphoto2/main.c:2140
+msgid "Skip existing files"
+msgstr ""
+
+#: gphoto2/main.c:2146
+msgid "Send file to stdout"
+msgstr "Send file to stdout"
+
+#: gphoto2/main.c:2148
+msgid "Print filesize before data"
+msgstr "Print filesize before data"
+
+#: gphoto2/main.c:2150
+msgid "List auto-detected cameras"
+msgstr "List auto-detected cameras"
+
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
+msgstr "Show EXIF information"
+
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
+
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "Show summary"
 
-#: gphoto2/main.c:1555
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Show camera driver manual"
 
-#: gphoto2/main.c:1557
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "About the camera driver manual"
 
-#: gphoto2/main.c:1784
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
-msgstr "gPhoto2 for OS/2 requires you to set the environment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
+#, fuzzy
+msgid "Show storage information"
+msgstr "Show EXIF information"
 
-#: gphoto2/main.c:1794
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
-msgstr "gPhoto2 for OS/2 requires you to set the environment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#: gphoto2/main.c:2167
+msgid "gPhoto shell"
+msgstr "gPhoto shell"
 
-#: gphoto2/options.c:181
-msgid "Usage:\n"
-msgstr "Usage:\n"
-
-#: gphoto2/options.c:184
-msgid ""
-"Short/long options (& argument)        Description\n"
-"--------------------------------------------------------------------------------\n"
+#: gphoto2/main.c:2173
+msgid "Common options"
 msgstr ""
-"Short/long options (& argument)        Description\n"
-"--------------------------------------------------------------------------------\n"
 
-#: gphoto2/options.c:209
-#, c-format
-msgid "%-38s %s\n"
-msgstr "%-38s %s\n"
-
-#: gphoto2/options.c:214
-msgid ""
-"--------------------------------------------------------------------------------\n"
-"[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
+#: gphoto2/main.c:2175
+msgid "Miscellaneous options (unsorted)"
 msgstr ""
-"--------------------------------------------------------------------------------\n"
-"[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
 
-#: gphoto2/range.c:103 gphoto2/range.c:157
+#: gphoto2/main.c:2177
+msgid "Get information on software and host system (not from the camera)"
+msgstr ""
+
+#: gphoto2/main.c:2179
+#, fuzzy
+msgid "Specify the camera to use"
+msgstr "Specify camera model"
+
+#: gphoto2/main.c:2181
+#, fuzzy
+msgid "Camera and software configuration"
+msgstr "Could not set configuration:"
+
+#: gphoto2/main.c:2183
+#, fuzzy
+msgid "Capture an image from or on the camera"
+msgstr "Change to a directory on the camera"
+
+#: gphoto2/main.c:2185
+msgid "Downloading, uploading and manipulating files"
+msgstr ""
+
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -942,7 +1461,7 @@ msgstr ""
 "%s\n"
 "Image IDs must be a number greater than zero."
 
-#: gphoto2/range.c:109 gphoto2/range.c:163
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -951,7 +1470,7 @@ msgstr ""
 "%s\n"
 "Image ID %i too high."
 
-#: gphoto2/range.c:125
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -960,7 +1479,7 @@ msgstr ""
 "%s\n"
 "Ranges must be separated by ','."
 
-#: gphoto2/range.c:139
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -969,7 +1488,7 @@ msgstr ""
 "%s\n"
 "Ranges need to start with a number."
 
-#: gphoto2/range.c:179
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -978,7 +1497,7 @@ msgstr ""
 "%s\n"
 "Unexpected character '%c'."
 
-#: gphoto2/range.c:202
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -987,122 +1506,422 @@ msgstr ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 
-#: gphoto2/shell.c:55
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Error (%i: '%s') ***"
 
-#: gphoto2/shell.c:98
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Change to a directory on the camera"
 
-#: gphoto2/shell.c:99 gphoto2/shell.c:101
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "directory"
 
-#: gphoto2/shell.c:100
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Change to a directory on the local drive"
 
-#: gphoto2/shell.c:102 gphoto2/shell.c:120 gphoto2/shell.c:121
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Exit the gPhoto shell"
 
-#: gphoto2/shell.c:103
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Download a file"
 
-#: gphoto2/shell.c:103 gphoto2/shell.c:106 gphoto2/shell.c:108
-#: gphoto2/shell.c:110 gphoto2/shell.c:111 gphoto2/shell.c:114
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[directory/]filename"
 
-#: gphoto2/shell.c:105
+#: gphoto2/shell.c:132
+#, fuzzy
+msgid "Upload a file"
+msgstr "Download a file"
+
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Download a thumbnail"
 
-#: gphoto2/shell.c:107
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Download raw data"
 
-#: gphoto2/shell.c:111
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Delete"
 
-#: gphoto2/shell.c:116 gphoto2/shell.c:122
+#: gphoto2/shell.c:140
+#, fuzzy
+msgid "Create Directory"
+msgstr "Create a directory"
+
+#: gphoto2/shell.c:141
+#, fuzzy
+msgid "Remove Directory"
+msgstr "Remove a directory"
+
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Displays command usage"
 
-#: gphoto2/shell.c:117 gphoto2/shell.c:122
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[command]"
 
-#: gphoto2/shell.c:118
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "List the contents of the current directory"
 
-#: gphoto2/shell.c:119
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[directory/]"
 
-#: gphoto2/shell.c:421
+#: gphoto2/shell.c:152
+msgid "List configuration variables"
+msgstr ""
+
+#: gphoto2/shell.c:153
+msgid "Get configuration variable"
+msgstr ""
+
+#: gphoto2/shell.c:153
+msgid "name"
+msgstr "name"
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+msgid "Set configuration variable"
+msgstr ""
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+msgid "name=value"
+msgstr ""
+
+#: gphoto2/shell.c:155
+msgid "Set configuration variable index"
+msgstr ""
+
+#: gphoto2/shell.c:155
+msgid "name=valueindex"
+msgstr ""
+
+#: gphoto2/shell.c:157
+msgid "Triggers the capture of a single image"
+msgstr ""
+
+#: gphoto2/shell.c:158
+#, fuzzy
+msgid "Capture a single image"
+msgstr "Capture an image"
+
+#: gphoto2/shell.c:159
+msgid "Capture a single image and download it"
+msgstr ""
+
+#: gphoto2/shell.c:160
+#, fuzzy
+msgid "Capture a preview image"
+msgstr "Capture an image"
+
+#: gphoto2/shell.c:161
+msgid "Wait for an event"
+msgstr ""
+
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
+msgid "count or seconds"
+msgstr ""
+
+#: gphoto2/shell.c:162
+msgid "Wait for images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:163
+msgid "Wait for events and images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Invalid command."
 
-#: gphoto2/shell.c:430
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "The command '%s' requires an argument."
 
-#: gphoto2/shell.c:483
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Invalid path."
 
-#: gphoto2/shell.c:529
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Could not find home directory."
 
-#: gphoto2/shell.c:537
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Could not change to local directory '%s'."
 
-#: gphoto2/shell.c:540
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Local directory now '%s'."
 
-#: gphoto2/shell.c:578
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Remote directory now '%s'."
 
-#: gphoto2/shell.c:734
+#: gphoto2/shell.c:874
+#, c-format
+msgid "set-config needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:895
+#, c-format
+msgid "set-config-value needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:916
+#, c-format
+msgid "set-config-index needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Command '%s' not found. Use 'help' to get a list of available commands."
+msgstr ""
+"Command '%s' not found. Use 'help' to get a list of available commands."
 
-#: gphoto2/shell.c:741
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Help on \"%s\":"
 
-#: gphoto2/shell.c:743
+#: gphoto2/shell.c:988
+#, c-format
 msgid "Usage:"
 msgstr "Usage:"
 
-#: gphoto2/shell.c:747
+#: gphoto2/shell.c:991
+#, c-format
 msgid "Description:"
 msgstr "Description:"
 
-#: gphoto2/shell.c:749
+#: gphoto2/shell.c:993
+#, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Arguments in brackets [] are optional"
 
-#: gphoto2/shell.c:770
+#: gphoto2/shell.c:1014
+#, c-format
 msgid "Available commands:"
 msgstr "Available commands:"
 
-#: gphoto2/shell.c:775
+#: gphoto2/shell.c:1019
+#, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr "To get help on a particular command, type in 'help command-name'."
+
+#, c-format
+#~ msgid "There are no folders in folder '%s'."
+#~ msgstr "There are no folders in folder '%s'."
+
+#, c-format
+#~ msgid "There are %i folders in folder '%s':"
+#~ msgstr "There are %i folders in folder '%s':"
+
+#, c-format
+#~ msgid "There are %i files in folder '%s':"
+#~ msgstr "There are %i files in folder '%s':"
+
+#, c-format
+#~ msgid "  Name:        '%s'\n"
+#~ msgstr "  Name:        '%s'\n"
+
+#~ msgid "Displays this help screen"
+#~ msgstr "Displays this help screen"
+
+#~ msgid "Display camera abilities"
+#~ msgstr "Display camera abilities"
+
+#~ msgid "Capture a movie "
+#~ msgstr "Capture a movie "
+
+#~ msgid "Show info"
+#~ msgstr "Show info"
+
+#~ msgid "Summary of camera status"
+#~ msgstr "Summary of camera status"
+
+#~ msgid "Camera driver manual"
+#~ msgstr "Camera driver manual"
+
+#~ msgid "About the camera driver"
+#~ msgstr "About the camera driver"
+
+#~ msgid "Jan"
+#~ msgstr "Jan"
+
+#~ msgid "January"
+#~ msgstr "January"
+
+#~ msgid "Feb"
+#~ msgstr "Feb"
+
+#~ msgid "February"
+#~ msgstr "February"
+
+#~ msgid "Mar"
+#~ msgstr "Mar"
+
+#~ msgid "March"
+#~ msgstr "March"
+
+#~ msgid "Apr"
+#~ msgstr "Apr"
+
+#~ msgid "April"
+#~ msgstr "April"
+
+#~ msgid "May"
+#~ msgstr "May"
+
+#~ msgid "Jun"
+#~ msgstr "Jun"
+
+#~ msgid "June"
+#~ msgstr "June"
+
+#~ msgid "Jul"
+#~ msgstr "Jul"
+
+#~ msgid "July"
+#~ msgstr "July"
+
+#~ msgid "Aug"
+#~ msgstr "Aug"
+
+#~ msgid "August"
+#~ msgstr "August"
+
+#~ msgid "Sep"
+#~ msgstr "Sep"
+
+#~ msgid "September"
+#~ msgstr "September"
+
+#~ msgid "Oct"
+#~ msgstr "Oct"
+
+#~ msgid "October"
+#~ msgstr "October"
+
+#~ msgid "Nov"
+#~ msgstr "Nov"
+
+#~ msgid "November"
+#~ msgstr "November"
+
+#~ msgid "Dec"
+#~ msgstr "Dec"
+
+#~ msgid "December"
+#~ msgstr "December"
+
+#~ msgid "Sun"
+#~ msgstr "Sun"
+
+#~ msgid "Sunday"
+#~ msgstr "Sunday"
+
+#~ msgid "Monday"
+#~ msgstr "Monday"
+
+#~ msgid "Tue"
+#~ msgstr "Tue"
+
+#~ msgid "Tuesday"
+#~ msgstr "Tuesday"
+
+#~ msgid "Wed"
+#~ msgstr "Wed"
+
+#~ msgid "Wednesday"
+#~ msgstr "Wednesday"
+
+#~ msgid "Thu"
+#~ msgstr "Thu"
+
+#~ msgid "Thursday"
+#~ msgstr "Thursday"
+
+#~ msgid "Fri"
+#~ msgstr "Fri"
+
+#~ msgid "Friday"
+#~ msgstr "Friday"
+
+#~ msgid "Sat"
+#~ msgstr "Sat"
+
+#~ msgid "Saturday"
+#~ msgstr "Saturday"
+
+#~ msgid "path"
+#~ msgstr "path"
+
+#~ msgid "speed"
+#~ msgstr "speed"
+
+#~ msgid "model"
+#~ msgstr "model"
+
+#~ msgid "filename"
+#~ msgstr "filename"
+
+#~ msgid "usbid"
+#~ msgstr "usbid"
+
+#~ msgid "folder"
+#~ msgstr "folder"
+
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the "
+#~ "location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgstr ""
+#~ "gPhoto2 for OS/2 requires you to set the environment value CAMLIBS to the "
+#~ "location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the "
+#~ "location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgstr ""
+#~ "gPhoto2 for OS/2 requires you to set the environment value IOLIBS to the "
+#~ "location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+
+#~ msgid "Usage:\n"
+#~ msgstr "Usage:\n"
+
+#~ msgid ""
+#~ "Short/long options (& argument)        Description\n"
+#~ "--------------------------------------------------------------------------------\n"
+#~ msgstr ""
+#~ "Short/long options (& argument)        Description\n"
+#~ "--------------------------------------------------------------------------------\n"
+
+#, c-format
+#~ msgid "%-38s %s\n"
+#~ msgstr "%-38s %s\n"
+
+#~ msgid ""
+#~ "--------------------------------------------------------------------------------\n"
+#~ "[Use double-quotes around arguments]        [Picture numbers begin with "
+#~ "one (1)]\n"
+#~ msgstr ""
+#~ "--------------------------------------------------------------------------------\n"
+#~ "[Use double-quotes around arguments]        [Picture numbers begin with "
+#~ "one (1)]\n"

--- a/po/es.po
+++ b/po/es.po
@@ -1,814 +1,979 @@
 # Translation of GPhoto2 to Castilian aka Spanish
-# TraducciÛn al castellano de Gphoto2
+# Traducci√≥n al castellano de Gphoto2
 # Copyright (C) 2002 Fabian Mandelbaum <fabman@mandrakesoft.com>
 # Quique <quique@sindominio.net>, 2004.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.1.2\n"
-"POT-Creation-Date: 2003-08-10 20:58+0200\n"
+"Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2004-05-11 07:55+0200\n"
 "Last-Translator: Quique <quique@sindominio.net>\n"
 "Language-Team: Spanish <es@li.org>\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: KBabel 1.3.1\n"
 
-#: gphoto2/actions.c:101
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
-msgstr "Cantidad de ficheros en la carpeta ´%sª: %i\n"
+msgstr "Cantidad de ficheros en la carpeta ¬´%s¬ª: %i\n"
 
-#: gphoto2/actions.c:122
-#, c-format
-msgid "There are no folders in folder '%s'."
-msgstr "No hay ninguna carpeta en la carpeta ´%sª."
+#: gphoto2/actions.c:201
+#, fuzzy, c-format
+msgid "There is %d folder in folder '%s'.\n"
+msgid_plural "There are %d folders in folder '%s'.\n"
+msgstr[0] "Hay una carpeta en la carpeta ¬´%s¬ª:"
+msgstr[1] "Hay una carpeta en la carpeta ¬´%s¬ª:"
 
-#: gphoto2/actions.c:126
-#, c-format
-msgid "There is one folder in folder '%s':"
-msgstr "Hay una carpeta en la carpeta ´%sª:"
+#: gphoto2/actions.c:250
+#, fuzzy, c-format
+msgid "There is no file in folder '%s'.\n"
+msgstr "Hay un fichero en la carpeta ¬´%s¬ª:"
 
-#: gphoto2/actions.c:130
-#, c-format
-msgid "There are %i folders in folder '%s':"
-msgstr "Hay %i carpetas en la carpeta ´%sª:"
+#: gphoto2/actions.c:253
+#, fuzzy, c-format
+msgid "There is %d file in folder '%s'.\n"
+msgid_plural "There are %d files in folder '%s'.\n"
+msgstr[0] "Hay un fichero en la carpeta ¬´%s¬ª:"
+msgstr[1] "Hay un fichero en la carpeta ¬´%s¬ª:"
 
-#: gphoto2/actions.c:157 gphoto2/foreach.c:277
-#, c-format
-msgid "There are no files in folder '%s'."
-msgstr "No hay ning˙n fichero en la carpeta ´%sª."
-
-#: gphoto2/actions.c:162
-#, c-format
-msgid "There is one file in folder '%s':"
-msgstr "Hay un fichero en la carpeta ´%sª:"
-
-#: gphoto2/actions.c:167
-#, c-format
-msgid "There are %i files in folder '%s':"
-msgstr "Hay %i ficheros en la carpeta ´%sª:"
-
-#: gphoto2/actions.c:188
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
-msgstr "InformaciÛn sobre el fichero ´%sª (carpeta ´%sª):\n"
+msgstr "Informaci√≥n sobre el fichero ¬´%s¬ª (carpeta ¬´%s¬ª):\n"
 
-#: gphoto2/actions.c:190
+#: gphoto2/actions.c:277
+#, c-format
 msgid "File:\n"
 msgstr "Fichero:\n"
 
-#: gphoto2/actions.c:192 gphoto2/actions.c:226 gphoto2/actions.c:242
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
+#, c-format
 msgid "  None available.\n"
 msgstr "  Ninguno disponible.\n"
 
-#: gphoto2/actions.c:195
-#, c-format
-msgid "  Name:        '%s'\n"
-msgstr "  Nombre:      ´%sª\n"
-
-#: gphoto2/actions.c:197 gphoto2/actions.c:229
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
-msgstr "  Tipo MIME:   ´%sª\n"
+msgstr "  Tipo MIME:   ¬´%s¬ª\n"
 
-#: gphoto2/actions.c:199 gphoto2/actions.c:231
-#, c-format
-msgid "  Size:        %li byte(s)\n"
-msgstr "  TamaÒo:      %li byte(s)\n"
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#, fuzzy, c-format
+msgid "  Size:        %lu byte(s)\n"
+msgstr "  Tama√±o:      %li byte(s)\n"
 
-#: gphoto2/actions.c:201 gphoto2/actions.c:233
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
-msgstr "  Anchura:     %i pÌxel(es)\n"
+msgstr "  Anchura:     %i p√≠xel(es)\n"
 
-#: gphoto2/actions.c:203 gphoto2/actions.c:235
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
-msgstr "  Altura:      %i pÌxel(es)\n"
+msgstr "  Altura:      %i p√≠xel(es)\n"
 
-#: gphoto2/actions.c:205 gphoto2/actions.c:237
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Descargado:  %s\n"
 
-#: gphoto2/actions.c:206 gphoto2/actions.c:238 gphoto2/actions.c:250
-#: gphoto2/actions.c:548 gphoto2/actions.c:550 gphoto2/actions.c:567
-#: gphoto2/actions.c:570 gphoto2/actions.c:573 gphoto2/actions.c:576
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
-msgstr "sÌ"
+msgstr "s√≠"
 
-#: gphoto2/actions.c:206 gphoto2/actions.c:238 gphoto2/actions.c:250
-#: gphoto2/actions.c:548 gphoto2/actions.c:550 gphoto2/actions.c:567
-#: gphoto2/actions.c:570 gphoto2/actions.c:573 gphoto2/actions.c:576
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "no"
 
-#: gphoto2/actions.c:208
+#: gphoto2/actions.c:293
+#, c-format
 msgid "  Permissions: "
 msgstr "  Permisos: "
 
-#: gphoto2/actions.c:211
+#: gphoto2/actions.c:296
+#, c-format
 msgid "read/delete"
 msgstr "lectura/borrado"
 
-#: gphoto2/actions.c:213
+#: gphoto2/actions.c:298
+#, c-format
 msgid "read"
 msgstr "lectura"
 
-#: gphoto2/actions.c:215
+#: gphoto2/actions.c:300
+#, c-format
 msgid "delete"
 msgstr "borrado"
 
-#: gphoto2/actions.c:217
+#: gphoto2/actions.c:302
+#, c-format
 msgid "none"
 msgstr "ninguno"
 
 # He comprobado que en otros idiomas lo traducen como "hora".
-#: gphoto2/actions.c:221
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Hora:        %s"
 
-#: gphoto2/actions.c:224
+#: gphoto2/actions.c:309
+#, c-format
 msgid "Thumbnail:\n"
 msgstr "Miniatura:\n"
 
-#: gphoto2/actions.c:240
+#: gphoto2/actions.c:325
+#, c-format
 msgid "Audio data:\n"
 msgstr "Datos de audio:\n"
 
-#: gphoto2/actions.c:245
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
-msgstr "  Tipo MIME: ´%sª\n"
+msgstr "  Tipo MIME: ¬´%s¬ª\n"
 
-#: gphoto2/actions.c:247
-#, c-format
-msgid "  Size:       %li byte(s)\n"
-msgstr "  TamaÒo:     %li byte(s)\n"
+#: gphoto2/actions.c:332
+#, fuzzy, c-format
+msgid "  Size:       %lu byte(s)\n"
+msgstr "  Tama√±o:     %li byte(s)\n"
 
-#: gphoto2/actions.c:249
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Descargado: %s\n"
 
-#: gphoto2/actions.c:380
+#: gphoto2/actions.c:504
 msgid "Could not parse EXIF data."
 msgstr "No se han podido analizar los datos EXIF."
 
-#: gphoto2/actions.c:384
+#: gphoto2/actions.c:508
+#, c-format
 msgid "EXIF tags:"
 msgstr "Etiquetas EXIF:"
 
-#: gphoto2/actions.c:387
+#: gphoto2/actions.c:511
 msgid "Tag"
 msgstr "Etiqueta"
 
-#: gphoto2/actions.c:389
+#: gphoto2/actions.c:513
 msgid "Value"
 msgstr "Valor"
 
-#: gphoto2/actions.c:410
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Los datos EXIF contienen una miniatura (%i bytes)."
 
-#: gphoto2/actions.c:419
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 ha sido compilado sin soporte para EXIF."
 
-#: gphoto2/actions.c:437
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
-msgstr "N˙mero de c·maras soportadas          : %i\n"
+msgstr "N√∫mero de c√°maras soportadas          : %i\n"
 
-#: gphoto2/actions.c:439
+#: gphoto2/actions.c:549
+#, c-format
 msgid "Supported cameras:\n"
-msgstr "C·maras soportadas:\n"
+msgstr "C√°maras soportadas:\n"
 
-#: gphoto2/actions.c:452
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (PRUEBA)\n"
 
-#: gphoto2/actions.c:455
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (EXPERIMENTAL)\n"
 
-#: gphoto2/actions.c:460
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:488
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Dispositivos encontrados: %i\n"
 
-#: gphoto2/actions.c:489
+#: gphoto2/actions.c:615
+#, c-format
 msgid ""
 "Path                             Description\n"
 "--------------------------------------------------------------\n"
 msgstr ""
-"Ruta                             DescripciÛn\n"
+"Ruta                             Descripci√≥n\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:528 gphoto2/actions.c:533
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:528
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Modelo"
 
-#: gphoto2/actions.c:528
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Puerto"
 
-#: gphoto2/actions.c:529
+#: gphoto2/actions.c:649
+#, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:546
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
-msgstr "Capacidades de la c·mara                : %s\n"
+msgstr "Capacidades de la c√°mara                : %s\n"
 
-#: gphoto2/actions.c:547
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Soporte de puerto serie                 : %s\n"
 
-#: gphoto2/actions.c:549
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Soporte de puerto USB                   : %s\n"
 
-#: gphoto2/actions.c:552
+#: gphoto2/actions.c:673
+#, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Velocidades de transferencia soportadas :\n"
 
-#: gphoto2/actions.c:554
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                        : %i\n"
 
-#: gphoto2/actions.c:557
+#: gphoto2/actions.c:678
+#, c-format
 msgid "Capture choices                  :\n"
 msgstr "Opciones de captura                     :\n"
 
-#: gphoto2/actions.c:559
+#: gphoto2/actions.c:680
+#, c-format
 msgid "                                 : Image\n"
 msgstr "                                        : Imagen\n"
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:684
+#, c-format
 msgid "                                 : Video\n"
-msgstr "                                        : VÌdeo\n"
+msgstr "                                        : V√≠deo\n"
 
-#: gphoto2/actions.c:563
+#: gphoto2/actions.c:688
+#, c-format
 msgid "                                 : Audio\n"
 msgstr "                                        : Audio\n"
 
-#: gphoto2/actions.c:565
+#: gphoto2/actions.c:692
+#, c-format
 msgid "                                 : Preview\n"
-msgstr "                                        : PrevisualizaciÛn\n"
+msgstr "                                        : Previsualizaci√≥n\n"
 
-#: gphoto2/actions.c:566
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                        : %i\n"
+
+#: gphoto2/actions.c:700
+#, fuzzy, c-format
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr "                                        : Previsualizaci√≥n\n"
+
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
-msgstr "Soporte de configuraciÛn                : %s\n"
+msgstr "Soporte de configuraci√≥n                : %s\n"
 
-#: gphoto2/actions.c:568
-#, c-format
-msgid "Delete files on camera support   : %s\n"
-msgstr "Soporte de borrado de ficheros en c·mara: %s\n"
+#: gphoto2/actions.c:704
+#, fuzzy, c-format
+msgid "Delete selected files on camera  : %s\n"
+msgstr "Soporte de borrado de ficheros en c√°mara: %s\n"
 
-#: gphoto2/actions.c:571
+#: gphoto2/actions.c:707
+#, fuzzy, c-format
+msgid "Delete all files on camera       : %s\n"
+msgstr "Soporte de borrado de ficheros en c√°mara: %s\n"
+
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Soporte de miniaturas                   : %s\n"
 
-#: gphoto2/actions.c:574
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
-msgstr "Soporte de envÌo de ficheros            : %s\n"
+msgstr "Soporte de env√≠o de ficheros            : %s\n"
 
-#: gphoto2/actions.c:591
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Los puertos deben tener un aspecto tal como ´serial:/dev/ttyS0ª o ´usb:ª, pero falta un ´:ª en ´%sª por lo que se va a intentar adivinar lo que quiso decir."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Los puertos deben tener un aspecto tal como ¬´serial:/dev/ttyS0¬ª o ¬´usb:¬ª, "
+"pero falta un ¬´:¬ª en ¬´%s¬ª por lo que se va a intentar adivinar lo que quiso "
+"decir."
 
-#: gphoto2/actions.c:630
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "No se puede encontrar el puerto que ha especificado (´%sª). Por favor, especifique uno de los puertos encontrados por ´gphoto2 --list-portsª y aseg˙rese de que la sintaxis es correcta (es decir, con el prefijo ´serial:ª o ´usb:ª)."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"No se puede encontrar el puerto que ha especificado (¬´%s¬ª). Por favor, "
+"especifique uno de los puertos encontrados por ¬´gphoto2 --list-ports¬ª y "
+"aseg√∫rese de que la sintaxis es correcta (es decir, con el prefijo ¬´serial:¬ª "
+"o ¬´usb:¬ª)."
 
-#: gphoto2/actions.c:668
+#: gphoto2/actions.c:797
+#, c-format
 msgid "About the camera driver:"
-msgstr "Acerca del controlador de la c·mara:"
+msgstr "Acerca del controlador de la c√°mara:"
 
-#: gphoto2/actions.c:682
-msgid "Camera summary:"
-msgstr "Resumen de la c·mara:"
-
-#: gphoto2/actions.c:696
-msgid "Camera manual:"
-msgstr "Manual de la c·mara:"
-
-#: gphoto2/actions.c:712
-msgid "You can only specify speeds for serial ports."
-msgstr "La velocidad sÛlo se puede especificar para los puertos serie."
-
-#: gphoto2/actions.c:763
+#: gphoto2/actions.c:810
 #, c-format
+msgid "Camera summary:"
+msgstr "Resumen de la c√°mara:"
+
+#: gphoto2/actions.c:823
+#, c-format
+msgid "Camera manual:"
+msgstr "Manual de la c√°mara:"
+
+#: gphoto2/actions.c:840
+#, c-format
+msgid "You can only specify speeds for serial ports."
+msgstr "La velocidad s√≥lo se puede especificar para los puertos serie."
+
+#: gphoto2/actions.c:890
+msgid "OS/2 port by Bart van Leeuwen\n"
+msgstr "Adaptado a OS/2 por Bart van Leeuwen\n"
+
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-2003 Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
 "Copyright (c) 2000-2003 Lutz Mueller y otros\n"
 "%s\n"
-"gphoto2 se entrega SIN NINGUNA GARANTÕA, hasta el punto permitido por la ley.\n"
-"Usted puede distribuir copias de gphoto2 bajo los tÈrminos de la Licencia\n"
-"P˙blica General de GNU. Para m·s informaciÛn al respecto, consulte los\n"
+"gphoto2 se entrega SIN NINGUNA GARANT√çA, hasta el punto permitido por la "
+"ley.\n"
+"Usted puede distribuir copias de gphoto2 bajo los t√©rminos de la Licencia\n"
+"P√∫blica General de GNU. Para m√°s informaci√≥n al respecto, consulte los\n"
 "ficheros llamados COPYING.\n"
 "\n"
-"Esta versiÛn de gphoto2 usa las siguientes versiones de software y opciones:\n"
+"Esta versi√≥n de gphoto2 usa las siguientes versiones de software y "
+"opciones:\n"
 
-#: gphoto2/actions.c:776
-msgid "OS/2 port by Bart van Leeuwen\n"
-msgstr "Adaptado a OS/2 por Bart van Leeuwen\n"
+#: gphoto2/actions.c:1015
+msgid "Could not open 'movie.mjpg'."
+msgstr ""
 
-#: gphoto2/actions.c:890
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "INCLUYA SIEMPRE LA SIGUIENTE LÕNEA CUANDO ENVÕE MENSAJES DE DEPURACI”N A LA LISTA DE DISTRIBUCI”N DE CORREO:"
-
-#: gphoto2/foreach.c:254
+#: gphoto2/actions.c:1022
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "N˙mero de fichero incorrecto. Ha indicado %i, pero sÛlo hay %i ficheros disponibles en ´%sª o sus subcarpetas. Por favor, obtenga antes un n˙mero de fichero v·lido de un listado de ficheros."
+msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
+msgstr ""
 
-#: gphoto2/foreach.c:283
+#: gphoto2/actions.c:1026
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "N˙mero de fichero incorrecto. Ha indicado %i, pero sÛlo hay disponible 1 fichero en ´%sª."
+msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1031
+#, c-format
+msgid "Capturing %d preview frames as movie to '%s'.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1047
+msgid "Movie capture error... Exiting."
+msgstr ""
+
+#: gphoto2/actions.c:1053
+#, c-format
+msgid "Movie capture error... Unhandled MIME type '%s'."
+msgstr ""
+
+#: gphoto2/actions.c:1060
+#, c-format
+msgid "Ctrl-C pressed ... Exiting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1074
+#, c-format
+msgid "Movie capture finished (%d frames)\n"
+msgstr ""
+
+#: gphoto2/actions.c:1106
+#, c-format
+msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1112
+#, c-format
+msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1117
+#, c-format
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1122
+#, c-format
+msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1125
+#, c-format
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1129
+#, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
+#, c-format
+msgid "event found, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
+#, fuzzy
+msgid "Could not set folder."
+msgstr "No se puede aplicar la configuraci√≥n:"
+
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
+#, fuzzy
+msgid "Could not get image."
+msgstr "No se puede aplicar la configuraci√≥n:"
+
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
+msgid "Buggy libcanon.so?"
+msgstr ""
+
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
+#, fuzzy
+msgid "Could not delete image."
+msgstr "No se puede encontrar el directorio inicial."
+
+#: gphoto2/actions.c:1300
+#, c-format
+msgid "Getting storage information not supported for this camera.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1315
+#, c-format
+msgid "Read-Write"
+msgstr ""
+
+#: gphoto2/actions.c:1318
+#, c-format
+msgid "Read-Only"
+msgstr ""
+
+#: gphoto2/actions.c:1321
+#, c-format
+msgid "Read-only with delete"
+msgstr ""
+
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
+#, c-format
+msgid "Unknown"
+msgstr ""
+
+#: gphoto2/actions.c:1337
+#, c-format
+msgid "Fixed ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1340
+#, c-format
+msgid "Removable ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1343
+#, c-format
+msgid "Fixed RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1346
+#, c-format
+msgid "Removable RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1356
+#, c-format
+msgid "Undefined"
+msgstr ""
+
+#: gphoto2/actions.c:1359
+#, c-format
+msgid "Generic Flat"
+msgstr ""
+
+#: gphoto2/actions.c:1362
+#, c-format
+msgid "Generic Hierarchical"
+msgstr ""
+
+#: gphoto2/actions.c:1365
+#, c-format
+msgid "Camera layout (DCIM)"
+msgstr ""
+
+#: gphoto2/actions.c:1406
+#, c-format
+msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
+msgstr ""
+
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"INCLUYA SIEMPRE LA SIGUIENTE L√çNEA CUANDO ENV√çE MENSAJES DE DEPURACI√ìN A LA "
+"LISTA DE DISTRIBUCI√ìN DE CORREO:"
+
+#: gphoto2/actions.c:1489
+#, c-format
+msgid "%s has been compiled with the following options:"
+msgstr ""
+
+#: gphoto2/actions.c:1629
+#, fuzzy, c-format
+msgid "%s not found in configuration tree."
+msgstr "No se puede aplicar la configuraci√≥n:"
+
+#: gphoto2/actions.c:1681
+#, c-format
+msgid "Failed to retrieve value of text widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1698
+#, c-format
+msgid "Failed to retrieve values of range widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1710
+#, c-format
+msgid "Failed to retrieve values of toggle widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1722
+#, c-format
+msgid "Failed to retrieve values of date/time widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1753
+#, c-format
+msgid "Failed to retrieve values of radio widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1799
+#, c-format
+msgid "Property %s is read only."
+msgstr ""
+
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
+#, c-format
+msgid "Failed to set the value of text widget %s to %s."
+msgstr ""
+
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
+#, c-format
+msgid "The passed value %s is not a floating point value."
+msgstr ""
+
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
+#, c-format
+msgid "The passed value %f is not within the expected range %f - %f."
+msgstr ""
+
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
+#, c-format
+msgid "Failed to set the value of range widget %s to %f."
+msgstr ""
+
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
+msgid "off"
+msgstr ""
+
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
+msgid "false"
+msgstr ""
+
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
+#, fuzzy
+msgid "on"
+msgstr "lun"
+
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
+msgid "true"
+msgstr ""
+
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
+#, c-format
+msgid "The passed value %s is not a valid toggle value."
+msgstr ""
+
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
+#, c-format
+msgid "Failed to set values %s of toggle widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
+#, fuzzy
+msgid "now"
+msgstr "no"
+
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
+#, c-format
+msgid "The passed value %s is neither a valid time nor an integer."
+msgstr ""
+
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
+#, c-format
+msgid "Failed to set new time of date/time widget %s to %s."
+msgstr ""
+
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
+#, c-format
+msgid "Choice %s not found within list of choices."
+msgstr ""
+
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
+#, c-format
+msgid "The %s widget is not configurable."
+msgstr ""
+
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
+#, c-format
+msgid "Failed to set new configuration value %s for configuration entry %s."
+msgstr ""
+
+#: gphoto2/actions.c:2019
+#, c-format
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+
+#: gphoto2/foreach.c:260
+#, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"N√∫mero de fichero incorrecto. Ha indicado %i, pero s√≥lo hay %i ficheros "
+"disponibles en ¬´%s¬ª o sus subcarpetas. Por favor, obtenga antes un n√∫mero de "
+"fichero v√°lido de un listado de ficheros."
+
+#: gphoto2/foreach.c:285
+#, c-format
+msgid "There are no files in folder '%s'."
+msgstr "No hay ning√∫n fichero en la carpeta ¬´%s¬ª."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'.Please obtain a valid file number from a file listing first."
-msgstr "N˙mero de fichero incorrecto. Ha indicado %i, pero sÛlo hay %i ficheros disponibles en ´%sª. Por favor, obtenga antes un n˙mero de fichero v·lido de un listado de ficheros."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"N√∫mero de fichero incorrecto. Ha indicado %i, pero s√≥lo hay disponible 1 "
+"fichero en ¬´%s¬ª."
 
-#: gphoto2/gp-params.c:53
+#: gphoto2/foreach.c:299
+#, fuzzy, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"N√∫mero de fichero incorrecto. Ha indicado %i, pero s√≥lo hay %i ficheros "
+"disponibles en ¬´%s¬ª. Por favor, obtenga antes un n√∫mero de fichero v√°lido de "
+"un listado de ficheros."
+
+#: gphoto2/gp-params.c:70
+#, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Error ***              \n"
 
-#: gphoto2/gp-params.c:220
+#: gphoto2/gp-params.c:243
+#, c-format
 msgid "Press any key to continue.\n"
 msgstr "Pulse cualquier tecla para continuar.\n"
 
-#: gphoto2/gp-params.c:237
+#: gphoto2/gp-params.c:266
+#, c-format
 msgid "Not enough memory."
 msgstr "No hay suficiente memoria."
 
-#: gphoto2/gphoto2-cmd-capture.c:201
+#: gphoto2/gphoto2-cmd-capture.c:211
 msgid "Operation cancelled"
-msgstr "OperaciÛn cancelada"
+msgstr "Operaci√≥n cancelada"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Continuar"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Cancelar"
 
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Error"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
-msgstr "No se puede aplicar la configuraciÛn:"
+msgstr "No se puede aplicar la configuraci√≥n:"
 
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Salir"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Regresar"
 
 # He comprobado que en otros idiomas lo traducen como hora.
-#: gphoto2/gphoto2-cmd-config.c:253
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Hora: "
 
-#: gphoto2/gphoto2-cmd-config.c:312 gphoto2/gphoto2-cmd-config.c:340
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Valor: "
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
-msgstr "SÌ"
+msgstr "S√≠"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "No"
 
-#: gphoto2/main.c:161 gphoto2/main.c:1461
-msgid "Turn on debugging"
-msgstr "Activar la depuraciÛn"
-
-#: gphoto2/main.c:162 gphoto2/main.c:1463
-msgid "Quiet output (default=verbose)"
-msgstr "Salida silenciosa (por omisiÛn=prolija)"
-
-#: gphoto2/main.c:166 gphoto2/main.c:1467
-msgid "Display version and exit"
-msgstr "Mostrar la versiÛn y salir"
-
-#: gphoto2/main.c:167
-msgid "Displays this help screen"
-msgstr "Muestra esta pantalla de ayuda"
-
-#: gphoto2/main.c:168 gphoto2/main.c:1469
-msgid "List supported camera models"
-msgstr "Lista los modelos de c·mara soportados"
-
-#: gphoto2/main.c:169 gphoto2/main.c:1471
-msgid "List supported port devices"
-msgstr "Lista los tipos de puerto soportados"
-
-#: gphoto2/main.c:170 gphoto2/main.c:1473
-msgid "Send file to stdout"
-msgstr "Enviar fichero a la salida est·ndar"
-
-#: gphoto2/main.c:171 gphoto2/main.c:1475
-msgid "Print filesize before data"
-msgstr "Mostrar el tamaÒo del fichero antes que los datos"
-
-#: gphoto2/main.c:172 gphoto2/main.c:1477
-msgid "List auto-detected cameras"
-msgstr "Listar las c·maras detectadas autom·ticamente"
-
-#: gphoto2/main.c:175 gphoto2/main.c:1479
-msgid "Specify port device"
-msgstr "Indicar el puerto del dispositivo"
-
-#: gphoto2/main.c:176 gphoto2/main.c:1481
-msgid "Specify serial transfer speed"
-msgstr "Indicar la velocidad de transferencia serie"
-
-#: gphoto2/main.c:177 gphoto2/main.c:1483
-msgid "Specify camera model"
-msgstr "Indicar el modelo de la c·mara"
-
-#: gphoto2/main.c:178 gphoto2/main.c:1485
-msgid "Specify a filename"
-msgstr "Indicar un nombre de fichero"
-
-#: gphoto2/main.c:179 gphoto2/main.c:1487
-msgid "(expert only) Override USB IDs"
-msgstr "(sÛlo para expertos) Ignorar los IDs de USB"
-
-#: gphoto2/main.c:182 gphoto2/main.c:1489
-msgid "Display camera abilities"
-msgstr "Mostrar las capacidades de la c·mara"
-
-#: gphoto2/main.c:183 gphoto2/main.c:1491
-msgid "Specify camera folder (default=\"/\")"
-msgstr "Indicar la carpeta de c·mara (predeterminada=\"/\")"
-
-#: gphoto2/main.c:184 gphoto2/main.c:1493
-msgid "Recursion (default for download)"
-msgstr "RecursiÛn (predeterminado para la descarga)"
-
-#: gphoto2/main.c:185 gphoto2/main.c:1495
-msgid "No recursion (default for deletion)"
-msgstr "Sin recursiÛn (predeterminado para el borrado)"
-
-#: gphoto2/main.c:186 gphoto2/main.c:1497
-msgid "List folders in folder"
-msgstr "Listar las carpetas que hay en la carpeta"
-
-#: gphoto2/main.c:187 gphoto2/main.c:1499
-msgid "List files in folder"
-msgstr "Listar los ficheros que hay en la carpeta"
-
-#: gphoto2/main.c:188 gphoto2/main.c:189
-msgid "name"
-msgstr "nombre"
-
-#: gphoto2/main.c:188 gphoto2/main.c:1501
-msgid "Create a directory"
-msgstr "Crear un directorio"
-
-#: gphoto2/main.c:189 gphoto2/main.c:1503
-msgid "Remove a directory"
-msgstr "Eliminar un directorio"
-
-#: gphoto2/main.c:190 gphoto2/main.c:1505
-msgid "Display number of files"
-msgstr "Mostrar el n˙mero de ficheros"
-
-#: gphoto2/main.c:191 gphoto2/main.c:1507
-msgid "Get files given in range"
-msgstr "Obtener los ficheros del intervalo"
-
-#: gphoto2/main.c:192 gphoto2/main.c:1509
-msgid "Get all files from folder"
-msgstr "Obtener todos los ficheros de la carpeta"
-
-#: gphoto2/main.c:193 gphoto2/main.c:1511
-msgid "Get thumbnails given in range"
-msgstr "Obtener las miniaturas del intervalo"
-
-#: gphoto2/main.c:194 gphoto2/main.c:1514
-msgid "Get all thumbnails from folder"
-msgstr "Obtener todas las miniaturas de la carpeta"
-
-#: gphoto2/main.c:195 gphoto2/main.c:1517
-msgid "Get raw data given in range"
-msgstr "Obtener los datos en bruto del intervalo"
-
-#: gphoto2/main.c:196 gphoto2/main.c:1520
-msgid "Get all raw data from folder"
-msgstr "Obtener todos los datos en bruto de la carpeta"
-
-#: gphoto2/main.c:197 gphoto2/main.c:1523
-msgid "Get audio data given in range"
-msgstr "Obtener los datos de audio del intervalo"
-
-#: gphoto2/main.c:198 gphoto2/main.c:1526
-msgid "Get all audio data from folder"
-msgstr "Obtener todos los datos de audio de la carpeta"
-
-#: gphoto2/main.c:199 gphoto2/main.c:1528
-msgid "Delete files given in range"
-msgstr "Borrar los ficheros del intervalo"
-
-#: gphoto2/main.c:200 gphoto2/main.c:1530
-msgid "Delete all files in folder"
-msgstr "Borrar todos los ficheros de la carpeta"
-
-#: gphoto2/main.c:201 gphoto2/main.c:1532
-msgid "Upload a file to camera"
-msgstr "Enviar un fichero a la c·mara"
-
-#: gphoto2/main.c:203 gphoto2/main.c:1535
-msgid "Configure"
-msgstr "Configurar"
-
-#: gphoto2/main.c:205 gphoto2/main.c:1539
-msgid "Capture a quick preview"
-msgstr "Capturar una previsualizaciÛn r·pida"
-
-#: gphoto2/main.c:206 gphoto2/main.c:1541
-msgid "Capture an image"
-msgstr "Capturar una imagen"
-
-#: gphoto2/main.c:207
-msgid "Capture a movie "
-msgstr "Capturar una pelÌcula "
-
-#: gphoto2/main.c:208 gphoto2/main.c:1545
-msgid "Capture an audio clip"
-msgstr "Capturar un clip de audio"
-
-#: gphoto2/main.c:210 gphoto2/main.c:1548 gphoto2/shell.c:113
-msgid "Show EXIF information"
-msgstr "Mostrar la informaciÛn EXIF"
-
-#: gphoto2/main.c:212 gphoto2/main.c:1551 gphoto2/shell.c:109
-msgid "Show info"
-msgstr "Mostrar informaciÛn"
-
-#: gphoto2/main.c:213
-msgid "Summary of camera status"
-msgstr "Resumen del estado de la c·mara"
-
-#: gphoto2/main.c:214
-msgid "Camera driver manual"
-msgstr "Manual del controlador de la c·mara"
-
-#: gphoto2/main.c:215
-msgid "About the camera driver"
-msgstr "Acerca del controlador de la c·mara"
-
-#: gphoto2/main.c:216 gphoto2/main.c:1559
-msgid "gPhoto shell"
-msgstr "IntÈrprete gPhoto"
-
-#: gphoto2/main.c:343 gphoto2/main.c:1192
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Utilice la sintaxis a:b=c:d para tratar a cualquier dispositivo USB detectado como a:b como si fuera c:d. a b c y d deberÌan ser n˙meros hexadecimales que comienzan con '0x'.\n"
-
-#: gphoto2/main.c:466
-msgid "Jan"
-msgstr "ene"
-
-#: gphoto2/main.c:466
-msgid "January"
-msgstr "enero"
-
-#: gphoto2/main.c:467
-msgid "Feb"
-msgstr "feb"
-
-#: gphoto2/main.c:467
-msgid "February"
-msgstr "febrero"
-
-#: gphoto2/main.c:468
-msgid "Mar"
-msgstr "mar"
-
-#: gphoto2/main.c:468
-msgid "March"
-msgstr "marzo"
-
-#: gphoto2/main.c:469
-msgid "Apr"
-msgstr "abr"
-
-#: gphoto2/main.c:469
-msgid "April"
-msgstr "abril"
-
-#: gphoto2/main.c:470
-msgid "May"
-msgstr "may"
-
-#: gphoto2/main.c:471
-msgid "Jun"
-msgstr "jun"
-
-#: gphoto2/main.c:471
-msgid "June"
-msgstr "junio"
-
-#: gphoto2/main.c:472
-msgid "Jul"
-msgstr "jul"
-
-#: gphoto2/main.c:472
-msgid "July"
-msgstr "julio"
-
-#: gphoto2/main.c:473
-msgid "Aug"
-msgstr "agt"
-
-#: gphoto2/main.c:473
-msgid "August"
-msgstr "agosto"
-
-#: gphoto2/main.c:474
-msgid "Sep"
-msgstr "sep"
-
-#: gphoto2/main.c:474
-msgid "September"
-msgstr "septiembre"
-
-#: gphoto2/main.c:475
-msgid "Oct"
-msgstr "oct"
-
-#: gphoto2/main.c:475
-msgid "October"
-msgstr "octubre"
-
-#: gphoto2/main.c:476
-msgid "Nov"
-msgstr "nov"
-
-#: gphoto2/main.c:476
-msgid "November"
-msgstr "noviembre"
-
-#: gphoto2/main.c:477
-msgid "Dec"
-msgstr "dic"
-
-#: gphoto2/main.c:477
-msgid "December"
-msgstr "diciembre"
-
-#: gphoto2/main.c:484
-msgid "Sun"
-msgstr "dom"
-
-#: gphoto2/main.c:484
-msgid "Sunday"
-msgstr "domingo"
-
-#: gphoto2/main.c:485
-msgid "Mon"
-msgstr "lun"
-
-#: gphoto2/main.c:485
-msgid "Monday"
-msgstr "lunes"
-
-#: gphoto2/main.c:486
-msgid "Tue"
-msgstr "mar"
-
-#: gphoto2/main.c:486
-msgid "Tuesday"
-msgstr "martes"
-
-#: gphoto2/main.c:487
-msgid "Wed"
-msgstr "miÈ"
-
-#: gphoto2/main.c:487
-msgid "Wednesday"
-msgstr "miÈrcoles"
-
-#: gphoto2/main.c:488
-msgid "Thu"
-msgstr "jue"
-
-#: gphoto2/main.c:488
-msgid "Thursday"
-msgstr "jueves"
-
-#: gphoto2/main.c:489
-msgid "Fri"
-msgstr "vie"
-
-#: gphoto2/main.c:489
-msgid "Friday"
-msgstr "viernes"
-
-#: gphoto2/main.c:490
-msgid "Sat"
-msgstr "s·b"
-
-#: gphoto2/main.c:490
-msgid "Saturday"
-msgstr "s·bado"
-
-#: gphoto2/main.c:552
+#: gphoto2/main.c:220
 #, c-format
-msgid "You cannot use '%n' in combination with non-persistent files!"
-msgstr "No puede utilizar ´%nª en combinaciÛn con ficheros no persistentes."
+msgid "Zero padding numbers in file names is only possible with %%n."
+msgstr ""
 
-#: gphoto2/main.c:575
+#: gphoto2/main.c:229
+#, fuzzy, c-format
+msgid "You cannot use %%n zero padding without a precision value!"
+msgstr "No puede utilizar ¬´%n¬ª en combinaci√≥n con ficheros no persistentes."
+
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
-msgstr "El nombre de fichero proporcionado por la c·mara (´%sª) no tiene sufijo."
+msgstr ""
+"El nombre de fichero proporcionado por la c√°mara (¬´%s¬ª) no tiene sufijo."
 
-#: gphoto2/main.c:654
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
-msgstr "Formato ´%sª no v·lido (error en la posiciÛn %i)."
+msgstr "Formato ¬´%s¬ª no v√°lido (error en la posici√≥n %i)."
+
+#: gphoto2/main.c:386 gphoto2/main.c:592
+#, fuzzy, c-format
+msgid "Skip existing file %s\n"
+msgstr "Guardando el fichero como %s\n"
 
 # !!! [y/n] !!! [CM]
-#: gphoto2/main.c:701
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
-msgstr "El fichero %s existe. øSobreescribir? [y|n] "
+msgstr "El fichero %s existe. ¬øSobreescribir? [y|n] "
 
-#: gphoto2/main.c:712
+#: gphoto2/main.c:410
+#, c-format
 msgid "Specify new filename? [y|n] "
-msgstr "øIndicar un nuevo nombre de fichero? [y|n] "
+msgstr "¬øIndicar un nuevo nombre de fichero? [y|n] "
 
-#: gphoto2/main.c:721
+#: gphoto2/main.c:422
+#, c-format
 msgid "Enter new filename: "
 msgstr "Introduzca el nuevo nombre de fichero: "
 
-#: gphoto2/main.c:726
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Guardando el fichero como %s\n"
 
-#: gphoto2/main.c:918
+#: gphoto2/main.c:630
+#, fuzzy
+msgid "Permission denied"
+msgstr "  Permisos: "
+
+#: gphoto2/main.c:800
+#, fuzzy
+msgid "Could not trigger capture."
+msgstr "No se han podido analizar los datos EXIF."
+
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
-msgstr "El nuevo fichero est· en la ubicaciÛn %s%s%s en la c·mara\n"
+msgstr "El nuevo fichero est√° en la ubicaci√≥n %s%s%s en la c√°mara\n"
 
-#: gphoto2/main.c:1050
+#: gphoto2/main.c:847 gphoto2/main.c:878
+#, fuzzy, c-format
+msgid "Keeping file %s%s%s on the camera\n"
+msgstr "El nuevo fichero est√° en la ubicaci√≥n %s%s%s en la c√°mara\n"
+
+#: gphoto2/main.c:868
+#, fuzzy, c-format
+msgid "Deleting file %s%s%s on the camera\n"
+msgstr "El nuevo fichero est√° en la ubicaci√≥n %s%s%s en la c√°mara\n"
+
+#: gphoto2/main.c:911
+#, c-format
+msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:916
+#, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:926
+#, c-format
+msgid "Event UNKNOWN %s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:932
+#, c-format
+msgid "Unknown event type %d during bulb wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:950
+#, fuzzy
+msgid "Could not get capabilities?"
+msgstr "No se puede aplicar la configuraci√≥n:"
+
+#: gphoto2/main.c:958
+#, c-format
+msgid "Time-lapse mode enabled (interval: %ds).\n"
+msgstr ""
+
+#: gphoto2/main.c:961
+#, c-format
+msgid "Standing by waiting for SIGUSR1 to capture.\n"
+msgstr ""
+
+#: gphoto2/main.c:967
+#, c-format
+msgid "Bulb mode enabled (exposure time: %ds).\n"
+msgstr ""
+
+#: gphoto2/main.c:975
+#, c-format
+msgid "Capturing frame #%d...\n"
+msgstr ""
+
+#: gphoto2/main.c:977
+#, c-format
+msgid "Capturing frame #%d/%d...\n"
+msgstr ""
+
+#: gphoto2/main.c:987
+#, c-format
+msgid "Could not set bulb capture, result %d."
+msgstr ""
+
+#: gphoto2/main.c:1001
+msgid "Could not end capture (bulb mode)."
+msgstr ""
+
+#: gphoto2/main.c:1014
+#, fuzzy
+msgid "Could not trigger image capture."
+msgstr "No se puede encontrar el directorio inicial."
+
+#: gphoto2/main.c:1021
+#, fuzzy
+msgid "Could not capture image."
+msgstr "Capturar una imagen"
+
+#: gphoto2/main.c:1028
+#, c-format
+msgid "Capture failed (auto-focus problem?)...\n"
+msgstr ""
+
+#: gphoto2/main.c:1039
+#, fuzzy
+msgid "Could not capture."
+msgstr "No se han podido analizar los datos EXIF."
+
+#: gphoto2/main.c:1074
+#, c-format
+msgid "Waiting for next capture slot %ld seconds...\n"
+msgstr ""
+
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
+#, c-format
+msgid "Awakened by SIGUSR1...\n"
+msgstr ""
+
+#: gphoto2/main.c:1096
+#, c-format
+msgid "not sleeping (%ld seconds behind schedule)\n"
+msgstr ""
+
+#: gphoto2/main.c:1240
+#, c-format
 msgid "ERROR: "
 msgstr "ERROR: "
 
-#: gphoto2/main.c:1073
+#: gphoto2/main.c:1263
+#, c-format
 msgid ""
 "\n"
 "Aborting...\n"
@@ -816,11 +981,13 @@ msgstr ""
 "\n"
 "Interrumpiendo...\n"
 
-#: gphoto2/main.c:1079
+#: gphoto2/main.c:1269
+#, c-format
 msgid "Aborted.\n"
 msgstr "Interrumpido.\n"
 
-#: gphoto2/main.c:1084
+#: gphoto2/main.c:1274
+#, c-format
 msgid ""
 "\n"
 "Cancelling...\n"
@@ -828,24 +995,43 @@ msgstr ""
 "\n"
 "Cancelando...\n"
 
-#: gphoto2/main.c:1291
+#: gphoto2/main.c:1426
+#, c-format
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Utilice la sintaxis a:b=c:d para tratar a cualquier dispositivo USB "
+"detectado como a:b como si fuera c:d. a b c y d deber√≠an ser n√∫meros "
+"hexadecimales que comienzan con '0x'.\n"
+
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 ha sido compilado sin soporte para CDK."
 
-#: gphoto2/main.c:1404
+#: gphoto2/main.c:1879
+#, c-format
 msgid "Operation cancelled.\n"
-msgstr "OperaciÛn cancelada.\n"
+msgstr "Operaci√≥n cancelada.\n"
 
-#: gphoto2/main.c:1408
+#: gphoto2/main.c:1883
+#, c-format
+msgid ""
+"*** Error: No camera found. ***\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
 "\n"
 msgstr ""
-"*** Error (%i: ´%sª) ***       \n"
+"*** Error (%i: ¬´%s¬ª) ***       \n"
 "\n"
 
-#: gphoto2/main.c:1412
+#: gphoto2/main.c:1890
+#, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
 "Debugging messages may help finding a solution to your problem.\n"
@@ -854,100 +1040,440 @@ msgid ""
 "gphoto2 as follows:\n"
 "\n"
 msgstr ""
-"Por favor, utilice la opciÛn --debug para obtener los mensajes de depuraciÛn.\n"
-"Estos mensajes pueden ayudar a encontrar una soluciÛn a su problema.\n"
-"Si piensa enviar cualquier mensaje de error o de depuraciÛn a la lista\n"
-"de distribuciÛn de desarrolladores de gPhoto <gphoto-devel@lists.sourceforge.net>,\n"
+"Por favor, utilice la opci√≥n --debug para obtener los mensajes de "
+"depuraci√≥n.\n"
+"Estos mensajes pueden ayudar a encontrar una soluci√≥n a su problema.\n"
+"Si piensa enviar cualquier mensaje de error o de depuraci√≥n a la lista\n"
+"de distribuci√≥n de desarrolladores de gPhoto <gphoto-devel@lists.sourceforge."
+"net>,\n"
 "por favor ejecute gphoto2 como sigue:\n"
 "\n"
 
-#: gphoto2/main.c:1465
-msgid "Overwrite files without asking."
+#: gphoto2/main.c:1911
+#, c-format
+msgid ""
+"Please make sure there is sufficient quoting around the arguments.\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1978
+msgid "Print complete help message on program usage"
+msgstr ""
+
+#: gphoto2/main.c:1980
+msgid "Print short message on program usage"
+msgstr ""
+
+#: gphoto2/main.c:1982
+msgid "Turn on debugging"
+msgstr "Activar la depuraci√≥n"
+
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
+
+#: gphoto2/main.c:1986
+msgid "Name of file to write debug info to"
+msgstr ""
+
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
+msgid "FILENAME"
+msgstr ""
+
+#: gphoto2/main.c:1988
+msgid "Quiet output (default=verbose)"
+msgstr "Salida silenciosa (por omisi√≥n=prolija)"
+
+#: gphoto2/main.c:1990
+msgid "Hook script to call after downloads, captures, etc."
+msgstr ""
+
+#: gphoto2/main.c:1997
+#, fuzzy
+msgid "Specify device port"
+msgstr "Indicar el puerto del dispositivo"
+
+#: gphoto2/main.c:1999
+msgid "Specify serial transfer speed"
+msgstr "Indicar la velocidad de transferencia serie"
+
+#: gphoto2/main.c:1999
+msgid "SPEED"
+msgstr ""
+
+#: gphoto2/main.c:2001
+msgid "Specify camera model"
+msgstr "Indicar el modelo de la c√°mara"
+
+#: gphoto2/main.c:2001
+msgid "MODEL"
+msgstr ""
+
+#: gphoto2/main.c:2003
+msgid "(expert only) Override USB IDs"
+msgstr "(s√≥lo para expertos) Ignorar los IDs de USB"
+
+#: gphoto2/main.c:2003
+msgid "USBIDs"
+msgstr ""
+
+#: gphoto2/main.c:2009
+msgid "Display version and exit"
+msgstr "Mostrar la versi√≥n y salir"
+
+#: gphoto2/main.c:2011
+msgid "List supported camera models"
+msgstr "Lista los modelos de c√°mara soportados"
+
+#: gphoto2/main.c:2013
+msgid "List supported port devices"
+msgstr "Lista los tipos de puerto soportados"
+
+#: gphoto2/main.c:2015
+msgid "Display the camera/driver abilities in the libgphoto2 database"
+msgstr ""
+
+#: gphoto2/main.c:2022
+msgid "Configure"
+msgstr "Configurar"
+
+#: gphoto2/main.c:2025
+#, fuzzy
+msgid "List configuration tree"
+msgstr "No se puede aplicar la configuraci√≥n:"
+
+#: gphoto2/main.c:2027
+msgid "Dump full configuration tree"
+msgstr ""
+
+#: gphoto2/main.c:2029
+#, fuzzy
+msgid "Get configuration value"
+msgstr "No se puede aplicar la configuraci√≥n:"
+
+#: gphoto2/main.c:2031
+msgid "Set configuration value or index in choices"
+msgstr ""
+
+#: gphoto2/main.c:2033
+msgid "Set configuration value index in choices"
+msgstr ""
+
+#: gphoto2/main.c:2035
+#, fuzzy
+msgid "Set configuration value"
+msgstr "No se puede aplicar la configuraci√≥n:"
+
+#: gphoto2/main.c:2037
+msgid "Reset device port"
+msgstr ""
+
+#: gphoto2/main.c:2043
+msgid "Keep images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2045
+msgid "Keep RAW images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2047
+msgid "Remove images from camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2049
+msgid "Wait for event(s) from camera"
+msgstr ""
+
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
+
+#: gphoto2/main.c:2051
+msgid "Wait for event(s) from the camera and download new images"
+msgstr ""
+
+#: gphoto2/main.c:2054
+msgid "Capture a quick preview"
+msgstr "Capturar una previsualizaci√≥n r√°pida"
+
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
+
+#: gphoto2/main.c:2059
+msgid "Set bulb exposure time in seconds"
+msgstr ""
+
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
+msgid "SECONDS"
+msgstr ""
+
+#: gphoto2/main.c:2061
+msgid "Set number of frames to capture (default=infinite)"
+msgstr ""
+
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr ""
+
+#: gphoto2/main.c:2063
+msgid "Set capture interval in seconds"
+msgstr ""
+
+#: gphoto2/main.c:2065
+msgid "Reset capture interval on signal (default=no)"
+msgstr ""
+
+#: gphoto2/main.c:2067
+msgid "Capture an image"
+msgstr "Capturar una imagen"
+
+#: gphoto2/main.c:2069
+#, fuzzy
+msgid "Trigger capture of an image"
+msgstr "Capturar una imagen"
+
+#: gphoto2/main.c:2071
+#, fuzzy
+msgid "Capture an image and download it"
+msgstr "Capturar una imagen"
+
+#: gphoto2/main.c:2073
+msgid "Capture a movie"
+msgstr "Capturar una pel√≠cula"
+
+#: gphoto2/main.c:2073
+msgid "COUNT or SECONDS"
+msgstr ""
+
+#: gphoto2/main.c:2075
+msgid "Capture an audio clip"
+msgstr "Capturar un clip de audio"
+
+#: gphoto2/main.c:2077
+msgid "Wait for shutter release on the camera and download"
+msgstr ""
+
+#: gphoto2/main.c:2083
+msgid "List folders in folder"
+msgstr "Listar las carpetas que hay en la carpeta"
+
+#: gphoto2/main.c:2085
+msgid "List files in folder"
+msgstr "Listar los ficheros que hay en la carpeta"
+
+#: gphoto2/main.c:2087
+msgid "Create a directory"
+msgstr "Crear un directorio"
+
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
+msgid "DIRNAME"
+msgstr ""
+
+#: gphoto2/main.c:2089
+msgid "Remove a directory"
+msgstr "Eliminar un directorio"
+
+#: gphoto2/main.c:2091
+msgid "Display number of files"
+msgstr "Mostrar el n√∫mero de ficheros"
+
+#: gphoto2/main.c:2093
+msgid "Get files given in range"
+msgstr "Obtener los ficheros del intervalo"
+
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
+msgid "RANGE"
+msgstr ""
+
+#: gphoto2/main.c:2095
+msgid "Get all files from folder"
+msgstr "Obtener todos los ficheros de la carpeta"
+
+#: gphoto2/main.c:2097
+msgid "Get thumbnails given in range"
+msgstr "Obtener las miniaturas del intervalo"
+
+#: gphoto2/main.c:2100
+msgid "Get all thumbnails from folder"
+msgstr "Obtener todas las miniaturas de la carpeta"
+
+#: gphoto2/main.c:2102
+#, fuzzy
+msgid "Get metadata given in range"
+msgstr "Obtener los datos en bruto del intervalo"
+
+#: gphoto2/main.c:2104
+#, fuzzy
+msgid "Get all metadata from folder"
+msgstr "Obtener todos los datos en bruto de la carpeta"
+
+#: gphoto2/main.c:2106
+msgid "Upload metadata for file"
+msgstr ""
+
+#: gphoto2/main.c:2109
+msgid "Get raw data given in range"
+msgstr "Obtener los datos en bruto del intervalo"
+
+#: gphoto2/main.c:2112
+msgid "Get all raw data from folder"
+msgstr "Obtener todos los datos en bruto de la carpeta"
+
+#: gphoto2/main.c:2115
+msgid "Get audio data given in range"
+msgstr "Obtener los datos de audio del intervalo"
+
+#: gphoto2/main.c:2118
+msgid "Get all audio data from folder"
+msgstr "Obtener todos los datos de audio de la carpeta"
+
+#: gphoto2/main.c:2120
+msgid "Delete files given in range"
+msgstr "Borrar los ficheros del intervalo"
+
+#: gphoto2/main.c:2122
+#, fuzzy
+msgid "Delete all files in folder (--no-recurse by default)"
+msgstr "Borrar todos los ficheros de la carpeta"
+
+#: gphoto2/main.c:2124
+msgid "Upload a file to camera"
+msgstr "Enviar un fichero a la c√°mara"
+
+#: gphoto2/main.c:2126
+#, fuzzy
+msgid "Specify a filename or filename pattern"
+msgstr "Indicar un nombre de fichero"
+
+#: gphoto2/main.c:2126
+msgid "FILENAME_PATTERN"
+msgstr ""
+
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
+msgid "Specify camera folder (default=\"/\")"
+msgstr "Indicar la carpeta de c√°mara (predeterminada=\"/\")"
+
+#: gphoto2/main.c:2130
+msgid "FOLDER"
+msgstr ""
+
+#: gphoto2/main.c:2132
+msgid "Recursion (default for download)"
+msgstr "Recursi√≥n (predeterminado para la descarga)"
+
+#: gphoto2/main.c:2134
+msgid "No recursion (default for deletion)"
+msgstr "Sin recursi√≥n (predeterminado para el borrado)"
+
+#: gphoto2/main.c:2136
+msgid "Process new files only"
+msgstr ""
+
+#: gphoto2/main.c:2138
+#, fuzzy
+msgid "Overwrite files without asking"
 msgstr "Sobreescribir los ficheros sin preguntar."
 
-#: gphoto2/main.c:1479
-msgid "path"
-msgstr "ruta"
+#: gphoto2/main.c:2140
+msgid "Skip existing files"
+msgstr ""
 
-#: gphoto2/main.c:1481
-msgid "speed"
-msgstr "velocidad"
+#: gphoto2/main.c:2146
+msgid "Send file to stdout"
+msgstr "Enviar fichero a la salida est√°ndar"
 
-#: gphoto2/main.c:1483
-msgid "model"
-msgstr "modelo"
+#: gphoto2/main.c:2148
+msgid "Print filesize before data"
+msgstr "Mostrar el tama√±o del fichero antes que los datos"
 
-#: gphoto2/main.c:1485
-msgid "filename"
-msgstr "fichero"
+#: gphoto2/main.c:2150
+msgid "List auto-detected cameras"
+msgstr "Listar las c√°maras detectadas autom√°ticamente"
 
-#: gphoto2/main.c:1487
-msgid "usbid"
-msgstr "usbid"
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
+msgstr "Mostrar la informaci√≥n EXIF"
 
-#: gphoto2/main.c:1491
-msgid "folder"
-msgstr "carpeta"
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
 
-#: gphoto2/main.c:1543
-msgid "Capture a movie"
-msgstr "Capturar una pelÌcula"
-
-#: gphoto2/main.c:1553
-msgid "Show summary"
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "Mostrar un resumen"
 
-#: gphoto2/main.c:1555
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
-msgstr "Mostrar el manual del controlador de la c·mara"
+msgstr "Mostrar el manual del controlador de la c√°mara"
 
-#: gphoto2/main.c:1557
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
-msgstr "Acerca del manual controlador de la c·mara"
+msgstr "Acerca del manual controlador de la c√°mara"
 
-#: gphoto2/main.c:1784
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
-msgstr "gPhoto2 para OS/2 necesita que configure la variable de entorno CAMLIBS con la ubicaciÛn de las bibliotecas de soporte de las c·maras. Por ejemplo SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
+#, fuzzy
+msgid "Show storage information"
+msgstr "Mostrar la informaci√≥n EXIF"
 
-#: gphoto2/main.c:1794
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
-msgstr "gPhoto2 para OS/2 necesita que configure la variable de entorno IOLIBS con la ubicaciÛn de las bibliotecas de E/S. Por ejemplo SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#: gphoto2/main.c:2167
+msgid "gPhoto shell"
+msgstr "Int√©rprete gPhoto"
 
-#: gphoto2/options.c:181
-msgid "Usage:\n"
-msgstr "Sintaxis:\n"
-
-#: gphoto2/options.c:184
-msgid ""
-"Short/long options (& argument)        Description\n"
-"--------------------------------------------------------------------------------\n"
+#: gphoto2/main.c:2173
+msgid "Common options"
 msgstr ""
-"Opciones cortas/largas (& argumento)   DescripciÛn\n"
-"--------------------------------------------------------------------------------\n"
 
-#: gphoto2/options.c:209
-#, c-format
-msgid "%-38s %s\n"
-msgstr "%-32s %s\n"
-
-#: gphoto2/options.c:214
-msgid ""
-"--------------------------------------------------------------------------------\n"
-"[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
+#: gphoto2/main.c:2175
+msgid "Miscellaneous options (unsorted)"
 msgstr ""
-"--------------------------------------------------------------------------------\n"
-"[Usar comillas para los arg.]     [Los n˙meros de imagen comienzan con un (1)]\n"
 
-#: gphoto2/range.c:103 gphoto2/range.c:157
+#: gphoto2/main.c:2177
+msgid "Get information on software and host system (not from the camera)"
+msgstr ""
+
+#: gphoto2/main.c:2179
+#, fuzzy
+msgid "Specify the camera to use"
+msgstr "Indicar el modelo de la c√°mara"
+
+#: gphoto2/main.c:2181
+#, fuzzy
+msgid "Camera and software configuration"
+msgstr "No se puede aplicar la configuraci√≥n:"
+
+#: gphoto2/main.c:2183
+#, fuzzy
+msgid "Capture an image from or on the camera"
+msgstr "Cambiar a un directorio en la c√°mara"
+
+#: gphoto2/main.c:2185
+msgid "Downloading, uploading and manipulating files"
+msgstr ""
+
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
 "Image IDs must be a number greater than zero."
 msgstr ""
 "%s\n"
-"Los ID de imagen deben ser un n˙mero mayor que cero."
+"Los ID de imagen deben ser un n√∫mero mayor que cero."
 
-#: gphoto2/range.c:109 gphoto2/range.c:163
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -956,34 +1482,34 @@ msgstr ""
 "%s\n"
 "ID de imagen %i demasiado grande."
 
-#: gphoto2/range.c:125
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
 "Ranges must be separated by ','."
 msgstr ""
 "%s\n"
-"Los intervalos deben estar separados por ´,ª."
+"Los intervalos deben estar separados por ¬´,¬ª."
 
-#: gphoto2/range.c:139
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
 "Ranges need to start with a number."
 msgstr ""
 "%s\n"
-"Los intervalos deben comenzar con un n˙mero."
+"Los intervalos deben comenzar con un n√∫mero."
 
-#: gphoto2/range.c:179
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
 "Unexpected character '%c'."
 msgstr ""
 "%s\n"
-"Car·cter inesperado ´%cª."
+"Car√°cter inesperado ¬´%c¬ª."
 
-#: gphoto2/range.c:202
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -992,122 +1518,427 @@ msgstr ""
 "%s\n"
 "No se permiten intervalos decrecientes. Ha indicado un intervalo de %i a %i."
 
-#: gphoto2/shell.c:55
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
-msgstr "*** Error (%i: ´%sª) ***"
+msgstr "*** Error (%i: ¬´%s¬ª) ***"
 
-#: gphoto2/shell.c:98
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
-msgstr "Cambiar a un directorio en la c·mara"
+msgstr "Cambiar a un directorio en la c√°mara"
 
-#: gphoto2/shell.c:99 gphoto2/shell.c:101
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "directorio"
 
-#: gphoto2/shell.c:100
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Cambiar a un directorio en el disco local"
 
-#: gphoto2/shell.c:102 gphoto2/shell.c:120 gphoto2/shell.c:121
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
-msgstr "Salir del intÈrprete gPhoto"
+msgstr "Salir del int√©rprete gPhoto"
 
-#: gphoto2/shell.c:103
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Descargar un fichero"
 
-#: gphoto2/shell.c:103 gphoto2/shell.c:106 gphoto2/shell.c:108
-#: gphoto2/shell.c:110 gphoto2/shell.c:111 gphoto2/shell.c:114
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[directorio/]fichero"
 
-#: gphoto2/shell.c:105
+#: gphoto2/shell.c:132
+#, fuzzy
+msgid "Upload a file"
+msgstr "Descargar un fichero"
+
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Descargar una miniatura"
 
-#: gphoto2/shell.c:107
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Descargar datos en bruto"
 
-#: gphoto2/shell.c:111
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Borrar"
 
-#: gphoto2/shell.c:116 gphoto2/shell.c:122
+#: gphoto2/shell.c:140
+#, fuzzy
+msgid "Create Directory"
+msgstr "Crear un directorio"
+
+#: gphoto2/shell.c:141
+#, fuzzy
+msgid "Remove Directory"
+msgstr "Eliminar un directorio"
+
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Muestra la sintaxis de los mandatos"
 
-#: gphoto2/shell.c:117 gphoto2/shell.c:122
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[mandato]"
 
-#: gphoto2/shell.c:118
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Lista el contenido del directorio actual"
 
-#: gphoto2/shell.c:119
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[directorio/]"
 
-#: gphoto2/shell.c:421
-msgid "Invalid command."
-msgstr "Mandato no v·lido."
+#: gphoto2/shell.c:152
+msgid "List configuration variables"
+msgstr ""
 
-#: gphoto2/shell.c:430
+#: gphoto2/shell.c:153
+msgid "Get configuration variable"
+msgstr ""
+
+#: gphoto2/shell.c:153
+msgid "name"
+msgstr "nombre"
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+msgid "Set configuration variable"
+msgstr ""
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+msgid "name=value"
+msgstr ""
+
+#: gphoto2/shell.c:155
+msgid "Set configuration variable index"
+msgstr ""
+
+#: gphoto2/shell.c:155
+msgid "name=valueindex"
+msgstr ""
+
+#: gphoto2/shell.c:157
+msgid "Triggers the capture of a single image"
+msgstr ""
+
+#: gphoto2/shell.c:158
+#, fuzzy
+msgid "Capture a single image"
+msgstr "Capturar una imagen"
+
+#: gphoto2/shell.c:159
+msgid "Capture a single image and download it"
+msgstr ""
+
+#: gphoto2/shell.c:160
+#, fuzzy
+msgid "Capture a preview image"
+msgstr "Capturar una imagen"
+
+#: gphoto2/shell.c:161
+msgid "Wait for an event"
+msgstr ""
+
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
+msgid "count or seconds"
+msgstr ""
+
+#: gphoto2/shell.c:162
+msgid "Wait for images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:163
+msgid "Wait for events and images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:488
+msgid "Invalid command."
+msgstr "Mandato no v√°lido."
+
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
-msgstr "El mandato ´%sª precisa de un argumento."
+msgstr "El mandato ¬´%s¬ª precisa de un argumento."
 
-#: gphoto2/shell.c:483
+#: gphoto2/shell.c:550
 msgid "Invalid path."
-msgstr "Ruta no v·lida."
+msgstr "Ruta no v√°lida."
 
-#: gphoto2/shell.c:529
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "No se puede encontrar el directorio inicial."
 
-#: gphoto2/shell.c:537
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
-msgstr "No se puede cambiar al directorio local ´%sª."
+msgstr "No se puede cambiar al directorio local ¬´%s¬ª."
 
-#: gphoto2/shell.c:540
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
-msgstr "El directorio local es ahora ´%sª."
+msgstr "El directorio local es ahora ¬´%s¬ª."
 
-#: gphoto2/shell.c:578
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
-msgstr "El directorio remoto es ahora ´%sª."
+msgstr "El directorio remoto es ahora ¬´%s¬ª."
 
-#: gphoto2/shell.c:734
+#: gphoto2/shell.c:874
+#, c-format
+msgid "set-config needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:895
+#, c-format
+msgid "set-config-value needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:916
+#, c-format
+msgid "set-config-index needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "No se ha encontrado el mandato ´%sª. Utilice ´helpª para obtener una lista de los mandatos disponibles."
+msgstr ""
+"No se ha encontrado el mandato ¬´%s¬ª. Utilice ¬´help¬ª para obtener una lista "
+"de los mandatos disponibles."
 
-#: gphoto2/shell.c:741
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Ayuda sobre \"%s\":"
 
-#: gphoto2/shell.c:743
+#: gphoto2/shell.c:988
+#, c-format
 msgid "Usage:"
 msgstr "Sintaxis:"
 
-#: gphoto2/shell.c:747
+#: gphoto2/shell.c:991
+#, c-format
 msgid "Description:"
-msgstr "DescripciÛn:"
+msgstr "Descripci√≥n:"
 
-#: gphoto2/shell.c:749
+#: gphoto2/shell.c:993
+#, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Los argumentos entre corchetes [] son opcionales"
 
-#: gphoto2/shell.c:770
+#: gphoto2/shell.c:1014
+#, c-format
 msgid "Available commands:"
 msgstr "Mandatos disponibles:"
 
-#: gphoto2/shell.c:775
+#: gphoto2/shell.c:1019
+#, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Para obtener ayuda sobre un mandato en particular, teclee ´help nombre-del-mandatoª."
+msgstr ""
+"Para obtener ayuda sobre un mandato en particular, teclee ¬´help nombre-del-"
+"mandato¬ª."
+
+#, c-format
+#~ msgid "There are no folders in folder '%s'."
+#~ msgstr "No hay ninguna carpeta en la carpeta ¬´%s¬ª."
+
+#, c-format
+#~ msgid "There are %i folders in folder '%s':"
+#~ msgstr "Hay %i carpetas en la carpeta ¬´%s¬ª:"
+
+#, c-format
+#~ msgid "There are %i files in folder '%s':"
+#~ msgstr "Hay %i ficheros en la carpeta ¬´%s¬ª:"
+
+#, c-format
+#~ msgid "  Name:        '%s'\n"
+#~ msgstr "  Nombre:      ¬´%s¬ª\n"
+
+#~ msgid "Displays this help screen"
+#~ msgstr "Muestra esta pantalla de ayuda"
+
+#~ msgid "Display camera abilities"
+#~ msgstr "Mostrar las capacidades de la c√°mara"
+
+#~ msgid "Capture a movie "
+#~ msgstr "Capturar una pel√≠cula "
+
+#~ msgid "Show info"
+#~ msgstr "Mostrar informaci√≥n"
+
+#~ msgid "Summary of camera status"
+#~ msgstr "Resumen del estado de la c√°mara"
+
+#~ msgid "Camera driver manual"
+#~ msgstr "Manual del controlador de la c√°mara"
+
+#~ msgid "About the camera driver"
+#~ msgstr "Acerca del controlador de la c√°mara"
+
+#~ msgid "Jan"
+#~ msgstr "ene"
+
+#~ msgid "January"
+#~ msgstr "enero"
+
+#~ msgid "Feb"
+#~ msgstr "feb"
+
+#~ msgid "February"
+#~ msgstr "febrero"
+
+#~ msgid "Mar"
+#~ msgstr "mar"
+
+#~ msgid "March"
+#~ msgstr "marzo"
+
+#~ msgid "Apr"
+#~ msgstr "abr"
+
+#~ msgid "April"
+#~ msgstr "abril"
+
+#~ msgid "May"
+#~ msgstr "may"
+
+#~ msgid "Jun"
+#~ msgstr "jun"
+
+#~ msgid "June"
+#~ msgstr "junio"
+
+#~ msgid "Jul"
+#~ msgstr "jul"
+
+#~ msgid "July"
+#~ msgstr "julio"
+
+#~ msgid "Aug"
+#~ msgstr "agt"
+
+#~ msgid "August"
+#~ msgstr "agosto"
+
+#~ msgid "Sep"
+#~ msgstr "sep"
+
+#~ msgid "September"
+#~ msgstr "septiembre"
+
+#~ msgid "Oct"
+#~ msgstr "oct"
+
+#~ msgid "October"
+#~ msgstr "octubre"
+
+#~ msgid "Nov"
+#~ msgstr "nov"
+
+#~ msgid "November"
+#~ msgstr "noviembre"
+
+#~ msgid "Dec"
+#~ msgstr "dic"
+
+#~ msgid "December"
+#~ msgstr "diciembre"
+
+#~ msgid "Sun"
+#~ msgstr "dom"
+
+#~ msgid "Sunday"
+#~ msgstr "domingo"
+
+#~ msgid "Monday"
+#~ msgstr "lunes"
+
+#~ msgid "Tue"
+#~ msgstr "mar"
+
+#~ msgid "Tuesday"
+#~ msgstr "martes"
+
+#~ msgid "Wed"
+#~ msgstr "mi√©"
+
+#~ msgid "Wednesday"
+#~ msgstr "mi√©rcoles"
+
+#~ msgid "Thu"
+#~ msgstr "jue"
+
+#~ msgid "Thursday"
+#~ msgstr "jueves"
+
+#~ msgid "Fri"
+#~ msgstr "vie"
+
+#~ msgid "Friday"
+#~ msgstr "viernes"
+
+#~ msgid "Sat"
+#~ msgstr "s√°b"
+
+#~ msgid "Saturday"
+#~ msgstr "s√°bado"
+
+#~ msgid "path"
+#~ msgstr "ruta"
+
+#~ msgid "speed"
+#~ msgstr "velocidad"
+
+#~ msgid "model"
+#~ msgstr "modelo"
+
+#~ msgid "filename"
+#~ msgstr "fichero"
+
+#~ msgid "usbid"
+#~ msgstr "usbid"
+
+#~ msgid "folder"
+#~ msgstr "carpeta"
+
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the "
+#~ "location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgstr ""
+#~ "gPhoto2 para OS/2 necesita que configure la variable de entorno CAMLIBS "
+#~ "con la ubicaci√≥n de las bibliotecas de soporte de las c√°maras. Por "
+#~ "ejemplo SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the "
+#~ "location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgstr ""
+#~ "gPhoto2 para OS/2 necesita que configure la variable de entorno IOLIBS "
+#~ "con la ubicaci√≥n de las bibliotecas de E/S. Por ejemplo SET IOLIBS=C:"
+#~ "\\GPHOTO2\\IOLIB\n"
+
+#~ msgid "Usage:\n"
+#~ msgstr "Sintaxis:\n"
+
+#~ msgid ""
+#~ "Short/long options (& argument)        Description\n"
+#~ "--------------------------------------------------------------------------------\n"
+#~ msgstr ""
+#~ "Opciones cortas/largas (& argumento)   Descripci√≥n\n"
+#~ "--------------------------------------------------------------------------------\n"
+
+#, c-format
+#~ msgid "%-38s %s\n"
+#~ msgstr "%-32s %s\n"
+
+#~ msgid ""
+#~ "--------------------------------------------------------------------------------\n"
+#~ "[Use double-quotes around arguments]        [Picture numbers begin with "
+#~ "one (1)]\n"
+#~ msgstr ""
+#~ "--------------------------------------------------------------------------------\n"
+#~ "[Usar comillas para los arg.]     [Los n√∫meros de imagen comienzan con un "
+#~ "(1)]\n"

--- a/po/eu.po
+++ b/po/eu.po
@@ -6,213 +6,209 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2008-03-24 20:14+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2005-05-11 18:05+0200\n"
 "Last-Translator: Hizkuntza Politikarako Sailburuordetza <hizkpol@ej-gv.es>\n"
 "Language-Team: Basque <translation-team-eu@lists.sourceforge.net>\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: KBabel 1.9.1\n"
 "Plural-Forms: Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "\n"
 
-#: gphoto2/actions.c:167
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "'%s' karpetako fitxategi-kopurua: %i\n"
 
-#: gphoto2/actions.c:187
+#: gphoto2/actions.c:201
 #, fuzzy, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "Karpeta bat dago '%s' karpetan:"
 msgstr[1] "Karpeta bat dago '%s' karpetan:"
 
-#: gphoto2/actions.c:227
+#: gphoto2/actions.c:250
 #, fuzzy, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Fitxategi bat dago '%s' karpetan:"
 
-#: gphoto2/actions.c:230
+#: gphoto2/actions.c:253
 #, fuzzy, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "Fitxategi bat dago '%s' karpetan:"
 msgstr[1] "Fitxategi bat dago '%s' karpetan:"
 
-#: gphoto2/actions.c:251
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "'%s' fitxategiari buruzko informazioa ('%s' karpeta):\n"
 
-#: gphoto2/actions.c:253
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Fitxategia:\n"
 
-#: gphoto2/actions.c:255 gphoto2/actions.c:289 gphoto2/actions.c:305
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Bat ere ez erabilgarri.\n"
 
-#: gphoto2/actions.c:258
-#, c-format
-msgid "  Name:        '%s'\n"
-msgstr "  Izena:        '%s'\n"
-
-#: gphoto2/actions.c:260 gphoto2/actions.c:292
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  MIME mota:   '%s'\n"
 
-#: gphoto2/actions.c:262 gphoto2/actions.c:294
-#, c-format
-msgid "  Size:        %li byte(s)\n"
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#, fuzzy, c-format
+msgid "  Size:        %lu byte(s)\n"
 msgstr "  Tamaina:        %li byte\n"
 
-#: gphoto2/actions.c:264 gphoto2/actions.c:296
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Zabalera:       %i pixel\n"
 
-#: gphoto2/actions.c:266 gphoto2/actions.c:298
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Altuera:       %i pixel\n"
 
-#: gphoto2/actions.c:268 gphoto2/actions.c:300
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Deskargatuta:  %s\n"
 
-#: gphoto2/actions.c:269 gphoto2/actions.c:301 gphoto2/actions.c:313
-#: gphoto2/actions.c:663 gphoto2/actions.c:665 gphoto2/actions.c:693
-#: gphoto2/actions.c:696 gphoto2/actions.c:699 gphoto2/actions.c:702
-#: gphoto2/actions.c:705 gphoto2/actions.c:1511
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "bai"
 
-#: gphoto2/actions.c:269 gphoto2/actions.c:301 gphoto2/actions.c:313
-#: gphoto2/actions.c:663 gphoto2/actions.c:665 gphoto2/actions.c:693
-#: gphoto2/actions.c:696 gphoto2/actions.c:699 gphoto2/actions.c:702
-#: gphoto2/actions.c:705 gphoto2/actions.c:1505
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "ez"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Baimenak: "
 
-#: gphoto2/actions.c:274
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "irakurri/ezabatu"
 
-#: gphoto2/actions.c:276
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "irakurri"
 
-#: gphoto2/actions.c:278
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "ezabatu"
 
-#: gphoto2/actions.c:280
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "bat ere ez"
 
-#: gphoto2/actions.c:284
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Denbora:        %s"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Koadro txikia:\n"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Audio-datuak:\n"
 
-#: gphoto2/actions.c:308
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  MIME mota:   '%s'\n"
 
-#: gphoto2/actions.c:310
-#, c-format
-msgid "  Size:       %li byte(s)\n"
+#: gphoto2/actions.c:332
+#, fuzzy, c-format
+msgid "  Size:       %lu byte(s)\n"
 msgstr "  Tamaina:        %li byte\n"
 
-#: gphoto2/actions.c:312
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Deskargatuta:  %s\n"
 
-#: gphoto2/actions.c:488
+#: gphoto2/actions.c:504
 msgid "Could not parse EXIF data."
 msgstr "Ezin izan dira EXIF datuak analizatu."
 
-#: gphoto2/actions.c:492
+#: gphoto2/actions.c:508
 #, c-format
 msgid "EXIF tags:"
 msgstr "EXIF etiketak:"
 
-#: gphoto2/actions.c:495
+#: gphoto2/actions.c:511
 msgid "Tag"
 msgstr "Etiketa"
 
-#: gphoto2/actions.c:497
+#: gphoto2/actions.c:513
 msgid "Value"
 msgstr "Balioa"
 
-#: gphoto2/actions.c:518
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "EXIF datuek koadro txiki bat dute (%i byte)."
 
-#: gphoto2/actions.c:527
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 EXIFen euskarririk gabe konpilatu da."
 
-#: gphoto2/actions.c:545
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Onartzen diren kameren kopurua: %i\n"
 
-#: gphoto2/actions.c:546
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Onartzen diren kamerak:\n"
 
-#: gphoto2/actions.c:559
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (PROBA)\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (ESPERIMENTALA)\n"
 
-#: gphoto2/actions.c:567
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:611
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Aurkitutako gailuak: %i\n"
 
-#: gphoto2/actions.c:612
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -221,107 +217,112 @@ msgstr ""
 "Bidea                             Azalpena\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:642 gphoto2/actions.c:647
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:642
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Modeloa"
 
-#: gphoto2/actions.c:642
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Ataka"
 
-#: gphoto2/actions.c:643
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Kameraren ahalmenak             : %s\n"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Serieko atakaren euskarria              : %s\n"
 
-#: gphoto2/actions.c:664
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB atakaren euskarria                      : %s\n"
 
-#: gphoto2/actions.c:667
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Onartzen diren transferentzia-abiadurak        :\n"
 
-#: gphoto2/actions.c:669
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:672
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Kapturatze-aukerak                  :\n"
 
-#: gphoto2/actions.c:674
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Irudia\n"
 
-#: gphoto2/actions.c:678
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Bideoa\n"
 
-#: gphoto2/actions.c:682
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Audioa\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Aurrebista\n"
 
-#: gphoto2/actions.c:690
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
+
+#: gphoto2/actions.c:700
 #, c-format
 msgid ""
 "                                 : Capture not supported by the driver\n"
 msgstr ""
 "                                 : Kontrolatzaileak ez du kaptura onartzen\n"
 
-#: gphoto2/actions.c:692
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Konfiguratzeko euskarria            : %s\n"
 
-#: gphoto2/actions.c:694
+#: gphoto2/actions.c:704
 #, fuzzy, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Kamerako fitxategiak ezabatzeko euskarria   : %s\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:707
 #, fuzzy, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Kamerako fitxategiak ezabatzeko euskarria   : %s\n"
 
-#: gphoto2/actions.c:700
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Fitxategiak (koadro txikiak) aurreikusteko euskarria : %s\n"
 
-#: gphoto2/actions.c:703
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Fitxategiak kargatzeko euskarria              : %s\n"
 
-#: gphoto2/actions.c:719
+#: gphoto2/actions.c:730
 #, c-format
 msgid ""
 "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
@@ -330,7 +331,7 @@ msgstr ""
 "Atakek 'serial:/dev/ttyS0' edo 'usb:' itxura izan behar dute, baina '%s'(e)k "
 "bi puntu falta ditu; beraz, zer esan nahi duen asmatzen saiatuko naiz."
 
-#: gphoto2/actions.c:753
+#: gphoto2/actions.c:764
 #, c-format
 msgid ""
 "The port you specified ('%s') can not be found. Please specify one of the "
@@ -341,36 +342,36 @@ msgstr ""
 "ek aurkitutako ataketako bat eta ziurtatu ondo idatzita dagoela (hau da, "
 "'serial:' edo 'usb:' aurrizkiekin)."
 
-#: gphoto2/actions.c:785
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "Kamera-kontrolatzaileari buruz:"
 
-#: gphoto2/actions.c:798
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Kameraren laburpena:"
 
-#: gphoto2/actions.c:811
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Kameraren eskuliburua:"
 
-#: gphoto2/actions.c:826
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Serieko ataketarako abiadurak baino ezin dituzu adierazi."
 
-#: gphoto2/actions.c:879
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "OS/2 ataka Bart van Leeuwen-en eskutik\n"
 
-#: gphoto2/actions.c:883
+#: gphoto2/actions.c:894
 #, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
@@ -393,192 +394,316 @@ msgstr ""
 "Gphoto2-ren bertsio honek hurrengo software-bertsioak eta -aukerak "
 "erabiltzen ditu:\n"
 
-#: gphoto2/actions.c:1004
-#, c-format
-msgid "Getting storage information not supported for this camera.\n"
-msgstr ""
-
-#: gphoto2/actions.c:1019
-#, c-format
-msgid "Read-Write"
-msgstr ""
+#: gphoto2/actions.c:1015
+#, fuzzy
+msgid "Could not open 'movie.mjpg'."
+msgstr "Ezin izan da argazkia eskuratu."
 
 #: gphoto2/actions.c:1022
 #, c-format
-msgid "Read-Only"
+msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1025
+#: gphoto2/actions.c:1026
 #, c-format
-msgid "Read-only with delete"
+msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1028 gphoto2/actions.c:1038
+#: gphoto2/actions.c:1031
 #, c-format
-msgid "Unknown"
-msgstr ""
-
-#: gphoto2/actions.c:1041
-#, c-format
-msgid "Fixed ROM"
-msgstr ""
-
-#: gphoto2/actions.c:1044
-#, c-format
-msgid "Removable ROM"
+msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr ""
 
 #: gphoto2/actions.c:1047
-#, c-format
-msgid "Fixed RAM"
+msgid "Movie capture error... Exiting."
 msgstr ""
 
-#: gphoto2/actions.c:1050
+#: gphoto2/actions.c:1053
 #, c-format
-msgid "Removable RAM"
+msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr ""
 
 #: gphoto2/actions.c:1060
 #, c-format
+msgid "Ctrl-C pressed ... Exiting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1074
+#, c-format
+msgid "Movie capture finished (%d frames)\n"
+msgstr ""
+
+#: gphoto2/actions.c:1106
+#, c-format
+msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1112
+#, c-format
+msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1117
+#, c-format
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1122
+#, c-format
+msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1125
+#, c-format
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1129
+#, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
+#, c-format
+msgid "event found, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
+msgid "Could not set folder."
+msgstr "Ezin izan da karpeta ezarri."
+
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
+msgid "Could not get image."
+msgstr "Ezin izan da argazkia eskuratu."
+
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
+msgid "Buggy libcanon.so?"
+msgstr "libcanon.so akatsduna?"
+
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
+#, fuzzy
+msgid "Could not delete image."
+msgstr "Ezin da argazkia ezabatu."
+
+#: gphoto2/actions.c:1300
+#, c-format
+msgid "Getting storage information not supported for this camera.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1315
+#, c-format
+msgid "Read-Write"
+msgstr ""
+
+#: gphoto2/actions.c:1318
+#, c-format
+msgid "Read-Only"
+msgstr ""
+
+#: gphoto2/actions.c:1321
+#, c-format
+msgid "Read-only with delete"
+msgstr ""
+
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
+#, c-format
+msgid "Unknown"
+msgstr ""
+
+#: gphoto2/actions.c:1337
+#, c-format
+msgid "Fixed ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1340
+#, c-format
+msgid "Removable ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1343
+#, c-format
+msgid "Fixed RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1346
+#, c-format
+msgid "Removable RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1356
+#, c-format
 msgid "Undefined"
 msgstr ""
 
-#: gphoto2/actions.c:1063
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr ""
 
-#: gphoto2/actions.c:1066
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr ""
 
-#: gphoto2/actions.c:1069
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr ""
 
-#: gphoto2/actions.c:1107
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr ""
 "Hornitzailaren/produktuaren USB 0x%x/0x%x IDa 0x%x/0x%x-kin gainidazten"
 
-#: gphoto2/actions.c:1171
+#: gphoto2/actions.c:1474
 msgid ""
 "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
 "MAILING LIST:"
 msgstr "JARRI BETI LERRO HAUEK ARAZKETA-MEZUAK POSTA-ZERRENDARA BIDALTZEAN:"
 
-#: gphoto2/actions.c:1186
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s honeko aukerekin konpilatu da:"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1629
 #, fuzzy, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s ez da konfigurazio-zuhatitzean aurkitu.\n"
 
-#: gphoto2/actions.c:1363
+#: gphoto2/actions.c:1681
 #, fuzzy, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Huts egin du %s testu-trepetaren balioa eskuratzean.\n"
 
-#: gphoto2/actions.c:1380
+#: gphoto2/actions.c:1698
 #, fuzzy, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Huts egin du %s barrutia trepetaren balioa eskuratzean.\n"
 
-#: gphoto2/actions.c:1392
+#: gphoto2/actions.c:1710
 #, fuzzy, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Huts egin du %s txandakatze-trepetaren balioa eskuratzean.\n"
 
-#: gphoto2/actions.c:1404
+#: gphoto2/actions.c:1722
 #, fuzzy, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Huts egin du %s data-/ordu-trepetaren balioa eskuratzean.\n"
 
-#: gphoto2/actions.c:1434
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1753
 #, fuzzy, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Huts egin du %s aukera-trepetaren balioa eskuratzean.\n"
 
-#: gphoto2/actions.c:1475
+#: gphoto2/actions.c:1799
+#, c-format
+msgid "Property %s is read only."
+msgstr ""
+
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, fuzzy, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Huts egin du %s testu-trepetaren balioa eskuratzean.\n"
 
-#: gphoto2/actions.c:1485
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr ""
 
-#: gphoto2/actions.c:1490
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr ""
 
-#: gphoto2/actions.c:1496
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, fuzzy, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Huts egin du %s barrutia trepetaren balioa eskuratzean.\n"
 
-#: gphoto2/actions.c:1505
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr ""
 
-#: gphoto2/actions.c:1506
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 #, fuzzy
 msgid "false"
 msgstr "Balioa"
 
-#: gphoto2/actions.c:1511
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 #, fuzzy
 msgid "on"
 msgstr "al."
 
-#: gphoto2/actions.c:1512
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr ""
 
-#: gphoto2/actions.c:1517
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr ""
 
-#: gphoto2/actions.c:1523
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, fuzzy, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Huts egin du %s txandakatze-trepetaren balioa eskuratzean.\n"
 
-#: gphoto2/actions.c:1536
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
+#, fuzzy
+msgid "now"
+msgstr "ez"
+
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr ""
 
-#: gphoto2/actions.c:1543
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, fuzzy, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Huts egin du %s data-/ordu-trepetaren balioa eskuratzean.\n"
 
-#: gphoto2/actions.c:1580
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr ""
 
-#: gphoto2/actions.c:1588
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr ""
 
-#: gphoto2/actions.c:1595
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, fuzzy, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr "Huts egin du %s aukera-trepetaren balioa eskuratzean.\n"
 
-#: gphoto2/foreach.c:254
+#: gphoto2/actions.c:2019
+#, c-format
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+
+#: gphoto2/foreach.c:260
 #, c-format
 msgid ""
 "Bad file number. You specified %i, but there are only %i files available in "
@@ -589,21 +714,21 @@ msgstr ""
 "daude '%s'(e)n edo haren azpikarpetetan. Lehenbizi, lortu baliozko fitxategi-"
 "zenbaki bat fitxategi-zerrendatik."
 
-#: gphoto2/foreach.c:279
+#: gphoto2/foreach.c:285
 #, c-format
 msgid "There are no files in folder '%s'."
 msgstr "Ez dago fitxategirik '%s' karpetan."
 
-#: gphoto2/foreach.c:285
+#: gphoto2/foreach.c:291
 #, c-format
 msgid ""
-"Bad file number. You specified %i, but there is only 1 file available in '%"
-"s'."
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
 msgstr ""
 "Fitxategi-zenbaki okerra. %i adierazi duzu, baina fitxategi bakarra dago "
 "erabilgarri '%s'(e)n."
 
-#: gphoto2/foreach.c:293
+#: gphoto2/foreach.c:299
 #, fuzzy, c-format
 msgid ""
 "Bad file number. You specified %i, but there are only %i files available in "
@@ -618,7 +743,7 @@ msgstr ""
 msgid "*** Error ***              \n"
 msgstr "*** Errorea ***              \n"
 
-#: gphoto2/gp-params.c:244
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Sakatu edozein tekla jarraitzeko.\n"
@@ -632,185 +757,218 @@ msgstr "Ez dago behar adina memoria."
 msgid "Operation cancelled"
 msgstr "Eragiketa bertan behera utzi da"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Jarraitu"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Utzi"
 
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Errorea"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Ezin izan da konfigurazioa ezarri:"
 
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Irten"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Atzera"
 
-#: gphoto2/gphoto2-cmd-config.c:254
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Denbora: "
 
-#: gphoto2/gphoto2-cmd-config.c:313 gphoto2/gphoto2-cmd-config.c:341
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Balioa: "
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Bai"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Ez"
 
-#: gphoto2/main.c:230
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr ""
 
-#: gphoto2/main.c:239
+#: gphoto2/main.c:229
 #, fuzzy, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr ""
 "Ezin duzu '%%n' erabili iraunkorrak ez diren fitxategiekin konbinatuta!"
 
-#: gphoto2/main.c:255
-#, c-format
-msgid "You cannot use '%%n' in combination with non-persistent files!"
-msgstr ""
-"Ezin duzu '%%n' erabili iraunkorrak ez diren fitxategiekin konbinatuta!"
-
-#: gphoto2/main.c:286
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Kamerak ('%s') emandako fitxategi-izenak ez du atzizkirik!"
 
-#: gphoto2/main.c:341
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "'%s' formatu baliogabea (errorea %i kokalekuan)."
 
-#: gphoto2/main.c:394
+#: gphoto2/main.c:386 gphoto2/main.c:592
+#, fuzzy, c-format
+msgid "Skip existing file %s\n"
+msgstr "Fitxategia honela gordetzen: %s\n"
+
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "%s fitxategia badago. Gainidatzi? [y|n] "
 
-#: gphoto2/main.c:406
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Fitxategi-izen berria zehaztu? [y|n] "
 
-#: gphoto2/main.c:416
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Sartu fitxategi-izen berria: "
 
-#: gphoto2/main.c:422
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Fitxategia honela gordetzen: %s\n"
 
-#: gphoto2/main.c:607
-#, c-format
-msgid "Time-lapse mode enabled (interval: %ds).\n"
-msgstr "Denbora-etena modua gaituta (tartea: %ds).\n"
+#: gphoto2/main.c:630
+#, fuzzy
+msgid "Permission denied"
+msgstr "  Baimenak: "
 
-#: gphoto2/main.c:610
-#, c-format
-msgid "Standing by waiting for SIGUSR1 to capture.\n"
-msgstr ""
-
-#: gphoto2/main.c:619
-#, c-format
-msgid "Capturing frame #%d...\n"
-msgstr "#%d fotograma kapturatzen...\n"
-
-#: gphoto2/main.c:621
-#, c-format
-msgid "Capturing frame #%d/%d...\n"
-msgstr "#%d/%d fotograma kapturatzen...\n"
-
-#: gphoto2/main.c:628
-msgid "Could not capture."
+#: gphoto2/main.c:800
+#, fuzzy
+msgid "Could not trigger capture."
 msgstr "Ezin izan da kapturatu."
 
-#: gphoto2/main.c:637
-#, c-format
-msgid "Capture failed (auto-focus problem?)...\n"
-msgstr "Huts egin du kapturatzean (auto-enfokatze arazoa?)...\n"
-
-#: gphoto2/main.c:651
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Fitxategi berria %s%s%s kokapenean dago kameran\n"
 
-#: gphoto2/main.c:661 gphoto2/main.c:814
-msgid "Could not set folder."
-msgstr "Ezin izan da karpeta ezarri."
+#: gphoto2/main.c:847 gphoto2/main.c:878
+#, fuzzy, c-format
+msgid "Keeping file %s%s%s on the camera\n"
+msgstr "Kamerako %s%s%s fitxategia ezabatzen\n"
 
-#: gphoto2/main.c:686 gphoto2/main.c:820
-msgid "Could not get image."
-msgstr "Ezin izan da argazkia eskuratu."
-
-#: gphoto2/main.c:693 gphoto2/main.c:827
-msgid "Buggy libcanon.so?"
-msgstr "libcanon.so akatsduna?"
-
-#: gphoto2/main.c:699
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Kamerako %s%s%s fitxategia ezabatzen\n"
 
-#: gphoto2/main.c:704 gphoto2/main.c:836
-#, fuzzy
-msgid "Could not delete image."
-msgstr "Ezin da argazkia ezabatu."
-
-#: gphoto2/main.c:724
-msgid "Could not close camera connection."
-msgstr "Ezin izan da kameraren konexioa itxi."
-
-#: gphoto2/main.c:738
+#: gphoto2/main.c:911
 #, c-format
-msgid "Sleeping for %d second(s)...\n"
-msgstr "%d segundo lotan...\n"
-
-#: gphoto2/main.c:743 gphoto2/main.c:771
-#, c-format
-msgid "Awakened by SIGUSR1...\n"
+msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr ""
 
-#: gphoto2/main.c:746
+#: gphoto2/main.c:916
 #, c-format
-msgid "not sleeping (%d seconds behind schedule)\n"
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
 msgstr ""
 
-#: gphoto2/main.c:788
+#: gphoto2/main.c:926
 #, c-format
-msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
-msgstr ""
-
-#: gphoto2/main.c:808
-#, c-format
-msgid "New file %s/%s, downloading...\n"
+msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr ""
 
 #: gphoto2/main.c:932
 #, c-format
+msgid "Unknown event type %d during bulb wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:950
+#, fuzzy
+msgid "Could not get capabilities?"
+msgstr "Ezin izan da argazkia eskuratu."
+
+#: gphoto2/main.c:958
+#, c-format
+msgid "Time-lapse mode enabled (interval: %ds).\n"
+msgstr "Denbora-etena modua gaituta (tartea: %ds).\n"
+
+#: gphoto2/main.c:961
+#, c-format
+msgid "Standing by waiting for SIGUSR1 to capture.\n"
+msgstr ""
+
+#: gphoto2/main.c:967
+#, fuzzy, c-format
+msgid "Bulb mode enabled (exposure time: %ds).\n"
+msgstr "Denbora-etena modua gaituta (tartea: %ds).\n"
+
+#: gphoto2/main.c:975
+#, c-format
+msgid "Capturing frame #%d...\n"
+msgstr "#%d fotograma kapturatzen...\n"
+
+#: gphoto2/main.c:977
+#, c-format
+msgid "Capturing frame #%d/%d...\n"
+msgstr "#%d/%d fotograma kapturatzen...\n"
+
+#: gphoto2/main.c:987
+#, fuzzy, c-format
+msgid "Could not set bulb capture, result %d."
+msgstr "Ezin izan da kapturatu."
+
+#: gphoto2/main.c:1001
+#, fuzzy
+msgid "Could not end capture (bulb mode)."
+msgstr "Ezin izan da kapturatu."
+
+#: gphoto2/main.c:1014
+#, fuzzy
+msgid "Could not trigger image capture."
+msgstr "Ezin izan da argazkia eskuratu."
+
+#: gphoto2/main.c:1021
+#, fuzzy
+msgid "Could not capture image."
+msgstr "Ezin izan da kapturatu."
+
+#: gphoto2/main.c:1028
+#, c-format
+msgid "Capture failed (auto-focus problem?)...\n"
+msgstr "Huts egin du kapturatzean (auto-enfokatze arazoa?)...\n"
+
+#: gphoto2/main.c:1039
+msgid "Could not capture."
+msgstr "Ezin izan da kapturatu."
+
+#: gphoto2/main.c:1074
+#, c-format
+msgid "Waiting for next capture slot %ld seconds...\n"
+msgstr ""
+
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
+#, c-format
+msgid "Awakened by SIGUSR1...\n"
+msgstr ""
+
+#: gphoto2/main.c:1096
+#, c-format
+msgid "not sleeping (%ld seconds behind schedule)\n"
+msgstr ""
+
+#: gphoto2/main.c:1240
+#, c-format
 msgid "ERROR: "
 msgstr "ERROREA: "
 
-#: gphoto2/main.c:955
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -819,12 +977,12 @@ msgstr ""
 "\n"
 "Abortatzen...\n"
 
-#: gphoto2/main.c:961
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Abortatu da.\n"
 
-#: gphoto2/main.c:966
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -833,7 +991,7 @@ msgstr ""
 "\n"
 "Bertan behera uzten...\n"
 
-#: gphoto2/main.c:1104
+#: gphoto2/main.c:1426
 #, c-format
 msgid ""
 "Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
@@ -843,16 +1001,23 @@ msgstr ""
 "tratatzeko. a b c d elementuek hasieran '0x'duten zenbaki hamaseitarrak izan "
 "behar dute.\n"
 
-#: gphoto2/main.c:1258
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 CDKren euskarririk gabe konpilatu da."
 
-#: gphoto2/main.c:1446
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Eragiketa bertan behera utzi da.\n"
 
-#: gphoto2/main.c:1450
+#: gphoto2/main.c:1883
+#, c-format
+msgid ""
+"*** Error: No camera found. ***\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -861,7 +1026,7 @@ msgstr ""
 "*** Errorea (%i: '%s') ***       \n"
 "\n"
 
-#: gphoto2/main.c:1454
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -878,340 +1043,427 @@ msgstr ""
 "honela gphoto2:\n"
 "\n"
 
-#: gphoto2/main.c:1543
+#: gphoto2/main.c:1911
+#, c-format
+msgid ""
+"Please make sure there is sufficient quoting around the arguments.\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr ""
 
-#: gphoto2/main.c:1545
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr ""
 
-#: gphoto2/main.c:1547
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Aktibatu arazketa"
 
-#: gphoto2/main.c:1549
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
+
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr ""
 
-#: gphoto2/main.c:1549 gphoto2/main.c:1554 gphoto2/main.c:1560
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr ""
 
-#: gphoto2/main.c:1551
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Irteera isila (lehenetsia=xehatua)"
 
-#: gphoto2/main.c:1553
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr ""
 
-#: gphoto2/main.c:1560
-msgid "Specify port device"
+#: gphoto2/main.c:1997
+#, fuzzy
+msgid "Specify device port"
 msgstr "Zehaztu ataka-gailua"
 
-#: gphoto2/main.c:1562
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Zehaztu serieko transferentzia-abiadura"
 
-#: gphoto2/main.c:1562
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr ""
 
-#: gphoto2/main.c:1564
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Zehaztu kamera-modeloa"
 
-#: gphoto2/main.c:1564
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr ""
 
-#: gphoto2/main.c:1566
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(adituak soilik) Ez ikusi egin USBren IDei"
 
-#: gphoto2/main.c:1566
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr ""
 
-#: gphoto2/main.c:1572
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Bistaratu bertsioa eta irten"
 
-#: gphoto2/main.c:1574
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Erakutsi onartutako kamera-modeloen zerrenda"
 
-#: gphoto2/main.c:1576
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Erakutsi onartutako ataka-gailuen zerrenda"
 
-#: gphoto2/main.c:1578
+#: gphoto2/main.c:2015
 #, fuzzy
-msgid "Display camera/driver abilities"
+msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Bistaratu kameraren ahalmenak"
 
-#: gphoto2/main.c:1585
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Konfiguratu"
 
-#: gphoto2/main.c:1588
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Konfigurazio-zuhaitzaren zerrenda"
 
-#: gphoto2/main.c:1590
+#: gphoto2/main.c:2027
+#, fuzzy
+msgid "Dump full configuration tree"
+msgstr "Konfigurazio-zuhaitzaren zerrenda"
+
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Lortu konfigurazio-balioa"
 
-#: gphoto2/main.c:1592
+#: gphoto2/main.c:2031
+#, fuzzy
+msgid "Set configuration value or index in choices"
+msgstr "Lortu konfigurazio-balioa"
+
+#: gphoto2/main.c:2033
+#, fuzzy
+msgid "Set configuration value index in choices"
+msgstr "Lortu konfigurazio-balioa"
+
+#: gphoto2/main.c:2035
 #, fuzzy
 msgid "Set configuration value"
 msgstr "Lortu konfigurazio-balioa"
 
-#: gphoto2/main.c:1598
-msgid "Wait for event from camera"
+#: gphoto2/main.c:2037
+msgid "Reset device port"
 msgstr ""
 
-#: gphoto2/main.c:1601
+#: gphoto2/main.c:2043
+msgid "Keep images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2045
+msgid "Keep RAW images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2047
+msgid "Remove images from camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2049
+msgid "Wait for event(s) from camera"
+msgstr ""
+
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
+
+#: gphoto2/main.c:2051
+msgid "Wait for event(s) from the camera and download new images"
+msgstr ""
+
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Kapturatu aurrebista bat"
 
-#: gphoto2/main.c:1603
-msgid "Set number of frames to capture (default=infinite)"
-msgstr "Ezarri kapturatu beharreko fotograma-kopurua (lehenetsia=infinitua)"
-
-#: gphoto2/main.c:1603
-msgid "COUNT"
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
 msgstr ""
 
-#: gphoto2/main.c:1605
-msgid "Set capture interval in seconds"
+#: gphoto2/main.c:2059
+#, fuzzy
+msgid "Set bulb exposure time in seconds"
 msgstr "Ezarri kapturatze tartea segundotan"
 
-#: gphoto2/main.c:1605
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr ""
 
-#: gphoto2/main.c:1607
+#: gphoto2/main.c:2061
+msgid "Set number of frames to capture (default=infinite)"
+msgstr "Ezarri kapturatu beharreko fotograma-kopurua (lehenetsia=infinitua)"
+
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr ""
+
+#: gphoto2/main.c:2063
+msgid "Set capture interval in seconds"
+msgstr "Ezarri kapturatze tartea segundotan"
+
+#: gphoto2/main.c:2065
 #, fuzzy
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Ezarri kapturatze tartea segundotan"
 
-#: gphoto2/main.c:1609
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Kapturatu irudi bat"
 
-#: gphoto2/main.c:1611
+#: gphoto2/main.c:2069
+#, fuzzy
+msgid "Trigger capture of an image"
+msgstr "Kapturatu irudi bat"
+
+#: gphoto2/main.c:2071
+#, fuzzy
+msgid "Capture an image and download it"
+msgstr "Kapturatu irudi bat"
+
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Kapturatu film bat"
 
-#: gphoto2/main.c:1613
+#: gphoto2/main.c:2073
+msgid "COUNT or SECONDS"
+msgstr ""
+
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Kapturatu audio-klip bat"
 
-#: gphoto2/main.c:1615
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr ""
 
-#: gphoto2/main.c:1621
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Erakutsi karpeten zerrenda karpetan"
 
-#: gphoto2/main.c:1623
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Erakutsi fitxategien zerrenda karpetan"
 
-#: gphoto2/main.c:1625
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Sortu direktorio bat"
 
-#: gphoto2/main.c:1625 gphoto2/main.c:1627
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr ""
 
-#: gphoto2/main.c:1627
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Kendu direktorio bat"
 
-#: gphoto2/main.c:1629
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Bistaratu fitxategi-kopurua"
 
-#: gphoto2/main.c:1631
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Eskuratu bitarteko fitxategiak"
 
-#: gphoto2/main.c:1631 gphoto2/main.c:1635 gphoto2/main.c:1640
-#: gphoto2/main.c:1647 gphoto2/main.c:1653 gphoto2/main.c:1658
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr ""
 
-#: gphoto2/main.c:1633
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Eskuratu karpetako fitxategi guztiak"
 
-#: gphoto2/main.c:1635
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Eskuratu bitarteko koadro txikiak"
 
-#: gphoto2/main.c:1638
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Eskuratu karpetako koadro txiki guztiak"
 
-#: gphoto2/main.c:1640
+#: gphoto2/main.c:2102
 #, fuzzy
 msgid "Get metadata given in range"
 msgstr "Eskuratu bitarteko formaturik gabeko datuak"
 
-#: gphoto2/main.c:1642
+#: gphoto2/main.c:2104
 #, fuzzy
 msgid "Get all metadata from folder"
 msgstr "Eskuratu karpetako formaturik gabeko datu guztiak"
 
-#: gphoto2/main.c:1644
+#: gphoto2/main.c:2106
 #, fuzzy
 msgid "Upload metadata for file"
 msgstr "Deskargatu fitxategi bat"
 
-#: gphoto2/main.c:1647
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Eskuratu bitarteko formaturik gabeko datuak"
 
-#: gphoto2/main.c:1650
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Eskuratu karpetako formaturik gabeko datu guztiak"
 
-#: gphoto2/main.c:1653
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Eskuratu bitarteko audio-datuak"
 
-#: gphoto2/main.c:1656
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Eskuratu karpetako audio-datu guztiak"
 
-#: gphoto2/main.c:1658
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Ezabatu bitarteko fitxategiak"
 
-#: gphoto2/main.c:1660
-msgid "Delete all files in folder"
+#: gphoto2/main.c:2122
+#, fuzzy
+msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Ezabatu karpetako fitxategi guztiak"
 
-#: gphoto2/main.c:1662
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Kargatu fitxategi bat kameran"
 
-#: gphoto2/main.c:1662
-msgid "filename"
-msgstr "fitxategi-izena"
-
-#: gphoto2/main.c:1664
+#: gphoto2/main.c:2126
 #, fuzzy
 msgid "Specify a filename or filename pattern"
 msgstr "Zehaztu fitxategi-izen bat"
 
-#: gphoto2/main.c:1664
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr ""
 
-#: gphoto2/main.c:1666
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Zehaztu kameraren karpeta (lehenetsia=\"/\")"
 
-#: gphoto2/main.c:1666
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr ""
 
-#: gphoto2/main.c:1668
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Errekurtsioa (lehenetsia deskargatzeko)"
 
-#: gphoto2/main.c:1670
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Errekurtsiorik ez (lehenetsia ezabatzeko)"
 
-#: gphoto2/main.c:1672
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr ""
 
-#: gphoto2/main.c:1674
+#: gphoto2/main.c:2138
 #, fuzzy
 msgid "Overwrite files without asking"
 msgstr "Gainidatzi fitxategiak galdetu gabe."
 
-#: gphoto2/main.c:1680
+#: gphoto2/main.c:2140
+msgid "Skip existing files"
+msgstr ""
+
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Bidali fitxategia irteera estandarrera"
 
-#: gphoto2/main.c:1682
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Inprimatu fitxategi-tamaina datuen aurretik"
 
-#: gphoto2/main.c:1684
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Erakutsi automatikoki detektatutako kameren zerrenda"
 
-#: gphoto2/main.c:1688 gphoto2/shell.c:132
-msgid "Show EXIF information"
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
 msgstr "Erakutsi EXIF informazioa"
 
-#: gphoto2/main.c:1691 gphoto2/shell.c:126
-msgid "Show info"
-msgstr "Erakutsi informazioa"
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
 
-#: gphoto2/main.c:1693
-msgid "Show summary"
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "Erakutsi laburpena"
 
-#: gphoto2/main.c:1695
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Erakutsi kamera-kontrolatzailearen eskuliburua"
 
-#: gphoto2/main.c:1697
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Kamera-kontrolatzailearen eskuliburuari buruz"
 
-#: gphoto2/main.c:1699
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 #, fuzzy
 msgid "Show storage information"
 msgstr "Erakutsi EXIF informazioa"
 
-#: gphoto2/main.c:1701
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "gPhoto shell-a"
 
-#: gphoto2/main.c:1707
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr ""
 
-#: gphoto2/main.c:1709
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr ""
 
-#: gphoto2/main.c:1711
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr ""
 
-#: gphoto2/main.c:1713
+#: gphoto2/main.c:2179
 #, fuzzy
 msgid "Specify the camera to use"
 msgstr "Zehaztu kamera-modeloa"
 
-#: gphoto2/main.c:1715
+#: gphoto2/main.c:2181
 #, fuzzy
 msgid "Camera and software configuration"
 msgstr "Ezin izan da konfigurazioa ezarri:"
 
-#: gphoto2/main.c:1717
+#: gphoto2/main.c:2183
 #, fuzzy
 msgid "Capture an image from or on the camera"
 msgstr "Aldatu kamerako direktorio batera"
 
-#: gphoto2/main.c:1719
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr ""
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1220,7 +1472,7 @@ msgstr ""
 "%s\n"
 "Irudi-IDek zero baino handiagoak izan behar dute."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1229,7 +1481,7 @@ msgstr ""
 "%s\n"
 " %i irudi-IDa handiegia da."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1238,7 +1490,7 @@ msgstr ""
 "%s\n"
 "Bitarteak',' ikurren bidez bereizi behar dira."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1247,7 +1499,7 @@ msgstr ""
 "%s\n"
 "Bitarteek zenbaki batekin hasi behar dute."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1256,7 +1508,7 @@ msgstr ""
 "%s\n"
 " '%c' ustekabeko karakterea."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -1266,183 +1518,256 @@ msgstr ""
 "Beheranzko bitarteak ez dira onartzen. %i eta %i arteko bitartea zehaztu "
 "duzu."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Errorea (%i: '%s') ***"
 
-#: gphoto2/shell.c:115
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Aldatu kamerako direktorio batera"
 
-#: gphoto2/shell.c:116 gphoto2/shell.c:118 gphoto2/shell.c:129
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "direktorioa"
 
-#: gphoto2/shell.c:117
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Aldatu unitate lokaleko direktorio batera"
 
-#: gphoto2/shell.c:119 gphoto2/shell.c:143 gphoto2/shell.c:144
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Irten gPhoto shell-etik"
 
-#: gphoto2/shell.c:120
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Deskargatu fitxategi bat"
 
-#: gphoto2/shell.c:120 gphoto2/shell.c:121 gphoto2/shell.c:123
-#: gphoto2/shell.c:125 gphoto2/shell.c:127 gphoto2/shell.c:128
-#: gphoto2/shell.c:133
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[direktorioa/]fitxategi-izena"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:132
 #, fuzzy
 msgid "Upload a file"
 msgstr "Deskargatu fitxategi bat"
 
-#: gphoto2/shell.c:122
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Deskargatu koadro txiki bat"
 
-#: gphoto2/shell.c:124
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Deskargatu formaturik gabeko datuak"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Ezabatu"
 
-#: gphoto2/shell.c:129
+#: gphoto2/shell.c:140
 #, fuzzy
 msgid "Create Directory"
 msgstr "Sortu direktorio bat"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:141
 #, fuzzy
 msgid "Remove Directory"
 msgstr "Kendu direktorio bat"
 
-#: gphoto2/shell.c:135 gphoto2/shell.c:145
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Bistaratu komandoen erabilera"
 
-#: gphoto2/shell.c:136 gphoto2/shell.c:145
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[komandoa]"
 
-#: gphoto2/shell.c:137
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Egin uneko direktorioaren edukien zerrenda"
 
-#: gphoto2/shell.c:138
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[direktorioa/]"
 
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:152
 #, fuzzy
 msgid "List configuration variables"
 msgstr "Lortu konfigurazio aldagaia"
 
-#: gphoto2/shell.c:140
+#: gphoto2/shell.c:153
 #, fuzzy
 msgid "Get configuration variable"
 msgstr "Lortu konfigurazio aldagaia"
 
-#: gphoto2/shell.c:140
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "izena"
 
-#: gphoto2/shell.c:141
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 #, fuzzy
 msgid "Set configuration variable"
 msgstr "Lortu konfigurazio aldagaia"
 
-#: gphoto2/shell.c:141
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr ""
 
-#: gphoto2/shell.c:142
+#: gphoto2/shell.c:155
+#, fuzzy
+msgid "Set configuration variable index"
+msgstr "Lortu konfigurazio aldagaia"
+
+#: gphoto2/shell.c:155
+msgid "name=valueindex"
+msgstr ""
+
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Kapturatu irudi bat"
+
+#: gphoto2/shell.c:158
 #, fuzzy
 msgid "Capture a single image"
 msgstr "Kapturatu irudi bat"
 
-#: gphoto2/shell.c:467
+#: gphoto2/shell.c:159
+#, fuzzy
+msgid "Capture a single image and download it"
+msgstr "Kapturatu irudi bat"
+
+#: gphoto2/shell.c:160
+#, fuzzy
+msgid "Capture a preview image"
+msgstr "Kapturatu irudi bat"
+
+#: gphoto2/shell.c:161
+msgid "Wait for an event"
+msgstr ""
+
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
+#, fuzzy
+msgid "count or seconds"
+msgstr "segundo"
+
+#: gphoto2/shell.c:162
+msgid "Wait for images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:163
+msgid "Wait for events and images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Komando baliogabea."
 
-#: gphoto2/shell.c:476
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "'%s' komandoak argumentu bat behar du."
 
-#: gphoto2/shell.c:529
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Bide baliogabea."
 
-#: gphoto2/shell.c:575
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Ezin izan da aurkitu etxeko direktorioa."
 
-#: gphoto2/shell.c:584
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Ezin izan da '%s' direktorio lokala aldatu."
 
-#: gphoto2/shell.c:587
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Orain direktorio lokala '%s' da."
 
-#: gphoto2/shell.c:625
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Orain urruneko direktorioa '%s' da."
 
-#: gphoto2/shell.c:841
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr ""
 
-#: gphoto2/shell.c:870
+#: gphoto2/shell.c:895
+#, c-format
+msgid "set-config-value needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:916
+#, c-format
+msgid "set-config-index needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
 msgstr ""
 "'%s' komandoa ez da aurkitu. Erabili 'help' erabilgarri dauden komandoen "
 "zerrenda lortzeko."
 
-#: gphoto2/shell.c:877
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "\"%s\"(r)i buruzko laguntza:"
 
-#: gphoto2/shell.c:879
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Erabilera:"
 
-#: gphoto2/shell.c:882
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Azalpena:"
 
-#: gphoto2/shell.c:884
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Kortxete [] arteko argumentuak hautazkoak dira"
 
-#: gphoto2/shell.c:905
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Erabilgarri dauden komandoak:"
 
-#: gphoto2/shell.c:910
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr ""
 "Komando jakin bati buruzko laguntza eskuratzeko, idatzi'help komando_izena'."
+
+#, c-format
+#~ msgid "  Name:        '%s'\n"
+#~ msgstr "  Izena:        '%s'\n"
+
+#, c-format
+#~ msgid "You cannot use '%%n' in combination with non-persistent files!"
+#~ msgstr ""
+#~ "Ezin duzu '%%n' erabili iraunkorrak ez diren fitxategiekin konbinatuta!"
+
+#~ msgid "Could not close camera connection."
+#~ msgstr "Ezin izan da kameraren konexioa itxi."
+
+#, c-format
+#~ msgid "Sleeping for %d second(s)...\n"
+#~ msgstr "%d segundo lotan...\n"
+
+#~ msgid "filename"
+#~ msgstr "fitxategi-izena"
+
+#~ msgid "Show info"
+#~ msgstr "Erakutsi informazioa"
 
 #, fuzzy
 #~ msgid "[name]"
@@ -1516,9 +1841,6 @@ msgstr ""
 
 #~ msgid "count"
 #~ msgstr "Zenbatu"
-
-#~ msgid "seconds"
-#~ msgstr "segundo"
 
 #~ msgid ""
 #~ "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the "

--- a/po/fi.po
+++ b/po/fi.po
@@ -1,213 +1,213 @@
 # Finnish translation for gphoto2.
 # Copyright (C) 2004 Free Software Foundation, Inc.
 # This file is distributed under the same license as the gphoto2 package.
-# Matti Pˆll‰ <mpo@iki.fi>, 2004.
+# Matti P√∂ll√§ <mpo@iki.fi>, 2004.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.1.2\n"
-"POT-Creation-Date: 2003-08-10 20:58+0200\n"
+"Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2004-07-07 01:46+0300\n"
-"Last-Translator: Matti Pˆll‰ <mpo@iki.fi>\n"
+"Last-Translator: Matti P√∂ll√§ <mpo@iki.fi>\n"
 "Language-Team: Finnish <translation-team-fi@lists.sourceforge.net>\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 
-#: gphoto2/actions.c:101
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
-msgstr "Kansiossa \"%s\" olevien tiedostojen lukum‰‰r‰:†%i\n"
+msgstr "Kansiossa \"%s\" olevien tiedostojen lukum√§√§r√§:¬†%i\n"
 
-#: gphoto2/actions.c:122
-#, c-format
-msgid "There are no folders in folder '%s'."
-msgstr "Kansio \"%s\" ei sis‰ll‰†kansioita."
+#: gphoto2/actions.c:201
+#, fuzzy, c-format
+msgid "There is %d folder in folder '%s'.\n"
+msgid_plural "There are %d folders in folder '%s'.\n"
+msgstr[0] "Kansio \"%s\" sis√§lt√§√§¬†yhden kansion:"
+msgstr[1] "Kansio \"%s\" sis√§lt√§√§¬†yhden kansion:"
 
-#: gphoto2/actions.c:126
-#, c-format
-msgid "There is one folder in folder '%s':"
-msgstr "Kansio \"%s\" sis‰lt‰‰†yhden kansion:"
+#: gphoto2/actions.c:250
+#, fuzzy, c-format
+msgid "There is no file in folder '%s'.\n"
+msgstr "Kansio \"%s\" sis√§lt√§√§¬†yhden tiedoston:"
 
-#: gphoto2/actions.c:130
-#, c-format
-msgid "There are %i folders in folder '%s':"
-msgstr "%i kansiota kansiossa \"%s\":"
+#: gphoto2/actions.c:253
+#, fuzzy, c-format
+msgid "There is %d file in folder '%s'.\n"
+msgid_plural "There are %d files in folder '%s'.\n"
+msgstr[0] "Kansio \"%s\" sis√§lt√§√§¬†yhden tiedoston:"
+msgstr[1] "Kansio \"%s\" sis√§lt√§√§¬†yhden tiedoston:"
 
-#: gphoto2/actions.c:157 gphoto2/foreach.c:277
-#, c-format
-msgid "There are no files in folder '%s'."
-msgstr "Kansio \"%s\" ei sis‰ll‰†tiedostoja."
-
-#: gphoto2/actions.c:162
-#, c-format
-msgid "There is one file in folder '%s':"
-msgstr "Kansio \"%s\" sis‰lt‰‰†yhden tiedoston:"
-
-#: gphoto2/actions.c:167
-#, c-format
-msgid "There are %i files in folder '%s':"
-msgstr "%i tiedostoa kansiossa \"%s\":"
-
-#: gphoto2/actions.c:188
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Tiedoston \"%s\" tiedot (kansio \"%s\"):\n"
 
-#: gphoto2/actions.c:190
+#: gphoto2/actions.c:277
+#, c-format
 msgid "File:\n"
 msgstr "Tiedosto:\n"
 
-#: gphoto2/actions.c:192 gphoto2/actions.c:226 gphoto2/actions.c:242
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
+#, c-format
 msgid "  None available.\n"
 msgstr "  Ei saatavilla.\n"
 
-#: gphoto2/actions.c:195
-#, c-format
-msgid "  Name:        '%s'\n"
-msgstr "  Nimi:        \"%s\"\n"
-
-#: gphoto2/actions.c:197 gphoto2/actions.c:229
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Mime-tyyppi:   \"%s\"\n"
 
-#: gphoto2/actions.c:199 gphoto2/actions.c:231
-#, c-format
-msgid "  Size:        %li byte(s)\n"
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#, fuzzy, c-format
+msgid "  Size:        %lu byte(s)\n"
 msgstr "  Koko:        %li tavu(a)\n"
 
-#: gphoto2/actions.c:201 gphoto2/actions.c:233
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
-msgstr "  Leveys:       %i pikseli(‰)\n"
+msgstr "  Leveys:       %i pikseli(√§)\n"
 
-#: gphoto2/actions.c:203 gphoto2/actions.c:235
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
-msgstr "  Korkeus:      %i pikseli(‰)\n"
+msgstr "  Korkeus:      %i pikseli(√§)\n"
 
-#: gphoto2/actions.c:205 gphoto2/actions.c:237
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Ladattu:  %s\n"
 
-#: gphoto2/actions.c:206 gphoto2/actions.c:238 gphoto2/actions.c:250
-#: gphoto2/actions.c:548 gphoto2/actions.c:550 gphoto2/actions.c:567
-#: gphoto2/actions.c:570 gphoto2/actions.c:573 gphoto2/actions.c:576
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
-msgstr "kyll‰"
+msgstr "kyll√§"
 
-#: gphoto2/actions.c:206 gphoto2/actions.c:238 gphoto2/actions.c:250
-#: gphoto2/actions.c:548 gphoto2/actions.c:550 gphoto2/actions.c:567
-#: gphoto2/actions.c:570 gphoto2/actions.c:573 gphoto2/actions.c:576
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "ei"
 
-#: gphoto2/actions.c:208
+#: gphoto2/actions.c:293
+#, c-format
 msgid "  Permissions: "
 msgstr "  Oikeudet: "
 
-#: gphoto2/actions.c:211
+#: gphoto2/actions.c:296
+#, c-format
 msgid "read/delete"
 msgstr "luku/poistaminen"
 
-#: gphoto2/actions.c:213
+#: gphoto2/actions.c:298
+#, c-format
 msgid "read"
 msgstr "luku"
 
-#: gphoto2/actions.c:215
+#: gphoto2/actions.c:300
+#, c-format
 msgid "delete"
 msgstr "poistaminen"
 
-#: gphoto2/actions.c:217
+#: gphoto2/actions.c:302
+#, c-format
 msgid "none"
-msgstr "ei mit‰‰n"
+msgstr "ei mit√§√§n"
 
-#: gphoto2/actions.c:221
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Aika:        %s"
 
-#: gphoto2/actions.c:224
+#: gphoto2/actions.c:309
+#, c-format
 msgid "Thumbnail:\n"
 msgstr "Pienoiskuva:\n"
 
-#: gphoto2/actions.c:240
+#: gphoto2/actions.c:325
+#, c-format
 msgid "Audio data:\n"
-msgstr "ƒ‰nidata:\n"
+msgstr "√Ñ√§nidata:\n"
 
-#: gphoto2/actions.c:245
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Mime-tyyppi:  \"%s\"\n"
 
-#: gphoto2/actions.c:247
-#, c-format
-msgid "  Size:       %li byte(s)\n"
+#: gphoto2/actions.c:332
+#, fuzzy, c-format
+msgid "  Size:       %lu byte(s)\n"
 msgstr "  Koko:       %li tavu(a)\n"
 
-#: gphoto2/actions.c:249
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Ladattu: %s\n"
 
-#: gphoto2/actions.c:380
+#: gphoto2/actions.c:504
 msgid "Could not parse EXIF data."
-msgstr "EXIF-tietojen j‰sent‰minen ei onnistunut."
+msgstr "EXIF-tietojen j√§sent√§minen ei onnistunut."
 
-#: gphoto2/actions.c:384
+#: gphoto2/actions.c:508
+#, c-format
 msgid "EXIF tags:"
 msgstr "EXIF-merkit:"
 
-#: gphoto2/actions.c:387
+#: gphoto2/actions.c:511
 msgid "Tag"
 msgstr "Merkki"
 
-#: gphoto2/actions.c:389
+#: gphoto2/actions.c:513
 msgid "Value"
 msgstr "Arvo"
 
-#: gphoto2/actions.c:410
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
-msgstr "EXIF-data sis‰lt‰‰†pienoiskuvan (%i tavua)."
+msgstr "EXIF-data sis√§lt√§√§¬†pienoiskuvan (%i tavua)."
 
-#: gphoto2/actions.c:419
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
-msgstr "gphoto2 on k‰‰netty ilman EXIF-tukea."
+msgstr "gphoto2 on k√§√§netty ilman EXIF-tukea."
 
-#: gphoto2/actions.c:437
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
-msgstr "Tuettujen kameroiden lukum‰‰r‰:†%i\n"
+msgstr "Tuettujen kameroiden lukum√§√§r√§:¬†%i\n"
 
-#: gphoto2/actions.c:439
+#: gphoto2/actions.c:549
+#, c-format
 msgid "Supported cameras:\n"
 msgstr "Tuetut kamerat:\n"
 
-#: gphoto2/actions.c:452
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
-msgstr "\t\"%s\" (TESTIKƒYTT÷)\n"
+msgstr "\t\"%s\" (TESTIK√ÑYTT√ñ)\n"
 
-#: gphoto2/actions.c:455
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (KOKEELLINEN)\n"
 
-#: gphoto2/actions.c:460
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:488
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
-msgstr "Lˆydettyjen laitteiden m‰‰r‰:†%i\n"
+msgstr "L√∂ydettyjen laitteiden m√§√§r√§:¬†%i\n"
 
-#: gphoto2/actions.c:489
+#: gphoto2/actions.c:615
+#, c-format
 msgid ""
 "Path                             Description\n"
 "--------------------------------------------------------------\n"
@@ -215,628 +215,774 @@ msgstr ""
 "Polku                            Kuvaus\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:528 gphoto2/actions.c:533
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:528
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Malli"
 
-#: gphoto2/actions.c:528
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Portti"
 
-#: gphoto2/actions.c:529
+#: gphoto2/actions.c:649
+#, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:546
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Kameran valmiudet                : %s\n"
 
-#: gphoto2/actions.c:547
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Tuki sarjaportille               : %s\n"
 
-#: gphoto2/actions.c:549
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB-tuki                         : %s\n"
 
-#: gphoto2/actions.c:552
+#: gphoto2/actions.c:673
+#, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Tuetut siirtonopeudet            :\n"
 
-#: gphoto2/actions.c:554
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:557
+#: gphoto2/actions.c:678
+#, c-format
 msgid "Capture choices                  :\n"
 msgstr "Kaappausvaihtoehdot              :\n"
 
-#: gphoto2/actions.c:559
+#: gphoto2/actions.c:680
+#, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Kuva\n"
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:684
+#, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:563
+#: gphoto2/actions.c:688
+#, c-format
 msgid "                                 : Audio\n"
-msgstr "                                 : ƒani\n"
+msgstr "                                 : √Ñani\n"
 
-#: gphoto2/actions.c:565
+#: gphoto2/actions.c:692
+#, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Esikatselu\n"
 
-#: gphoto2/actions.c:566
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
+
+#: gphoto2/actions.c:700
+#, fuzzy, c-format
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr "                                 : Esikatselu\n"
+
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Tuki asetusten muuttamiselle     : %s\n"
 
-#: gphoto2/actions.c:568
-#, c-format
-msgid "Delete files on camera support   : %s\n"
+#: gphoto2/actions.c:704
+#, fuzzy, c-format
+msgid "Delete selected files on camera  : %s\n"
 msgstr "Kuvien poistaminen kamerasta     : %s\n"
 
-#: gphoto2/actions.c:571
+#: gphoto2/actions.c:707
+#, fuzzy, c-format
+msgid "Delete all files on camera       : %s\n"
+msgstr "Kuvien poistaminen kamerasta     : %s\n"
+
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Tuki tiedoston esikatselulle     : %s\n"
 
-#: gphoto2/actions.c:574
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr ""
 "Tuki tiedostojen lataamiselle \n"
 "tietokoneelta kameraan           : %s\n"
 
-#: gphoto2/actions.c:591
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
 msgstr ""
 "Portti ilmaistaan esimerkiksi \"serial:/dev/ttyS0\" tai \"usb\", mutta \n"
-"merkkijonosta \"%s\" puuttuu kaksoispiste, joten oikea portti yritet‰‰n\n"
-"lˆyt‰‰†automaattisesti."
+"merkkijonosta \"%s\" puuttuu kaksoispiste, joten oikea portti yritet√§√§n\n"
+"l√∂yt√§√§¬†automaattisesti."
 
-#: gphoto2/actions.c:630
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
 msgstr ""
-"M‰‰rittelem‰‰si porttia (\"%s\") ei lˆydy. M‰‰rittele jokin komennon\n"
+"M√§√§rittelem√§√§si porttia (\"%s\") ei l√∂ydy. M√§√§rittele jokin komennon\n"
 "\"gphoto2 --list-ports\" listaamista porteista ja tarkista kirjoitusasu \n"
 "(esim. etuliite \"serial:\" tai \"usb:\")"
 
-#: gphoto2/actions.c:668
+#: gphoto2/actions.c:797
+#, c-format
 msgid "About the camera driver:"
 msgstr "Tietoa kameran ajurista:"
 
-#: gphoto2/actions.c:682
+#: gphoto2/actions.c:810
+#, c-format
 msgid "Camera summary:"
 msgstr "Kameran kooste:"
 
-#: gphoto2/actions.c:696
-msgid "Camera manual:"
-msgstr "Kameran k‰yttˆohje:"
-
-#: gphoto2/actions.c:712
-msgid "You can only specify speeds for serial ports."
-msgstr "Nopeuden voi m‰‰ritt‰‰†vain sarjaporteille."
-
-#: gphoto2/actions.c:763
+#: gphoto2/actions.c:823
 #, c-format
-msgid ""
-"gphoto2 %s\n"
-"\n"
-"Copyright (c) 2000-2003 Lutz Mueller and others\n"
-"%s\n"
-"gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
-"redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
-"\n"
-"This version of gphoto2 is using the following software versions and options:\n"
-msgstr ""
-"gphoto2 %s\n"
-"\n"
-"Tekij‰noikeus ©†2000-2003 Lutz Mueller ja muut\n"
-"%s\n"
-"\n"
-"T‰ll‰†ohjelmalla EI lain sallimissa rajoissa OLE TAKUUTA.\n"
-"Ohjelmaa saa levitt‰‰†GNU:n General Public Licensen mukaisesti;\n"
-"katso lis‰tietoja tiedostosta COPYING.\n"
-"\n"
-"T‰m‰ gphoto2:n versio k‰ytt‰‰†seuraavia ohjelmistoversioita ja valitsimia:\n"
+msgid "Camera manual:"
+msgstr "Kameran k√§ytt√∂ohje:"
 
-#: gphoto2/actions.c:776
+#: gphoto2/actions.c:840
+#, c-format
+msgid "You can only specify speeds for serial ports."
+msgstr "Nopeuden voi m√§√§ritt√§√§¬†vain sarjaporteille."
+
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "OS/2-siirros Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:890
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
+msgid ""
+"gphoto2 %s\n"
+"\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
+"%s\n"
+"gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
+"redistribute copies of gphoto2 under the terms of the GNU General Public\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
+"\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
-"SISƒLLYTƒ†VIESTIISI AINA SEURAAVAT RIVIT LƒHETTƒESSƒSI VIANETSINTƒ-\n"
-"VIESTEJƒ POSTITUSLISTALLE:"
+"gphoto2 %s\n"
+"\n"
+"Tekij√§noikeus ¬©¬†2000-2003 Lutz Mueller ja muut\n"
+"%s\n"
+"\n"
+"T√§ll√§¬†ohjelmalla EI lain sallimissa rajoissa OLE TAKUUTA.\n"
+"Ohjelmaa saa levitt√§√§¬†GNU:n General Public Licensen mukaisesti;\n"
+"katso lis√§tietoja tiedostosta COPYING.\n"
+"\n"
+"T√§m√§ gphoto2:n versio k√§ytt√§√§¬†seuraavia ohjelmistoversioita ja valitsimia:\n"
 
-#: gphoto2/foreach.c:254
+#: gphoto2/actions.c:1015
+msgid "Could not open 'movie.mjpg'."
+msgstr ""
+
+#: gphoto2/actions.c:1022
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
+msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1026
+#, c-format
+msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1031
+#, c-format
+msgid "Capturing %d preview frames as movie to '%s'.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1047
+msgid "Movie capture error... Exiting."
+msgstr ""
+
+#: gphoto2/actions.c:1053
+#, c-format
+msgid "Movie capture error... Unhandled MIME type '%s'."
+msgstr ""
+
+#: gphoto2/actions.c:1060
+#, c-format
+msgid "Ctrl-C pressed ... Exiting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1074
+#, c-format
+msgid "Movie capture finished (%d frames)\n"
+msgstr ""
+
+#: gphoto2/actions.c:1106
+#, c-format
+msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1112
+#, c-format
+msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1117
+#, c-format
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1122
+#, c-format
+msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1125
+#, c-format
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1129
+#, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
+#, c-format
+msgid "event found, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
+#, fuzzy
+msgid "Could not set folder."
+msgstr "Asetusten p√§ivitys ep√§onistui:"
+
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
+#, fuzzy
+msgid "Could not get image."
+msgstr "Asetusten p√§ivitys ep√§onistui:"
+
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
+msgid "Buggy libcanon.so?"
+msgstr ""
+
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
+#, fuzzy
+msgid "Could not delete image."
+msgstr "Kotikansiota ei l√∂ytynyt."
+
+#: gphoto2/actions.c:1300
+#, c-format
+msgid "Getting storage information not supported for this camera.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1315
+#, c-format
+msgid "Read-Write"
+msgstr ""
+
+#: gphoto2/actions.c:1318
+#, c-format
+msgid "Read-Only"
+msgstr ""
+
+#: gphoto2/actions.c:1321
+#, c-format
+msgid "Read-only with delete"
+msgstr ""
+
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
+#, c-format
+msgid "Unknown"
+msgstr ""
+
+#: gphoto2/actions.c:1337
+#, c-format
+msgid "Fixed ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1340
+#, c-format
+msgid "Removable ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1343
+#, c-format
+msgid "Fixed RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1346
+#, c-format
+msgid "Removable RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1356
+#, c-format
+msgid "Undefined"
+msgstr ""
+
+#: gphoto2/actions.c:1359
+#, c-format
+msgid "Generic Flat"
+msgstr ""
+
+#: gphoto2/actions.c:1362
+#, c-format
+msgid "Generic Hierarchical"
+msgstr ""
+
+#: gphoto2/actions.c:1365
+#, c-format
+msgid "Camera layout (DCIM)"
+msgstr ""
+
+#: gphoto2/actions.c:1406
+#, c-format
+msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
+msgstr ""
+
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"SIS√ÑLLYT√Ñ¬†VIESTIISI AINA SEURAAVAT RIVIT L√ÑHETT√ÑESS√ÑSI VIANETSINT√Ñ-\n"
+"VIESTEJ√Ñ POSTITUSLISTALLE:"
+
+#: gphoto2/actions.c:1489
+#, c-format
+msgid "%s has been compiled with the following options:"
+msgstr ""
+
+#: gphoto2/actions.c:1629
+#, fuzzy, c-format
+msgid "%s not found in configuration tree."
+msgstr "Asetusten p√§ivitys ep√§onistui:"
+
+#: gphoto2/actions.c:1681
+#, c-format
+msgid "Failed to retrieve value of text widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1698
+#, c-format
+msgid "Failed to retrieve values of range widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1710
+#, c-format
+msgid "Failed to retrieve values of toggle widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1722
+#, c-format
+msgid "Failed to retrieve values of date/time widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1753
+#, c-format
+msgid "Failed to retrieve values of radio widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1799
+#, c-format
+msgid "Property %s is read only."
+msgstr ""
+
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
+#, c-format
+msgid "Failed to set the value of text widget %s to %s."
+msgstr ""
+
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
+#, c-format
+msgid "The passed value %s is not a floating point value."
+msgstr ""
+
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
+#, c-format
+msgid "The passed value %f is not within the expected range %f - %f."
+msgstr ""
+
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
+#, c-format
+msgid "Failed to set the value of range widget %s to %f."
+msgstr ""
+
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
+msgid "off"
+msgstr ""
+
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
+msgid "false"
+msgstr ""
+
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
+#, fuzzy
+msgid "on"
+msgstr "ma"
+
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
+msgid "true"
+msgstr ""
+
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
+#, c-format
+msgid "The passed value %s is not a valid toggle value."
+msgstr ""
+
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
+#, c-format
+msgid "Failed to set values %s of toggle widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
+#, fuzzy
+msgid "now"
+msgstr "ei"
+
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
+#, c-format
+msgid "The passed value %s is neither a valid time nor an integer."
+msgstr ""
+
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
+#, c-format
+msgid "Failed to set new time of date/time widget %s to %s."
+msgstr ""
+
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
+#, c-format
+msgid "Choice %s not found within list of choices."
+msgstr ""
+
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
+#, c-format
+msgid "The %s widget is not configurable."
+msgstr ""
+
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
+#, c-format
+msgid "Failed to set new configuration value %s for configuration entry %s."
+msgstr ""
+
+#: gphoto2/actions.c:2019
+#, c-format
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+
+#: gphoto2/foreach.c:260
+#, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
 msgstr ""
 "Virheellinen tiedoston numero. Annoit numeron %i, mutta vain %i tiedostoa\n"
-"on saatavilla kansiossa \"%s\" ja sen alikansioissa. Selvit‰†ensin oikea\n"
+"on saatavilla kansiossa \"%s\" ja sen alikansioissa. Selvit√§¬†ensin oikea\n"
 "tiedoston numero tiedostolistauksesta."
 
-#: gphoto2/foreach.c:283
+#: gphoto2/foreach.c:285
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr ""
-"Virheellinen tiedoston numero. M‰‰ritit numeron %i, mutta kansio \"%s\"\n"
-"sis‰lt‰‰†vain yhden tiedoston."
+msgid "There are no files in folder '%s'."
+msgstr "Kansio \"%s\" ei sis√§ll√§¬†tiedostoja."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'.Please obtain a valid file number from a file listing first."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
 msgstr ""
-"Virheellinen tiedoston numero. M‰‰ritit numeron %i, mutta vain %i tiedostoa on\n"
-"saatavilla kansiossa \"%s\". Selvit‰†ensin oikea tiedoston numero tiedostolistauksesta."
+"Virheellinen tiedoston numero. M√§√§ritit numeron %i, mutta kansio \"%s\"\n"
+"sis√§lt√§√§¬†vain yhden tiedoston."
 
-#: gphoto2/gp-params.c:53
+#: gphoto2/foreach.c:299
+#, fuzzy, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Virheellinen tiedoston numero. M√§√§ritit numeron %i, mutta vain %i tiedostoa "
+"on\n"
+"saatavilla kansiossa \"%s\". Selvit√§¬†ensin oikea tiedoston numero "
+"tiedostolistauksesta."
+
+#: gphoto2/gp-params.c:70
+#, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Virhe ***              \n"
 
-#: gphoto2/gp-params.c:220
+#: gphoto2/gp-params.c:243
+#, c-format
 msgid "Press any key to continue.\n"
-msgstr "Paina jotakin n‰pp‰int‰†jatkaaksesi.\n"
+msgstr "Paina jotakin n√§pp√§int√§¬†jatkaaksesi.\n"
 
-#: gphoto2/gp-params.c:237
+#: gphoto2/gp-params.c:266
+#, c-format
 msgid "Not enough memory."
-msgstr "Muistin m‰‰r‰ ei riit‰."
+msgstr "Muistin m√§√§r√§ ei riit√§."
 
-#: gphoto2/gphoto2-cmd-capture.c:201
+#: gphoto2/gphoto2-cmd-capture.c:211
 msgid "Operation cancelled"
 msgstr "Operaatio peruttu"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Jatka"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Peru"
 
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Virhe"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
-msgstr "Asetusten p‰ivitys ep‰onistui:"
+msgstr "Asetusten p√§ivitys ep√§onistui:"
 
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Lopeta"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Takaisin"
 
-#: gphoto2/gphoto2-cmd-config.c:253
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Aika: "
 
-#: gphoto2/gphoto2-cmd-config.c:312 gphoto2/gphoto2-cmd-config.c:340
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Arvo: "
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
-msgstr "Kyll‰"
+msgstr "Kyll√§"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Ei"
 
-#: gphoto2/main.c:161 gphoto2/main.c:1461
-msgid "Turn on debugging"
-msgstr "Aseta vianetsint‰†p‰‰lle"
-
-#: gphoto2/main.c:162 gphoto2/main.c:1463
-msgid "Quiet output (default=verbose)"
-msgstr "Hiljainen tuloste (oletus=verbose)"
-
-#: gphoto2/main.c:166 gphoto2/main.c:1467
-msgid "Display version and exit"
-msgstr "N‰yt‰†versio ja lopeta"
-
-#: gphoto2/main.c:167
-msgid "Displays this help screen"
-msgstr "N‰ytt‰‰ t‰m‰n opasteruudun"
-
-#: gphoto2/main.c:168 gphoto2/main.c:1469
-msgid "List supported camera models"
-msgstr "Listaa tuetut kameramallit"
-
-#: gphoto2/main.c:169 gphoto2/main.c:1471
-msgid "List supported port devices"
-msgstr "Listaa tuetut portit"
-
-#: gphoto2/main.c:170 gphoto2/main.c:1473
-msgid "Send file to stdout"
-msgstr "L‰het‰†tiedosto vakiotulosteeseen"
-
-#: gphoto2/main.c:171 gphoto2/main.c:1475
-msgid "Print filesize before data"
-msgstr "Tulosta tiedoston koko ennen dataa"
-
-#: gphoto2/main.c:172 gphoto2/main.c:1477
-msgid "List auto-detected cameras"
-msgstr "Listaa automaattisesti tunnistetut kamerat"
-
-#: gphoto2/main.c:175 gphoto2/main.c:1479
-msgid "Specify port device"
-msgstr "M‰‰rit‰†portti"
-
-#: gphoto2/main.c:176 gphoto2/main.c:1481
-msgid "Specify serial transfer speed"
-msgstr "M‰‰rit‰†sarjaportin siirtonopeus"
-
-#: gphoto2/main.c:177 gphoto2/main.c:1483
-msgid "Specify camera model"
-msgstr "M‰‰rit‰†kameran malli"
-
-#: gphoto2/main.c:178 gphoto2/main.c:1485
-msgid "Specify a filename"
-msgstr "M‰‰rit‰†tiedoston nimi"
-
-#: gphoto2/main.c:179 gphoto2/main.c:1487
-msgid "(expert only) Override USB IDs"
-msgstr "(vain asiantuntijoille) Kumoa USB-tunnisteet"
-
-#: gphoto2/main.c:182 gphoto2/main.c:1489
-msgid "Display camera abilities"
-msgstr "N‰yt‰†kameran valmiudet"
-
-#: gphoto2/main.c:183 gphoto2/main.c:1491
-msgid "Specify camera folder (default=\"/\")"
-msgstr "M‰‰rit‰†kameran kansio (oletus=\"/\")"
-
-#: gphoto2/main.c:184 gphoto2/main.c:1493
-msgid "Recursion (default for download)"
-msgstr "Rekursio (oletus tiedostojen kamerasta lataamiselle)"
-
-#: gphoto2/main.c:185 gphoto2/main.c:1495
-msgid "No recursion (default for deletion)"
-msgstr "Ei rekursiota (oletus poistolle)"
-
-#: gphoto2/main.c:186 gphoto2/main.c:1497
-msgid "List folders in folder"
-msgstr "Listaa kansion sis‰lt‰m‰t kansiot"
-
-#: gphoto2/main.c:187 gphoto2/main.c:1499
-msgid "List files in folder"
-msgstr "Listaa kansion sis‰lt‰m‰t tiedostot"
-
-#: gphoto2/main.c:188 gphoto2/main.c:189
-msgid "name"
-msgstr "nimi"
-
-#: gphoto2/main.c:188 gphoto2/main.c:1501
-msgid "Create a directory"
-msgstr "Luo kansio"
-
-#: gphoto2/main.c:189 gphoto2/main.c:1503
-msgid "Remove a directory"
-msgstr "Poista kansio"
-
-#: gphoto2/main.c:190 gphoto2/main.c:1505
-msgid "Display number of files"
-msgstr "N‰yt‰†tiedostojen lukum‰‰r‰"
-
-#: gphoto2/main.c:191 gphoto2/main.c:1507
-msgid "Get files given in range"
-msgstr "Hae tiedostot m‰‰ritellylt‰†lukualueelta"
-
-#: gphoto2/main.c:192 gphoto2/main.c:1509
-msgid "Get all files from folder"
-msgstr "Hae kaikki tiedostot kansiosta"
-
-#: gphoto2/main.c:193 gphoto2/main.c:1511
-msgid "Get thumbnails given in range"
-msgstr "Hae pienoiskuvat m‰‰ritellylt‰†lukualueelta"
-
-#: gphoto2/main.c:194 gphoto2/main.c:1514
-msgid "Get all thumbnails from folder"
-msgstr "Hae kaikki pienoiskuvat kansiosta"
-
-#: gphoto2/main.c:195 gphoto2/main.c:1517
-msgid "Get raw data given in range"
-msgstr "Hae raakadata m‰‰ritellylt‰†lukualueelta"
-
-#: gphoto2/main.c:196 gphoto2/main.c:1520
-msgid "Get all raw data from folder"
-msgstr "Hae kaikki raakadata kansiosta"
-
-#: gphoto2/main.c:197 gphoto2/main.c:1523
-msgid "Get audio data given in range"
-msgstr "Hae ‰‰nidata m‰‰ritellylt‰†lukualueelta"
-
-#: gphoto2/main.c:198 gphoto2/main.c:1526
-msgid "Get all audio data from folder"
-msgstr "Hae kaikki ‰‰nidata kansiosta"
-
-#: gphoto2/main.c:199 gphoto2/main.c:1528
-msgid "Delete files given in range"
-msgstr "Poista tiedostot m‰‰ritellylt‰†lukualueelta"
-
-#: gphoto2/main.c:200 gphoto2/main.c:1530
-msgid "Delete all files in folder"
-msgstr "Poista kaikki tiedostot kansiosta"
-
-#: gphoto2/main.c:201 gphoto2/main.c:1532
-msgid "Upload a file to camera"
-msgstr "Lataa tiedosto kameraan"
-
-#: gphoto2/main.c:203 gphoto2/main.c:1535
-msgid "Configure"
-msgstr "Aseta"
-
-#: gphoto2/main.c:205 gphoto2/main.c:1539
-msgid "Capture a quick preview"
-msgstr "Kaappaa nopea esikatselukuva"
-
-#: gphoto2/main.c:206 gphoto2/main.c:1541
-msgid "Capture an image"
-msgstr "Kaappaa kuva"
-
-#: gphoto2/main.c:207
-msgid "Capture a movie "
-msgstr "Kaappaa elokuva "
-
-#: gphoto2/main.c:208 gphoto2/main.c:1545
-msgid "Capture an audio clip"
-msgstr "Kaappaa ‰‰nip‰tk‰"
-
-#: gphoto2/main.c:210 gphoto2/main.c:1548 gphoto2/shell.c:113
-msgid "Show EXIF information"
-msgstr "N‰yt‰†EXIF-tiedot"
-
-#: gphoto2/main.c:212 gphoto2/main.c:1551 gphoto2/shell.c:109
-msgid "Show info"
-msgstr "N‰yt‰ tiedot"
-
-#: gphoto2/main.c:213
-msgid "Summary of camera status"
-msgstr "Kooste kameran tilasta"
-
-#: gphoto2/main.c:214
-msgid "Camera driver manual"
-msgstr "Kameran ajurin k‰yttˆohje"
-
-#: gphoto2/main.c:215
-msgid "About the camera driver"
-msgstr "Tietoa kameran ajurista"
-
-#: gphoto2/main.c:216 gphoto2/main.c:1559
-msgid "gPhoto shell"
-msgstr "gPhoto-komentotulkki"
-
-#: gphoto2/main.c:343 gphoto2/main.c:1192
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr ""
-"K‰yt‰†merkint‰tapaa a:b=c:d k‰sitelless‰si a:b:n‰†tunnistettua \n"
-"USB-laitetta c:d:n‰.†a, b, c ja d tulee olla \"0x\":ll‰†alkavia \n"
-"heksadesimaalilukuja.\n"
-
-#: gphoto2/main.c:466
-msgid "Jan"
-msgstr "tam"
-
-#: gphoto2/main.c:466
-msgid "January"
-msgstr "tammikuuta"
-
-#: gphoto2/main.c:467
-msgid "Feb"
-msgstr "hel"
-
-#: gphoto2/main.c:467
-msgid "February"
-msgstr "helmikuuta"
-
-#: gphoto2/main.c:468
-msgid "Mar"
-msgstr "maa"
-
-#: gphoto2/main.c:468
-msgid "March"
-msgstr "maaliskuuta"
-
-#: gphoto2/main.c:469
-msgid "Apr"
-msgstr "huh"
-
-#: gphoto2/main.c:469
-msgid "April"
-msgstr "huhtikuuta"
-
-#: gphoto2/main.c:470
-msgid "May"
-msgstr "tou"
-
-#: gphoto2/main.c:471
-msgid "Jun"
-msgstr "kes"
-
-#: gphoto2/main.c:471
-msgid "June"
-msgstr "kes‰kuuta"
-
-#: gphoto2/main.c:472
-msgid "Jul"
-msgstr "hei"
-
-#: gphoto2/main.c:472
-msgid "July"
-msgstr "hein‰kuuta"
-
-#: gphoto2/main.c:473
-msgid "Aug"
-msgstr "elo"
-
-#: gphoto2/main.c:473
-msgid "August"
-msgstr "elokuuta"
-
-#: gphoto2/main.c:474
-msgid "Sep"
-msgstr "syy"
-
-#: gphoto2/main.c:474
-msgid "September"
-msgstr "syyskuuta"
-
-#: gphoto2/main.c:475
-msgid "Oct"
-msgstr "lok"
-
-#: gphoto2/main.c:475
-msgid "October"
-msgstr "lokakuuta"
-
-#: gphoto2/main.c:476
-msgid "Nov"
-msgstr "mar"
-
-#: gphoto2/main.c:476
-msgid "November"
-msgstr "marraskuuta"
-
-#: gphoto2/main.c:477
-msgid "Dec"
-msgstr "jou"
-
-#: gphoto2/main.c:477
-msgid "December"
-msgstr "joulukuuta"
-
-#: gphoto2/main.c:484
-msgid "Sun"
-msgstr "su"
-
-#: gphoto2/main.c:484
-msgid "Sunday"
-msgstr "sunnuntai"
-
-#: gphoto2/main.c:485
-msgid "Mon"
-msgstr "ma"
-
-#: gphoto2/main.c:485
-msgid "Monday"
-msgstr "maanantai"
-
-#: gphoto2/main.c:486
-msgid "Tue"
-msgstr "ti"
-
-#: gphoto2/main.c:486
-msgid "Tuesday"
-msgstr "tiistai"
-
-#: gphoto2/main.c:487
-msgid "Wed"
-msgstr "ke"
-
-#: gphoto2/main.c:487
-msgid "Wednesday"
-msgstr "keskiviikko"
-
-#: gphoto2/main.c:488
-msgid "Thu"
-msgstr "to"
-
-#: gphoto2/main.c:488
-msgid "Thursday"
-msgstr "torstai"
-
-#: gphoto2/main.c:489
-msgid "Fri"
-msgstr "pe"
-
-#: gphoto2/main.c:489
-msgid "Friday"
-msgstr "perjantai"
-
-#: gphoto2/main.c:490
-msgid "Sat"
-msgstr "la"
-
-#: gphoto2/main.c:490
-msgid "Saturday"
-msgstr "lauantai"
-
-#: gphoto2/main.c:552
+#: gphoto2/main.c:220
 #, c-format
-msgid "You cannot use '%n' in combination with non-persistent files!"
-msgstr "Et voi k‰ytt‰‰†kohdetta \"%n\" v‰liaikaistiedostojen yhteydess‰!"
+msgid "Zero padding numbers in file names is only possible with %%n."
+msgstr ""
 
-#: gphoto2/main.c:575
+#: gphoto2/main.c:229
+#, fuzzy, c-format
+msgid "You cannot use %%n zero padding without a precision value!"
+msgstr "Et voi k√§ytt√§√§¬†kohdetta \"%n\" v√§liaikaistiedostojen yhteydess√§!"
+
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
-msgstr "Kameran antama tiedoston nimi (\"%s\") ei sis‰ll‰†p‰‰tett‰!"
+msgstr "Kameran antama tiedoston nimi (\"%s\") ei sis√§ll√§¬†p√§√§tett√§!"
 
-#: gphoto2/main.c:654
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Virheellinen muoto \"%s\" (virhe kohdassa %i)."
 
-#: gphoto2/main.c:701
+#: gphoto2/main.c:386 gphoto2/main.c:592
+#, fuzzy, c-format
+msgid "Skip existing file %s\n"
+msgstr "Tallennetaan tiedosto nimell√§¬†%s\n"
+
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Tiedosto %s on olemassa. Ylikirjoitetaanko? [y|n] "
 
-#: gphoto2/main.c:712
+#: gphoto2/main.c:410
+#, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Anna uusi tiedostonimi? [y|n] "
 
-#: gphoto2/main.c:721
+#: gphoto2/main.c:422
+#, c-format
 msgid "Enter new filename: "
-msgstr "Syˆt‰†uusi tiedostonimi: "
+msgstr "Sy√∂t√§¬†uusi tiedostonimi: "
 
-#: gphoto2/main.c:726
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
-msgstr "Tallennetaan tiedosto nimell‰†%s\n"
+msgstr "Tallennetaan tiedosto nimell√§¬†%s\n"
 
-#: gphoto2/main.c:918
+#: gphoto2/main.c:630
+#, fuzzy
+msgid "Permission denied"
+msgstr "  Oikeudet: "
+
+#: gphoto2/main.c:800
+#, fuzzy
+msgid "Could not trigger capture."
+msgstr "EXIF-tietojen j√§sent√§minen ei onnistunut."
+
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Uusi tiedosto sijaitsee kamerassa paikassa %s%s%s\n"
 
-#: gphoto2/main.c:1050
+#: gphoto2/main.c:847 gphoto2/main.c:878
+#, fuzzy, c-format
+msgid "Keeping file %s%s%s on the camera\n"
+msgstr "Uusi tiedosto sijaitsee kamerassa paikassa %s%s%s\n"
+
+#: gphoto2/main.c:868
+#, fuzzy, c-format
+msgid "Deleting file %s%s%s on the camera\n"
+msgstr "Uusi tiedosto sijaitsee kamerassa paikassa %s%s%s\n"
+
+#: gphoto2/main.c:911
+#, c-format
+msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:916
+#, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:926
+#, c-format
+msgid "Event UNKNOWN %s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:932
+#, c-format
+msgid "Unknown event type %d during bulb wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:950
+#, fuzzy
+msgid "Could not get capabilities?"
+msgstr "Asetusten p√§ivitys ep√§onistui:"
+
+#: gphoto2/main.c:958
+#, c-format
+msgid "Time-lapse mode enabled (interval: %ds).\n"
+msgstr ""
+
+#: gphoto2/main.c:961
+#, c-format
+msgid "Standing by waiting for SIGUSR1 to capture.\n"
+msgstr ""
+
+#: gphoto2/main.c:967
+#, c-format
+msgid "Bulb mode enabled (exposure time: %ds).\n"
+msgstr ""
+
+#: gphoto2/main.c:975
+#, c-format
+msgid "Capturing frame #%d...\n"
+msgstr ""
+
+#: gphoto2/main.c:977
+#, c-format
+msgid "Capturing frame #%d/%d...\n"
+msgstr ""
+
+#: gphoto2/main.c:987
+#, c-format
+msgid "Could not set bulb capture, result %d."
+msgstr ""
+
+#: gphoto2/main.c:1001
+msgid "Could not end capture (bulb mode)."
+msgstr ""
+
+#: gphoto2/main.c:1014
+#, fuzzy
+msgid "Could not trigger image capture."
+msgstr "Kotikansiota ei l√∂ytynyt."
+
+#: gphoto2/main.c:1021
+#, fuzzy
+msgid "Could not capture image."
+msgstr "Kaappaa kuva"
+
+#: gphoto2/main.c:1028
+#, c-format
+msgid "Capture failed (auto-focus problem?)...\n"
+msgstr ""
+
+#: gphoto2/main.c:1039
+#, fuzzy
+msgid "Could not capture."
+msgstr "EXIF-tietojen j√§sent√§minen ei onnistunut."
+
+#: gphoto2/main.c:1074
+#, c-format
+msgid "Waiting for next capture slot %ld seconds...\n"
+msgstr ""
+
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
+#, c-format
+msgid "Awakened by SIGUSR1...\n"
+msgstr ""
+
+#: gphoto2/main.c:1096
+#, c-format
+msgid "not sleeping (%ld seconds behind schedule)\n"
+msgstr ""
+
+#: gphoto2/main.c:1240
+#, c-format
 msgid "ERROR: "
 msgstr "VIRHE: "
 
-#: gphoto2/main.c:1073
+#: gphoto2/main.c:1263
+#, c-format
 msgid ""
 "\n"
 "Aborting...\n"
 msgstr ""
 "\n"
-"Keskeytet‰‰n...\n"
+"Keskeytet√§√§n...\n"
 
-#: gphoto2/main.c:1079
+#: gphoto2/main.c:1269
+#, c-format
 msgid "Aborted.\n"
 msgstr "Keskeytetty.\n"
 
-#: gphoto2/main.c:1084
+#: gphoto2/main.c:1274
+#, c-format
 msgid ""
 "\n"
 "Cancelling...\n"
@@ -844,15 +990,33 @@ msgstr ""
 "\n"
 "Perutaan...\n"
 
-#: gphoto2/main.c:1291
-msgid "gphoto2 has been compiled without support for CDK."
-msgstr "gphoto2 on k‰‰netty ilman tukea CDK:lle."
+#: gphoto2/main.c:1426
+#, c-format
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"K√§yt√§¬†merkint√§tapaa a:b=c:d k√§sitelless√§si a:b:n√§¬†tunnistettua \n"
+"USB-laitetta c:d:n√§.¬†a, b, c ja d tulee olla \"0x\":ll√§¬†alkavia \n"
+"heksadesimaalilukuja.\n"
 
-#: gphoto2/main.c:1404
+#: gphoto2/main.c:1609
+msgid "gphoto2 has been compiled without support for CDK."
+msgstr "gphoto2 on k√§√§netty ilman tukea CDK:lle."
+
+#: gphoto2/main.c:1879
+#, c-format
 msgid "Operation cancelled.\n"
 msgstr "Toimenpide keskeytetty.\n"
 
-#: gphoto2/main.c:1408
+#: gphoto2/main.c:1883
+#, c-format
+msgid ""
+"*** Error: No camera found. ***\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -861,7 +1025,8 @@ msgstr ""
 "*** Virhe (%i: \"%s\") ***        \n"
 "\n"
 
-#: gphoto2/main.c:1412
+#: gphoto2/main.c:1890
+#, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
 "Debugging messages may help finding a solution to your problem.\n"
@@ -870,96 +1035,429 @@ msgid ""
 "gphoto2 as follows:\n"
 "\n"
 msgstr ""
-"N‰hd‰ksesi vianetsint‰viestit, k‰yt‰†≠-debug-valitsinta. \n"
-"Vianetsint‰viestit voivat auttaa lˆyt‰m‰‰n ratkaisun ongelmaasi. \n"
-"Jos aiot l‰hett‰‰†virhe- tai vianetsint‰viestej‰†gphoto:n\n"
-"kehitt‰jien s‰hkˆpostilistalle <gphoto-devel@lists.sourceforge.net>,\n"
-"ole hyv‰†ja k‰ynnist‰†gphoto2 seuraavasti:\n"
+"N√§hd√§ksesi vianetsint√§viestit, k√§yt√§¬†¬≠-debug-valitsinta. \n"
+"Vianetsint√§viestit voivat auttaa l√∂yt√§m√§√§n ratkaisun ongelmaasi. \n"
+"Jos aiot l√§hett√§√§¬†virhe- tai vianetsint√§viestej√§¬†gphoto:n\n"
+"kehitt√§jien s√§hk√∂postilistalle <gphoto-devel@lists.sourceforge.net>,\n"
+"ole hyv√§¬†ja k√§ynnist√§¬†gphoto2 seuraavasti:\n"
 "\n"
 
-#: gphoto2/main.c:1465
-msgid "Overwrite files without asking."
-msgstr "Ylikirjoita tiedostot kysym‰tt‰."
+#: gphoto2/main.c:1911
+#, c-format
+msgid ""
+"Please make sure there is sufficient quoting around the arguments.\n"
+"\n"
+msgstr ""
 
-#: gphoto2/main.c:1479
-msgid "path"
-msgstr "polku"
+#: gphoto2/main.c:1978
+msgid "Print complete help message on program usage"
+msgstr ""
 
-#: gphoto2/main.c:1481
-msgid "speed"
-msgstr "nopeus"
+#: gphoto2/main.c:1980
+msgid "Print short message on program usage"
+msgstr ""
 
-#: gphoto2/main.c:1483
-msgid "model"
-msgstr "malli"
+#: gphoto2/main.c:1982
+msgid "Turn on debugging"
+msgstr "Aseta vianetsint√§¬†p√§√§lle"
 
-#: gphoto2/main.c:1485
-msgid "filename"
-msgstr "tiedostonimi"
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
 
-#: gphoto2/main.c:1487
-msgid "usbid"
-msgstr "usbid"
+#: gphoto2/main.c:1986
+msgid "Name of file to write debug info to"
+msgstr ""
 
-#: gphoto2/main.c:1491
-msgid "folder"
-msgstr "kansio"
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
+msgid "FILENAME"
+msgstr ""
 
-#: gphoto2/main.c:1543
+#: gphoto2/main.c:1988
+msgid "Quiet output (default=verbose)"
+msgstr "Hiljainen tuloste (oletus=verbose)"
+
+#: gphoto2/main.c:1990
+msgid "Hook script to call after downloads, captures, etc."
+msgstr ""
+
+#: gphoto2/main.c:1997
+#, fuzzy
+msgid "Specify device port"
+msgstr "M√§√§rit√§¬†portti"
+
+#: gphoto2/main.c:1999
+msgid "Specify serial transfer speed"
+msgstr "M√§√§rit√§¬†sarjaportin siirtonopeus"
+
+#: gphoto2/main.c:1999
+msgid "SPEED"
+msgstr ""
+
+#: gphoto2/main.c:2001
+msgid "Specify camera model"
+msgstr "M√§√§rit√§¬†kameran malli"
+
+#: gphoto2/main.c:2001
+msgid "MODEL"
+msgstr ""
+
+#: gphoto2/main.c:2003
+msgid "(expert only) Override USB IDs"
+msgstr "(vain asiantuntijoille) Kumoa USB-tunnisteet"
+
+#: gphoto2/main.c:2003
+msgid "USBIDs"
+msgstr ""
+
+#: gphoto2/main.c:2009
+msgid "Display version and exit"
+msgstr "N√§yt√§¬†versio ja lopeta"
+
+#: gphoto2/main.c:2011
+msgid "List supported camera models"
+msgstr "Listaa tuetut kameramallit"
+
+#: gphoto2/main.c:2013
+msgid "List supported port devices"
+msgstr "Listaa tuetut portit"
+
+#: gphoto2/main.c:2015
+msgid "Display the camera/driver abilities in the libgphoto2 database"
+msgstr ""
+
+#: gphoto2/main.c:2022
+msgid "Configure"
+msgstr "Aseta"
+
+#: gphoto2/main.c:2025
+#, fuzzy
+msgid "List configuration tree"
+msgstr "Asetusten p√§ivitys ep√§onistui:"
+
+#: gphoto2/main.c:2027
+msgid "Dump full configuration tree"
+msgstr ""
+
+#: gphoto2/main.c:2029
+#, fuzzy
+msgid "Get configuration value"
+msgstr "Asetusten p√§ivitys ep√§onistui:"
+
+#: gphoto2/main.c:2031
+msgid "Set configuration value or index in choices"
+msgstr ""
+
+#: gphoto2/main.c:2033
+msgid "Set configuration value index in choices"
+msgstr ""
+
+#: gphoto2/main.c:2035
+#, fuzzy
+msgid "Set configuration value"
+msgstr "Asetusten p√§ivitys ep√§onistui:"
+
+#: gphoto2/main.c:2037
+msgid "Reset device port"
+msgstr ""
+
+#: gphoto2/main.c:2043
+msgid "Keep images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2045
+msgid "Keep RAW images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2047
+msgid "Remove images from camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2049
+msgid "Wait for event(s) from camera"
+msgstr ""
+
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
+
+#: gphoto2/main.c:2051
+msgid "Wait for event(s) from the camera and download new images"
+msgstr ""
+
+#: gphoto2/main.c:2054
+msgid "Capture a quick preview"
+msgstr "Kaappaa nopea esikatselukuva"
+
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
+
+#: gphoto2/main.c:2059
+msgid "Set bulb exposure time in seconds"
+msgstr ""
+
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
+msgid "SECONDS"
+msgstr ""
+
+#: gphoto2/main.c:2061
+msgid "Set number of frames to capture (default=infinite)"
+msgstr ""
+
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr ""
+
+#: gphoto2/main.c:2063
+msgid "Set capture interval in seconds"
+msgstr ""
+
+#: gphoto2/main.c:2065
+msgid "Reset capture interval on signal (default=no)"
+msgstr ""
+
+#: gphoto2/main.c:2067
+msgid "Capture an image"
+msgstr "Kaappaa kuva"
+
+#: gphoto2/main.c:2069
+#, fuzzy
+msgid "Trigger capture of an image"
+msgstr "Kaappaa kuva"
+
+#: gphoto2/main.c:2071
+#, fuzzy
+msgid "Capture an image and download it"
+msgstr "Kaappaa kuva"
+
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Kaappaa elokuva"
 
-#: gphoto2/main.c:1553
-msgid "Show summary"
-msgstr "N‰yt‰†kooste"
-
-#: gphoto2/main.c:1555
-msgid "Show camera driver manual"
-msgstr "N‰yt‰†kameran ajurin k‰yttˆohje"
-
-#: gphoto2/main.c:1557
-msgid "About the camera driver manual"
-msgstr "Tietoa kameran ajurin k‰yttˆohjeesta"
-
-#: gphoto2/main.c:1784
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#: gphoto2/main.c:2073
+msgid "COUNT or SECONDS"
 msgstr ""
-"gPhoto2 OS/2:lle vaatii \"CAMLIBS\"-ymp‰ristˆmuuttujan asettamisen \n"
-"kamerakirjastoihin sopivaksi. Esim. SET CAMLIBS=C:\\\\GPHOTO2\\\\CAM\n"
 
-#: gphoto2/main.c:1794
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#: gphoto2/main.c:2075
+msgid "Capture an audio clip"
+msgstr "Kaappaa √§√§nip√§tk√§"
+
+#: gphoto2/main.c:2077
+msgid "Wait for shutter release on the camera and download"
 msgstr ""
-"gPhoto2 OS/2:lle vaatii \"IOLIBS\"-ymp‰ristˆmuuttujan asettamisen \n"
-"io-kirjastoihin sopivaksi. Esim. SET IOLIBS=C:\\\\GPHOTO2\\\\IOLIB\n"
 
-#: gphoto2/options.c:181
-msgid "Usage:\n"
-msgstr "K‰yttˆ:\n"
+#: gphoto2/main.c:2083
+msgid "List folders in folder"
+msgstr "Listaa kansion sis√§lt√§m√§t kansiot"
 
-#: gphoto2/options.c:184
-msgid ""
-"Short/long options (& argument)        Description\n"
-"--------------------------------------------------------------------------------\n"
+#: gphoto2/main.c:2085
+msgid "List files in folder"
+msgstr "Listaa kansion sis√§lt√§m√§t tiedostot"
+
+#: gphoto2/main.c:2087
+msgid "Create a directory"
+msgstr "Luo kansio"
+
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
+msgid "DIRNAME"
 msgstr ""
-"Lyhyet/pitk‰t†valinnat (ja argumentit) Kuvaus\n"
-"--------------------------------------------------------------------------------\n"
 
-#: gphoto2/options.c:209
+#: gphoto2/main.c:2089
+msgid "Remove a directory"
+msgstr "Poista kansio"
+
+#: gphoto2/main.c:2091
+msgid "Display number of files"
+msgstr "N√§yt√§¬†tiedostojen lukum√§√§r√§"
+
+#: gphoto2/main.c:2093
+msgid "Get files given in range"
+msgstr "Hae tiedostot m√§√§ritellylt√§¬†lukualueelta"
+
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
+msgid "RANGE"
+msgstr ""
+
+#: gphoto2/main.c:2095
+msgid "Get all files from folder"
+msgstr "Hae kaikki tiedostot kansiosta"
+
+#: gphoto2/main.c:2097
+msgid "Get thumbnails given in range"
+msgstr "Hae pienoiskuvat m√§√§ritellylt√§¬†lukualueelta"
+
+#: gphoto2/main.c:2100
+msgid "Get all thumbnails from folder"
+msgstr "Hae kaikki pienoiskuvat kansiosta"
+
+#: gphoto2/main.c:2102
+#, fuzzy
+msgid "Get metadata given in range"
+msgstr "Hae raakadata m√§√§ritellylt√§¬†lukualueelta"
+
+#: gphoto2/main.c:2104
+#, fuzzy
+msgid "Get all metadata from folder"
+msgstr "Hae kaikki raakadata kansiosta"
+
+#: gphoto2/main.c:2106
+msgid "Upload metadata for file"
+msgstr ""
+
+#: gphoto2/main.c:2109
+msgid "Get raw data given in range"
+msgstr "Hae raakadata m√§√§ritellylt√§¬†lukualueelta"
+
+#: gphoto2/main.c:2112
+msgid "Get all raw data from folder"
+msgstr "Hae kaikki raakadata kansiosta"
+
+#: gphoto2/main.c:2115
+msgid "Get audio data given in range"
+msgstr "Hae √§√§nidata m√§√§ritellylt√§¬†lukualueelta"
+
+#: gphoto2/main.c:2118
+msgid "Get all audio data from folder"
+msgstr "Hae kaikki √§√§nidata kansiosta"
+
+#: gphoto2/main.c:2120
+msgid "Delete files given in range"
+msgstr "Poista tiedostot m√§√§ritellylt√§¬†lukualueelta"
+
+#: gphoto2/main.c:2122
+#, fuzzy
+msgid "Delete all files in folder (--no-recurse by default)"
+msgstr "Poista kaikki tiedostot kansiosta"
+
+#: gphoto2/main.c:2124
+msgid "Upload a file to camera"
+msgstr "Lataa tiedosto kameraan"
+
+#: gphoto2/main.c:2126
+#, fuzzy
+msgid "Specify a filename or filename pattern"
+msgstr "M√§√§rit√§¬†tiedoston nimi"
+
+#: gphoto2/main.c:2126
+msgid "FILENAME_PATTERN"
+msgstr ""
+
+#: gphoto2/main.c:2128
 #, c-format
-msgid "%-38s %s\n"
-msgstr "%-38s %s\n"
-
-#: gphoto2/options.c:214
-msgid ""
-"--------------------------------------------------------------------------------\n"
-"[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
+msgid "Specify the number a filename %%n will starts with (default 1)"
 msgstr ""
-"--------------------------------------------------------------------------------\n"
-"[K‰yt‰†kaksoislainausmerkkej‰†argumenttien ymp‰rill‰†  [Kuvan numero alkaa\n"
-"ykkˆsell‰†(1)]\n"
 
-#: gphoto2/range.c:103 gphoto2/range.c:157
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
+msgid "Specify camera folder (default=\"/\")"
+msgstr "M√§√§rit√§¬†kameran kansio (oletus=\"/\")"
+
+#: gphoto2/main.c:2130
+msgid "FOLDER"
+msgstr ""
+
+#: gphoto2/main.c:2132
+msgid "Recursion (default for download)"
+msgstr "Rekursio (oletus tiedostojen kamerasta lataamiselle)"
+
+#: gphoto2/main.c:2134
+msgid "No recursion (default for deletion)"
+msgstr "Ei rekursiota (oletus poistolle)"
+
+#: gphoto2/main.c:2136
+msgid "Process new files only"
+msgstr ""
+
+#: gphoto2/main.c:2138
+#, fuzzy
+msgid "Overwrite files without asking"
+msgstr "Ylikirjoita tiedostot kysym√§tt√§."
+
+#: gphoto2/main.c:2140
+msgid "Skip existing files"
+msgstr ""
+
+#: gphoto2/main.c:2146
+msgid "Send file to stdout"
+msgstr "L√§het√§¬†tiedosto vakiotulosteeseen"
+
+#: gphoto2/main.c:2148
+msgid "Print filesize before data"
+msgstr "Tulosta tiedoston koko ennen dataa"
+
+#: gphoto2/main.c:2150
+msgid "List auto-detected cameras"
+msgstr "Listaa automaattisesti tunnistetut kamerat"
+
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
+msgstr "N√§yt√§¬†EXIF-tiedot"
+
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
+
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
+msgstr "N√§yt√§¬†kooste"
+
+#: gphoto2/main.c:2161
+msgid "Show camera driver manual"
+msgstr "N√§yt√§¬†kameran ajurin k√§ytt√∂ohje"
+
+#: gphoto2/main.c:2163
+msgid "About the camera driver manual"
+msgstr "Tietoa kameran ajurin k√§ytt√∂ohjeesta"
+
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
+#, fuzzy
+msgid "Show storage information"
+msgstr "N√§yt√§¬†EXIF-tiedot"
+
+#: gphoto2/main.c:2167
+msgid "gPhoto shell"
+msgstr "gPhoto-komentotulkki"
+
+#: gphoto2/main.c:2173
+msgid "Common options"
+msgstr ""
+
+#: gphoto2/main.c:2175
+msgid "Miscellaneous options (unsorted)"
+msgstr ""
+
+#: gphoto2/main.c:2177
+msgid "Get information on software and host system (not from the camera)"
+msgstr ""
+
+#: gphoto2/main.c:2179
+#, fuzzy
+msgid "Specify the camera to use"
+msgstr "M√§√§rit√§¬†kameran malli"
+
+#: gphoto2/main.c:2181
+#, fuzzy
+msgid "Camera and software configuration"
+msgstr "Asetusten p√§ivitys ep√§onistui:"
+
+#: gphoto2/main.c:2183
+#, fuzzy
+msgid "Capture an image from or on the camera"
+msgstr "Siirry kameran kansioon"
+
+#: gphoto2/main.c:2185
+msgid "Downloading, uploading and manipulating files"
+msgstr ""
+
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -968,7 +1466,7 @@ msgstr ""
 "%s\n"
 "Kuvan numeron tulee olla nollaa suurempi."
 
-#: gphoto2/range.c:109 gphoto2/range.c:163
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -977,7 +1475,7 @@ msgstr ""
 "%s\n"
 "Kuvan numero %i on liian suuri."
 
-#: gphoto2/range.c:125
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -986,7 +1484,7 @@ msgstr ""
 "%s\n"
 "Lukualueet tulee erottaa pilkuilla \",\"."
 
-#: gphoto2/range.c:139
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -995,7 +1493,7 @@ msgstr ""
 "%s\n"
 "Lukualueiden tulee alkaa numerolla."
 
-#: gphoto2/range.c:179
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1004,134 +1502,436 @@ msgstr ""
 "%s\n"
 "Odottamaton merkki \"%c\"."
 
-#: gphoto2/range.c:202
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"V‰henev‰t†lukualueet eiv‰t†ole sallittuja. M‰‰ritit alueen luvusta %i \n"
+"V√§henev√§t¬†lukualueet eiv√§t¬†ole sallittuja. M√§√§ritit alueen luvusta %i \n"
 "lukuun %i."
 
-#: gphoto2/shell.c:55
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Virhe (%i: \"%s\") ***"
 
-#: gphoto2/shell.c:98
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Siirry kameran kansioon"
 
-#: gphoto2/shell.c:99 gphoto2/shell.c:101
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "kansio"
 
-#: gphoto2/shell.c:100
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Siirry paikallisen aseman kansioon"
 
-#: gphoto2/shell.c:102 gphoto2/shell.c:120 gphoto2/shell.c:121
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Poistu gPhoto-komentotulkista"
 
-#: gphoto2/shell.c:103
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Lataa tiedosto"
 
-#: gphoto2/shell.c:103 gphoto2/shell.c:106 gphoto2/shell.c:108
-#: gphoto2/shell.c:110 gphoto2/shell.c:111 gphoto2/shell.c:114
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[kansio/]tiedostonimi"
 
-#: gphoto2/shell.c:105
+#: gphoto2/shell.c:132
+#, fuzzy
+msgid "Upload a file"
+msgstr "Lataa tiedosto"
+
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Lataa pienoiskuva"
 
-#: gphoto2/shell.c:107
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Lataa raakadata"
 
-#: gphoto2/shell.c:111
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Poista"
 
-#: gphoto2/shell.c:116 gphoto2/shell.c:122
-msgid "Displays command usage"
-msgstr "N‰yt‰†komennon k‰yttˆohjeet"
+#: gphoto2/shell.c:140
+#, fuzzy
+msgid "Create Directory"
+msgstr "Luo kansio"
 
-#: gphoto2/shell.c:117 gphoto2/shell.c:122
+#: gphoto2/shell.c:141
+#, fuzzy
+msgid "Remove Directory"
+msgstr "Poista kansio"
+
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
+msgid "Displays command usage"
+msgstr "N√§yt√§¬†komennon k√§ytt√∂ohjeet"
+
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[komento]"
 
-#: gphoto2/shell.c:118
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
-msgstr "Listaa nykyisen kansion sis‰ltˆ"
+msgstr "Listaa nykyisen kansion sis√§lt√∂"
 
-#: gphoto2/shell.c:119
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[kansio/]"
 
-#: gphoto2/shell.c:421
+#: gphoto2/shell.c:152
+msgid "List configuration variables"
+msgstr ""
+
+#: gphoto2/shell.c:153
+msgid "Get configuration variable"
+msgstr ""
+
+#: gphoto2/shell.c:153
+msgid "name"
+msgstr "nimi"
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+msgid "Set configuration variable"
+msgstr ""
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+msgid "name=value"
+msgstr ""
+
+#: gphoto2/shell.c:155
+msgid "Set configuration variable index"
+msgstr ""
+
+#: gphoto2/shell.c:155
+msgid "name=valueindex"
+msgstr ""
+
+#: gphoto2/shell.c:157
+msgid "Triggers the capture of a single image"
+msgstr ""
+
+#: gphoto2/shell.c:158
+#, fuzzy
+msgid "Capture a single image"
+msgstr "Kaappaa kuva"
+
+#: gphoto2/shell.c:159
+msgid "Capture a single image and download it"
+msgstr ""
+
+#: gphoto2/shell.c:160
+#, fuzzy
+msgid "Capture a preview image"
+msgstr "Kaappaa kuva"
+
+#: gphoto2/shell.c:161
+msgid "Wait for an event"
+msgstr ""
+
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
+msgid "count or seconds"
+msgstr ""
+
+#: gphoto2/shell.c:162
+msgid "Wait for images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:163
+msgid "Wait for events and images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Virheellinen komento."
 
-#: gphoto2/shell.c:430
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Komento \"%s\" vaatii argumentin."
 
-#: gphoto2/shell.c:483
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Virheellinen polku."
 
-#: gphoto2/shell.c:529
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
-msgstr "Kotikansiota ei lˆytynyt."
+msgstr "Kotikansiota ei l√∂ytynyt."
 
-#: gphoto2/shell.c:537
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Paikalliseen kansioon \"%s\" siirtyminen ei onnistunut."
 
-#: gphoto2/shell.c:540
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Paikallinen kansio on nyt \"%s\"."
 
-#: gphoto2/shell.c:578
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
-msgstr "Et‰kansio on nyt \"%s\"."
+msgstr "Et√§kansio on nyt \"%s\"."
 
-#: gphoto2/shell.c:734
+#: gphoto2/shell.c:874
+#, c-format
+msgid "set-config needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:895
+#, c-format
+msgid "set-config-value needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:916
+#, c-format
+msgid "set-config-index needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
 msgstr ""
-"Komentoa \"%s\" ei lˆydy. K‰yt‰†komentoa \"help\" n‰hd‰ksesi listan k‰ytˆss‰ olevista\n"
+"Komentoa \"%s\" ei l√∂ydy. K√§yt√§¬†komentoa \"help\" n√§hd√§ksesi listan k√§yt√∂ss√§ "
+"olevista\n"
 "komennoista."
 
-#: gphoto2/shell.c:741
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Ohjeita aiheesta \"%s\":"
 
-#: gphoto2/shell.c:743
+#: gphoto2/shell.c:988
+#, c-format
 msgid "Usage:"
-msgstr "K‰yttˆ:"
+msgstr "K√§ytt√∂:"
 
-#: gphoto2/shell.c:747
+#: gphoto2/shell.c:991
+#, c-format
 msgid "Description:"
 msgstr "Kuvaus:"
 
-#: gphoto2/shell.c:749
+#: gphoto2/shell.c:993
+#, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Argumentit hakasuluissa [] ovat valinnaisia"
 
-#: gphoto2/shell.c:770
+#: gphoto2/shell.c:1014
+#, c-format
 msgid "Available commands:"
-msgstr "K‰ytˆss‰ olevat komennot:"
+msgstr "K√§yt√∂ss√§ olevat komennot:"
 
-#: gphoto2/shell.c:775
+#: gphoto2/shell.c:1019
+#, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Saadaksesi apua tietyn komennon k‰ytˆst‰ kirjoita \"help komennon-nimi\"."
+msgstr ""
+"Saadaksesi apua tietyn komennon k√§yt√∂st√§ kirjoita \"help komennon-nimi\"."
+
+#, c-format
+#~ msgid "There are no folders in folder '%s'."
+#~ msgstr "Kansio \"%s\" ei sis√§ll√§¬†kansioita."
+
+#, c-format
+#~ msgid "There are %i folders in folder '%s':"
+#~ msgstr "%i kansiota kansiossa \"%s\":"
+
+#, c-format
+#~ msgid "There are %i files in folder '%s':"
+#~ msgstr "%i tiedostoa kansiossa \"%s\":"
+
+#, c-format
+#~ msgid "  Name:        '%s'\n"
+#~ msgstr "  Nimi:        \"%s\"\n"
+
+#~ msgid "Displays this help screen"
+#~ msgstr "N√§ytt√§√§ t√§m√§n opasteruudun"
+
+#~ msgid "Display camera abilities"
+#~ msgstr "N√§yt√§¬†kameran valmiudet"
+
+#~ msgid "Capture a movie "
+#~ msgstr "Kaappaa elokuva "
+
+#~ msgid "Show info"
+#~ msgstr "N√§yt√§ tiedot"
+
+#~ msgid "Summary of camera status"
+#~ msgstr "Kooste kameran tilasta"
+
+#~ msgid "Camera driver manual"
+#~ msgstr "Kameran ajurin k√§ytt√∂ohje"
+
+#~ msgid "About the camera driver"
+#~ msgstr "Tietoa kameran ajurista"
+
+#~ msgid "Jan"
+#~ msgstr "tam"
+
+#~ msgid "January"
+#~ msgstr "tammikuuta"
+
+#~ msgid "Feb"
+#~ msgstr "hel"
+
+#~ msgid "February"
+#~ msgstr "helmikuuta"
+
+#~ msgid "Mar"
+#~ msgstr "maa"
+
+#~ msgid "March"
+#~ msgstr "maaliskuuta"
+
+#~ msgid "Apr"
+#~ msgstr "huh"
+
+#~ msgid "April"
+#~ msgstr "huhtikuuta"
+
+#~ msgid "May"
+#~ msgstr "tou"
+
+#~ msgid "Jun"
+#~ msgstr "kes"
+
+#~ msgid "June"
+#~ msgstr "kes√§kuuta"
+
+#~ msgid "Jul"
+#~ msgstr "hei"
+
+#~ msgid "July"
+#~ msgstr "hein√§kuuta"
+
+#~ msgid "Aug"
+#~ msgstr "elo"
+
+#~ msgid "August"
+#~ msgstr "elokuuta"
+
+#~ msgid "Sep"
+#~ msgstr "syy"
+
+#~ msgid "September"
+#~ msgstr "syyskuuta"
+
+#~ msgid "Oct"
+#~ msgstr "lok"
+
+#~ msgid "October"
+#~ msgstr "lokakuuta"
+
+#~ msgid "Nov"
+#~ msgstr "mar"
+
+#~ msgid "November"
+#~ msgstr "marraskuuta"
+
+#~ msgid "Dec"
+#~ msgstr "jou"
+
+#~ msgid "December"
+#~ msgstr "joulukuuta"
+
+#~ msgid "Sun"
+#~ msgstr "su"
+
+#~ msgid "Sunday"
+#~ msgstr "sunnuntai"
+
+#~ msgid "Monday"
+#~ msgstr "maanantai"
+
+#~ msgid "Tue"
+#~ msgstr "ti"
+
+#~ msgid "Tuesday"
+#~ msgstr "tiistai"
+
+#~ msgid "Wed"
+#~ msgstr "ke"
+
+#~ msgid "Wednesday"
+#~ msgstr "keskiviikko"
+
+#~ msgid "Thu"
+#~ msgstr "to"
+
+#~ msgid "Thursday"
+#~ msgstr "torstai"
+
+#~ msgid "Fri"
+#~ msgstr "pe"
+
+#~ msgid "Friday"
+#~ msgstr "perjantai"
+
+#~ msgid "Sat"
+#~ msgstr "la"
+
+#~ msgid "Saturday"
+#~ msgstr "lauantai"
+
+#~ msgid "path"
+#~ msgstr "polku"
+
+#~ msgid "speed"
+#~ msgstr "nopeus"
+
+#~ msgid "model"
+#~ msgstr "malli"
+
+#~ msgid "filename"
+#~ msgstr "tiedostonimi"
+
+#~ msgid "usbid"
+#~ msgstr "usbid"
+
+#~ msgid "folder"
+#~ msgstr "kansio"
+
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the "
+#~ "location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgstr ""
+#~ "gPhoto2 OS/2:lle vaatii \"CAMLIBS\"-ymp√§rist√∂muuttujan asettamisen \n"
+#~ "kamerakirjastoihin sopivaksi. Esim. SET CAMLIBS=C:\\\\GPHOTO2\\\\CAM\n"
+
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the "
+#~ "location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgstr ""
+#~ "gPhoto2 OS/2:lle vaatii \"IOLIBS\"-ymp√§rist√∂muuttujan asettamisen \n"
+#~ "io-kirjastoihin sopivaksi. Esim. SET IOLIBS=C:\\\\GPHOTO2\\\\IOLIB\n"
+
+#~ msgid "Usage:\n"
+#~ msgstr "K√§ytt√∂:\n"
+
+#~ msgid ""
+#~ "Short/long options (& argument)        Description\n"
+#~ "--------------------------------------------------------------------------------\n"
+#~ msgstr ""
+#~ "Lyhyet/pitk√§t¬†valinnat (ja argumentit) Kuvaus\n"
+#~ "--------------------------------------------------------------------------------\n"
+
+#, c-format
+#~ msgid "%-38s %s\n"
+#~ msgstr "%-38s %s\n"
+
+#~ msgid ""
+#~ "--------------------------------------------------------------------------------\n"
+#~ "[Use double-quotes around arguments]        [Picture numbers begin with "
+#~ "one (1)]\n"
+#~ msgstr ""
+#~ "--------------------------------------------------------------------------------\n"
+#~ "[K√§yt√§¬†kaksoislainausmerkkej√§¬†argumenttien ymp√§rill√§¬†  [Kuvan numero "
+#~ "alkaa\n"
+#~ "ykk√∂sell√§¬†(1)]\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.9\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-11-18 22:19+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2016-12-23 22:52+0100\n"
 "Last-Translator: David Prévot <david@tilapin.org>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -24,135 +24,135 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Nombre de fichiers dans le dossier « %s » : %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "Le dossier « %2$s » contient %1$d dossier.\n"
 msgstr[1] "Le dossier « %2$s » contient %1$d dossiers.\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Le dossier « %s » ne contient aucun fichier.\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "Le dossier « %2$s » contient %1$d fichier.\n"
 msgstr[1] "Le dossier « %2$s » contient %1$d fichiers.\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Renseignements sur le fichier « %s » (dossier « %s ») :\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Fichier :\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Aucun disponible.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Type MIME : « %s »\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Taille :      %lu octet(s)\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Largeur :     %i pixel(s)\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Hauteur :     %i pixel(s)\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Téléchargé :  %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "oui"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "non"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Droits : "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "lecture et suppression"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "lecture"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "suppression"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "aucun"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Heure :       %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Vignette :\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Données sonores :\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Type MIME : « %s »\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Taille :      %lu octets(s)\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Téléchargé :  %s\n"
@@ -174,46 +174,46 @@ msgstr "Balise"
 msgid "Value"
 msgstr "Valeur"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Les données EXIF contiennent une vignette (%i octets)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gPhoto2 a été compilé sans la gestion EXIF."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Nombre d'appareils gérés : %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Appareils gérés :\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t« %s » (test)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t« %s » (expérimental)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t« %s »\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Périphériques trouvés : %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -222,460 +222,530 @@ msgstr ""
 "Chemin                           Description\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Modèle"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Port"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Possibilités de l'appareil                      : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Gestion du port série                           : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Gestion du port USB                             : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Vitesses de transfert gérées                    :\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                                : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Choix d'acquisition                             :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                                : Image\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                                : Vidéo\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                                : Audio\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                                : Prévisualisation\n"
 
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, c-format
 msgid "                                 : Trigger Capture\n"
-msgstr "                                                : Déclencher l’acquisition\n"
+msgstr ""
+"                                                : Déclencher l’acquisition\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                                : Acquisition non gérée par ce pilote\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                                : Acquisition non gérée par "
+"ce pilote\n"
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Gestion de la configuration                     : %s\n"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Effacer les fichiers sélectionnés de l'appareil : %s\n"
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Supprimer tous les fichiers de l'appareil       : %s\n"
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Gestion des vignettes de prévisualisation       : %s\n"
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Gestion de l'envoi de fichiers                  : %s\n"
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Les ports doivent être de la forme « serial:/dev/ttyS0 » ou « usb: », mais un deux points manque à « %s » ; tentative de deviner ce qui est voulu."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Les ports doivent être de la forme « serial:/dev/ttyS0 » ou « usb: », mais "
+"un deux points manque à « %s » ; tentative de deviner ce qui est voulu."
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Le port indiqué (« %s ») est introuvable. Veuillez indiquer l'un des ports trouvés par la commande « gphoto2 --list-ports » et assurez-vous que la syntaxe est correcte (c'est-à-dire avec le préfixe « serial: » ou « usb: »)."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Le port indiqué (« %s ») est introuvable. Veuillez indiquer l'un des ports "
+"trouvés par la commande « gphoto2 --list-ports » et assurez-vous que la "
+"syntaxe est correcte (c'est-à-dire avec le préfixe « serial: » ou « usb: »)."
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "À propos du pilote de l'appareil :"
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Résumé sur l'appareil :"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Manuel de l'appareil :"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "La vitesse ne peut être indiquée que pour les ports série."
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "Portage OS/2 par Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:907
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
 "Copyright (c) 2000-%d Lutz Mueller et autres\n"
 "%s\n"
-"gPhoto2 est livré SANS AUCUNE GARANTIE, dans les limites définies par la loi.\n"
+"gPhoto2 est livré SANS AUCUNE GARANTIE, dans les limites définies par la "
+"loi.\n"
 "Vous pouvez en redistribuer des copies selon les termes de la Licence\n"
-"Publique Générale GNU (GPL). Pour obtenir plus de renseignements à ce sujet,\n"
+"Publique Générale GNU (GPL). Pour obtenir plus de renseignements à ce "
+"sujet,\n"
 "veuillez consulter les fichiers appelés « COPYING ».\n"
 "\n"
 "Cette version de gphoto2 utilise les versions des logiciels et les options\n"
 "suivantes :\n"
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Impossible d'ouvrir « movie.mjpg »."
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Acquisition d'aperçus d'image comme vidéo de « %s ». Ctrl-C pour abandonner.\n"
+msgstr ""
+"Acquisition d'aperçus d'image comme vidéo de « %s ». Ctrl-C pour "
+"abandonner.\n"
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
-msgstr "Acquisition d'aperçus d'image comme vidéo de « %s » pour %d secondes.\n"
+msgstr ""
+"Acquisition d'aperçus d'image comme vidéo de « %s » pour %d secondes.\n"
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Acquisition de %d aperçus d'image comme vidéo de « %s ».\n"
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Erreur d'acquisition vidéo… Quitter."
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Erreur d'acquisition vidéo… Type MIME « %s » non gérée."
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ctrl-C reçu… Quitter.\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Acquisition de film terminée (%d trames)\n"
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "Attente d'événements de l'appareil. Ctrl-C pour abandonner.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr "Attente de %d images de l'appareil. Ctrl-C pour abandonner.\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Attente de %d millisecondes pour les événements de l'appareil. Ctrl-C pour abandonner.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Attente de %d millisecondes pour les événements de l'appareil. Ctrl-C pour "
+"abandonner.\n"
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Attente de %d secondes pour les événements de l'appareil. Ctrl-C pour abandonner.\n"
+msgstr ""
+"Attente de %d secondes pour les événements de l'appareil. Ctrl-C pour "
+"abandonner.\n"
 
-#: gphoto2/actions.c:1121
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
 msgstr "Attente de %d événements de l'appareil. Ctrl-C pour abandonner.\n"
 
-#: gphoto2/actions.c:1125
-#, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
 msgstr "Attente d’événement %s de l'appareil. Ctrl-C pour abandonner.\n"
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "événement trouvé, arrêtez d’attendre.\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "événement trouvé, arrêtez d’attendre.\n"
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Impossible de définir le répertoire."
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Impossible d'obtenir l'image."
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "libcanon.so défectueuse ?"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Impossible de supprimer l'image."
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
-msgstr "Obtention de renseignements sur le stockage impossible avec cet appareil.\n"
+msgstr ""
+"Obtention de renseignements sur le stockage impossible avec cet appareil.\n"
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Lecture et écriture"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Lecture seule"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Lecture seule avec suppression"
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "ROM fixe"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "ROM amovible"
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "RAM fixe"
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "RAM amovible"
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Indéfinie"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Générique plat"
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Générique hiérarchique"
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Disposition de l'appareil (DCIM)"
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
-msgstr "Remplacement des identifiants USB constructeur/produit 0x%x/0x%x par 0x%x/0x%x"
+msgstr ""
+"Remplacement des identifiants USB constructeur/produit 0x%x/0x%x par 0x%x/0x"
+"%x"
 
-#: gphoto2/actions.c:1435
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "Veuillez toujours intégrer les lignes suivantes lors de l'envoi de messages de débogage à la liste de diffusion :"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"Veuillez toujours intégrer les lignes suivantes lors de l'envoi de messages "
+"de débogage à la liste de diffusion :"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s a été compilé avec les options suivantes :"
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s introuvable dans l'arborescence de configuration."
 
-#: gphoto2/actions.c:1630
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
-msgstr "Échec de récupération de la valeur dans l'élément graphique textuel %s."
+msgstr ""
+"Échec de récupération de la valeur dans l'élément graphique textuel %s."
 
-#: gphoto2/actions.c:1647
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
-msgstr "Échec de récupération des valeurs dans l'élément graphique d'intervalle %s."
+msgstr ""
+"Échec de récupération des valeurs dans l'élément graphique d'intervalle %s."
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
-msgstr "Échec de récupération des valeurs dans l'élément graphique de bascule %s."
+msgstr ""
+"Échec de récupération des valeurs dans l'élément graphique de bascule %s."
 
-#: gphoto2/actions.c:1671
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
-msgstr "Échec de récupération des valeurs dans l'élément graphique de date et heure %s."
+msgstr ""
+"Échec de récupération des valeurs dans l'élément graphique de date et heure "
+"%s."
 
-#: gphoto2/actions.c:1680
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "Utiliser « maintenant » comme date actuelle de réglage.\n"
 
-#: gphoto2/actions.c:1702
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Échec de récupération des valeurs dans l'élément graphique radio %s."
 
-#: gphoto2/actions.c:1746
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "La propriété %s est en lecture seule."
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
-msgstr "Échec de définition de la valeur de l'élément graphique textuel %s à %s."
+msgstr ""
+"Échec de définition de la valeur de l'élément graphique textuel %s à %s."
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "La valeur %s, passée en paramètre, n'est pas un nombre réel."
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
-msgstr "La valeur %f, passée en paramètre, n'est pas dans l'intervalle attendu de %f à %f."
+msgstr ""
+"La valeur %f, passée en paramètre, n'est pas dans l'intervalle attendu de %f "
+"à %f."
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
-msgstr "Échec de définition de la valeur dans l'élément graphique d'intervalle %s à %f."
+msgstr ""
+"Échec de définition de la valeur dans l'élément graphique d'intervalle %s à "
+"%f."
 
-#: gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "arrêt"
 
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "faux"
 
-#: gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "marche"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "vrai"
 
-#: gphoto2/actions.c:1802 gphoto2/actions.c:2039
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
-msgstr "La valeur %s, passée en paramètre, n'est pas une valeur de bascule possible."
+msgstr ""
+"La valeur %s, passée en paramètre, n'est pas une valeur de bascule possible."
 
-#: gphoto2/actions.c:1808 gphoto2/actions.c:2045
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
-msgstr "Échec de définition des valeurs %s de l'élément graphique de bascule %s."
+msgstr ""
+"Échec de définition des valeurs %s de l'élément graphique de bascule %s."
 
-#: gphoto2/actions.c:1820
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "maintenant"
 
-#: gphoto2/actions.c:1832 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
-msgstr "La valeur %s, passée en paramètre, n'est ni une heure possible, ni un entier."
+msgstr ""
+"La valeur %s, passée en paramètre, n'est ni une heure possible, ni un entier."
 
-#: gphoto2/actions.c:1840 gphoto2/actions.c:2065
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
-msgstr "Échec de définition de la nouvelle valeur d'heure de l'élément graphique de date et heure %s à %s."
+msgstr ""
+"Échec de définition de la nouvelle valeur d'heure de l'élément graphique de "
+"date et heure %s à %s."
 
-#: gphoto2/actions.c:1887 gphoto2/actions.c:1951 gphoto2/actions.c:2095
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Le choix %s est introuvable parmi les choix possibles."
 
-#: gphoto2/actions.c:1895 gphoto2/actions.c:2103
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "L'élément graphique %s n'est pas configurable."
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:1970 gphoto2/actions.c:2110
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
-msgstr "Échec de définition de la nouvelle valeur de configuration %s pour l'entrée de configuration %s."
+msgstr ""
+"Échec de définition de la nouvelle valeur de configuration %s pour l'entrée "
+"de configuration %s."
 
-#: gphoto2/actions.c:1963
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "L'élément graphique %s n'a pas de liste de choix indicée. Utilisez plutôt --set-config-value."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"L'élément graphique %s n'a pas de liste de choix indicée. Utilisez plutôt --"
+"set-config-value."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Numéro de fichier incorrect. Vous avez indiqué %i, mais seuls %i fichiers sont disponibles dans « %s » et ses sous-répertoires. Vous pouvez obtenir un numéro de fichier possible dans la liste des fichiers."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Numéro de fichier incorrect. Vous avez indiqué %i, mais seuls %i fichiers "
+"sont disponibles dans « %s » et ses sous-répertoires. Vous pouvez obtenir un "
+"numéro de fichier possible dans la liste des fichiers."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -684,25 +754,34 @@ msgstr "Le dossier « %s » ne contient aucun fichier."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Numéro de fichier incorrect. Vous avez indiqué %i, mais un seul fichier est disponible dans « %s »."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Numéro de fichier incorrect. Vous avez indiqué %i, mais un seul fichier est "
+"disponible dans « %s »."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Numéro de fichier incorrect. Vous avez indiqué %i, mais seuls %i fichiers sont disponibles dans « %s ». Vous pouvez obtenir un numéro de fichier possible dans la liste des fichiers."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Numéro de fichier incorrect. Vous avez indiqué %i, mais seuls %i fichiers "
+"sont disponibles dans « %s ». Vous pouvez obtenir un numéro de fichier "
+"possible dans la liste des fichiers."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Erreur ***\n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Veuillez appuyer sur une touche pour continuer.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Mémoire insuffisante."
@@ -711,207 +790,216 @@ msgstr "Mémoire insuffisante."
 msgid "Operation cancelled"
 msgstr "Opération annulée"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Continuer"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Annuler"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Erreur"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Impossible d'appliquer la configuration :"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Sortir"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Retour"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Heure : "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Valeur : "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Oui"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Non"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
-msgstr "Le remplissage des noms de fichier avec des zéros n'est possible qu'avec %%n."
+msgstr ""
+"Le remplissage des noms de fichier avec des zéros n'est possible qu'avec %%n."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
-msgstr "Impossible d'utiliser le remplissage avec des zéros %%n sans valeur de précision."
+msgstr ""
+"Impossible d'utiliser le remplissage avec des zéros %%n sans valeur de "
+"précision."
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Le fichier donné par l'appareil photo (« %s ») n'a pas de suffixe."
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Format « %s » incorrect (erreur à la position %i)."
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Saut du fichier %s existant\n"
 
 # !!! [y/n] !!! [CM]
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Le fichier %s existe. Voulez-vous l'écraser ? [y|n] "
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Voulez-vous indiquer un nouveau nom de fichier ? [y|n] "
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Entrez un nouveau nom de fichier : "
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Enregistrement du fichier en %s\n"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Permission refusée"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Impossible de déclencher l'acquisition."
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Le nouveau fichier est à l'emplacement %s%s%s de l'appareil\n"
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Conservation du fichier %s%s%s de l'appareil\n"
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Effacement du fichier %s%s%s de l'appareil\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "Événement d'ajout de dossier %s/%s pendant l'attente, ignorer.\n"
 
 #: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "Événement d'ajout de dossier %s/%s pendant l'attente, ignorer.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Événement inconnu %s pendant l'attente, ignorer.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
-msgstr "Type %d d'événement inconnu pendant l'attente en pose longue, ignorer.\n"
+msgstr ""
+"Type %d d'événement inconnu pendant l'attente en pose longue, ignorer.\n"
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Impossible d'obtenir les capacités."
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Mode accéléré activé (intervalle : %d s).\n"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Reste en attente pour l'acquisition de SIGUSR1.\n"
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Mode pose longue activé (intervalle : %d s).\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Acquisition de l'image nº %d…\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Acquisition de l'image nº %d/%d…\n"
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Impossible de paramétrer l'acquisition en pose longue, résultat %d."
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Impossible de terminer l'acquisition (mode pose longue)"
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Impossible de déclencher l'acquisition d'image."
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Acquisition d'image impossible."
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Échec d'acquisition (problème d'autofocus possible)…\n"
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Acquisition impossible."
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "En attente de la prochaine acquisition dans %ld secondes…\n"
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Réveillé par SIGUSR1…\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "pas en veille (%ld secondes de retard)\n"
 
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "Erreur : "
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -920,12 +1008,12 @@ msgstr ""
 "\n"
 "Abandon…\n"
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Abandonné.\n"
 
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -934,21 +1022,26 @@ msgstr ""
 "\n"
 "Annulation…\n"
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Utilisez la syntaxe a:b=c:d pour traiter n'importe quel périphérique USB détecté comme a:b au lieu de c:d. a, b, c et d doivent être des nombres hexadécimaux commençant par « 0x ».\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Utilisez la syntaxe a:b=c:d pour traiter n'importe quel périphérique USB "
+"détecté comme a:b au lieu de c:d. a, b, c et d doivent être des nombres "
+"hexadécimaux commençant par « 0x ».\n"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gPhoto2 a été compilé sans la gestion de CDK."
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Opération annulée.\n"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -957,7 +1050,7 @@ msgstr ""
 "*** Erreur : aucun appareil trouvé. ***\n"
 "\n"
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -966,7 +1059,7 @@ msgstr ""
 "*** Erreur (%i : « %s ») ***\n"
 "\n"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -983,7 +1076,7 @@ msgstr ""
 "en anglais, veuillez exécuter gphoto2 comme suit :\n"
 "\n"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
@@ -992,393 +1085,404 @@ msgstr ""
 "Veuillez vous assurer que les arguments sont suffisamment protégés.\n"
 "\n"
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Afficher l'aide complète d'utilisation du programme"
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Afficher le résumé d'utilisation du programme"
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Activer le débogage"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Définir le niveau de débogage [error|debug|data|all]"
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Nom du fichier où écrire les renseignements de débogage"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "NOM_DE_FICHIER"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Mode silencieux (bavard par défaut)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Script à appeler après le téléchargement, l'acquisition, etc."
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Indiquer le port du périphérique"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Indiquer la vitesse du transfert série"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "VITESSE"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Indiquer le modèle de l'appareil"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODÈLE"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "Redéfinir les identifiants USB (pour les spécialistes)"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "IDENTIFIANTS"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Afficher la version et quitter"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Afficher les modèles d'appareils gérés"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Afficher les ports de périphériques gérés"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
-msgstr "Afficher les possibilités de l'appareil ou du pilote dans la base de données de libgphoto2"
+msgstr ""
+"Afficher les possibilités de l'appareil ou du pilote dans la base de données "
+"de libgphoto2"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Configurer"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Afficher l'arborescence de configuration"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Afficher l'arborescence de configuration complète"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Obtenir une valeur de configuration"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Définir une valeur de configuration ou d'indice de choix"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Définir une valeur d'indice de choix de configuration"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Définir une valeur de configuration "
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Réinitialiser le port du périphérique"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Garder les images sur l'appareil après l'acquisition"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr "Garder les images brutes sur l'appareil après l'acquisition"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Supprimer les images de l'appareil après l'acquisition"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Attendre un ou des événements de l'appareil"
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr "NOMBRE, SECONDES, MILLISECONDES ou CHAÎNE"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
-msgstr "Attendre un ou des événements de l'appareil et télécharger les nouvelles images"
+msgstr ""
+"Attendre un ou des événements de l'appareil et télécharger les nouvelles "
+"images"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Acquérir une prévisualisation"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr "Montrer une prévisualisation en art ASCII"
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Initialiser le temps d'exposition de pose longue en seconde"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SECONDES"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Définir le nombre d'images à capturer (infini par défaut)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "NOMBRE"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Définir l'intervalle de capture en seconde"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Réinitialiser l'intervalle de capture au signal (non par défaut)"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Acquérir une image"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Déclencher l'acquisition d'une image"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Acquérir et télécharger une image"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Acquérir un film"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "NOMBRE ou SECONDES"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Acquérir un extrait sonore"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Attendre que le déclencheur soit relâché et télécharger"
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr "Déclencher l'acquisition d'image."
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Afficher les dossiers du dossier"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Afficher les fichiers du dossier"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Créer un répertoire"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "NOM_DE_RÉPERTOIRE"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Supprimer un répertoire"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Afficher le nombre de fichiers"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Récupérer les fichiers de l'intervalle"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "INTERVALLE"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Récupérer tous les fichiers du dossier"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Récupérer les vignettes de l'intervalle"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Récupérer toutes les vignettes du dossier"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Récupérer les métadonnées de l'intervalle"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Récupérer toutes les métadonnées du dossier"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Envoyer les métadonnées du fichier"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Récupérer les données brutes de l'intervalle"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Récupérer toutes les données brutes du dossier"
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Récupérer les données sonores de l'intervalle"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Récupérer toutes les données sonores du dossier"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Supprimer les fichiers de l'intervalle"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Supprimer tous les fichiers du dossier (--no-recurse par défaut)"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Envoyer un fichier à l'appareil"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Indiquer un nom de fichier ou un motif de nom de fichier"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "MOTIF_DE_FICHIER"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Indiquer le dossier de l'appareil (« / » par défaut)"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "DOSSIER"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Récursion (par défaut pour le téléchargement)"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Pas de récursion (par défaut pour l'effacement)"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Ne traiter que les nouveaux fichiers"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Écraser les fichiers sans confirmation"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Saut des fichiers existants"
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Envoyer les fichiers sur la sortie standard"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Afficher la taille du fichier avant les données"
 
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Afficher les appareils autodétectés"
 
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "Afficher les données EXIF des images JPEG"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
-msgstr "Afficher des renseignements sur l’image, tels que largeur, hauteur et date d’acquisition"
+msgstr ""
+"Afficher des renseignements sur l’image, tels que largeur, hauteur et date "
+"d’acquisition"
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr "Afficher le résumé de l’appareil photo"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Afficher le manuel du pilote de l'appareil"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "À propos du manuel du pilote de l'appareil"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Afficher les renseignements de stockage"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "Interpréteur gPhoto"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Options communes"
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Options diverses (non triés)"
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "Renseignements sur le programme et le système (pas sur l'appareil)"
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Indication de l'appareil à utiliser"
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Configuration de l'appareil et du programme"
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Acquisition d'une image de l'appareil"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Téléchargement, envoi et manipulation de fichiers"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1387,7 +1491,7 @@ msgstr ""
 "%s\n"
 "Les identifiants d'image doivent être des nombres supérieurs à zéro."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1396,7 +1500,7 @@ msgstr ""
 "%s\n"
 "Identifiant d'image %i trop grand."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1405,7 +1509,7 @@ msgstr ""
 "%s\n"
 "Les intervalles doivent être séparés par des « , »."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1414,7 +1518,7 @@ msgstr ""
 "%s\n"
 "Les intervalles doivent commencer par un nombre."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1423,225 +1527,238 @@ msgstr ""
 "%s\n"
 "Caractère « %c » inattendu."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"Les intervalles décroissants ne sont pas autorisés. Vous devez indiquer un intervalle de %i à %i."
+"Les intervalles décroissants ne sont pas autorisés. Vous devez indiquer un "
+"intervalle de %i à %i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Erreur (%i : « %s ») ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Aller dans un répertoire de l'appareil"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "répertoire"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Aller dans un répertoire du disque local"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Quitter l'interpréteur gPhoto"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Télécharger un fichier"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[répertoire/]nom_de_fichier"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Envoi d'un fichier"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Télécharger une vignette"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Télécharger des données brutes"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Supprimer"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Créer un répertoire"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Supprimer un répertoire"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Afficher l'aide sur les commandes"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[commande]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Afficher le contenu du répertoire actuel"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[répertoire/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Afficher les variables de configuration"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Obtenir une variable de configuration"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "nom"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Définir une variable de configuration"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "nom=valeur"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Initialiser l'indice d'une variable de configuration"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "nom=indicevaleur"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Déclencher l'acquisition d'une image"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Acquérir une seule image"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Acquérir une seule image et la télécharger"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Acquérir un aperçu d'image"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Attendre d'un événement"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "nombre ou secondes"
 
 # NOTE: s/it/them/?
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Attendre l'acquisition d'images avant de télécharger"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Attendre les événements et l'acquisition d'images avant de télécharger"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Commande incorrecte."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "La commande « %s » a besoin d'un paramètre."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Chemin d'accès incorrect."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Répertoire personnel introuvable."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Impossible d'aller dans le répertoire local « %s »."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Le répertoire local est désormais « %s »."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Le répertoire distant est désormais « %s »."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config a besoin d'un deuxième paramètre.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "set-config-value a besoin d'un deuxième paramètre.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "set-config-index a besoin d'un deuxième paramètre.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Commande « %s » introuvable. Utilisez « help » pour obtenir la liste des commandes disponibles."
+msgstr ""
+"Commande « %s » introuvable. Utilisez « help » pour obtenir la liste des "
+"commandes disponibles."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Aide sur « %s » :"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Utilisation :"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Description :"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Les paramètres entre crochets [] sont facultatifs"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Commandes disponibles :"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Pour obtenir de l'aide sur une commande particulière, entrez « help nom-de-la-commande ». "
+msgstr ""
+"Pour obtenir de l'aide sur une commande particulière, entrez « help nom-de-"
+"la-commande ». "
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Déclencher l'acquisition d'image."
 
 #~ msgid "Show info"
 #~ msgstr "Afficher les renseignements"
@@ -1703,11 +1820,22 @@ msgstr "Pour obtenir de l'aide sur une commande particulière, entrez « help n
 #~ msgid "count"
 #~ msgstr "nombre"
 
-#~ msgid "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
-#~ msgstr "Pour gPhoto2 version OS/2, il est nécessaire de définir la variable d'environnement CAMLIBS, afin qu'elle indique l'emplacement des bibliothèques de gestion des appareils, par ex. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the "
+#~ "location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgstr ""
+#~ "Pour gPhoto2 version OS/2, il est nécessaire de définir la variable "
+#~ "d'environnement CAMLIBS, afin qu'elle indique l'emplacement des "
+#~ "bibliothèques de gestion des appareils, par ex. SET CAMLIBS=C:"
+#~ "\\GPHOTO2\\CAM\n"
 
-#~ msgid "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
-#~ msgstr "Pour gPhoto2 version OS/2, il est nécessaire de définir la variable d'environnement IOLIBS, afin qu'elle indique l'emplacement des bibliothèques de communication, par ex. SET CAMLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the "
+#~ "location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgstr ""
+#~ "Pour gPhoto2 version OS/2, il est nécessaire de définir la variable "
+#~ "d'environnement IOLIBS, afin qu'elle indique l'emplacement des "
+#~ "bibliothèques de communication, par ex. SET CAMLIBS=C:\\GPHOTO2\\IOLIB\n"
 
 #~ msgid "Usage:\n"
 #~ msgstr "Utilisation :\n"
@@ -1724,7 +1852,9 @@ msgstr "Pour obtenir de l'aide sur une commande particulière, entrez « help n
 
 #~ msgid ""
 #~ "--------------------------------------------------------------------------------\n"
-#~ "[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
+#~ "[Use double-quotes around arguments]        [Picture numbers begin with "
+#~ "one (1)]\n"
 #~ msgstr ""
 #~ "--------------------------------------------------------------------------------\n"
-#~ "[Mettre les paramètres entre « \" »]   [Les numéros d'images commencent à un (1)]\n"
+#~ "[Mettre les paramètres entre « \" »]   [Les numéros d'images commencent à "
+#~ "un (1)]\n"

--- a/po/hu.po
+++ b/po/hu.po
@@ -8,147 +8,147 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.9\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-11-18 22:19+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2015-11-20 23:38+0100\n"
 "Last-Translator: Balázs Úr <urbalazs@gmail.com>\n"
 "Language-Team: Hungarian <translation-team-hu@lists.sourceforge.net>\n"
 "Language: hu\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 1.2\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "A(z) „%s” mappában lévő fájlok száma: %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "%d mappa van a(z) „%s” mappában.\n"
 msgstr[1] "%d mappa van a(z) „%s” mappában.\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Nincs fájl a(z) „%s” mappában.\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "%d fájl van a(z) „%s” mappában.\n"
 msgstr[1] "%d fájl van a(z) „%s” mappában.\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Információ a(z) „%s” fájlról („%s” könyvtárban):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Fájl:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Nincs elérhető.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  MIME-típus:  „%s”\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Méret:       %lu bájt\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Szélesség:   %i képpont\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Magasság:    %i képpont\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Letöltve:    %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "igen"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "nem"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Jogosultságok: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "olvasás/törlés"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "olvasás"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "törlés"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "nincs"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Idő:         %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Bélyegkép:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Hanganyag:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  MIME-típus: „%s”\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Méret:      %lu bájt\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Letöltve:   %s\n"
@@ -170,46 +170,46 @@ msgstr "Címke"
 msgid "Value"
 msgstr "Érték"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Az EXIF adat egy bélyegképet tartalmaz (%i bájt)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "A gphoto2 EXIF támogatás nélkül lett lefordítva."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Támogatott kamerák száma: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Támogatott kamerák:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t„%s” (TESZTELÉS)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t„%s” (KÍSÉRLETI)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t„%s”\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Talált eszközök: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -218,155 +218,170 @@ msgstr ""
 "Útvonal                          Leírás\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Modell"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Port"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "A kamera képességei              : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Soros port támogatás             : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB támogatás                    : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Támogatott átviteli sebességek   :\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Rögzítési lehetőségek            :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Kép\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Videó\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Hang\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Előnézet\n"
 
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr "                                 : Aktiváló rögzítés\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : A meghajtó nem támogatja a rögzítést\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : A meghajtó nem támogatja a rögzítést\n"
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Beállítási támogatás             : %s\n"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Kijelölt fájlok törlése a kamerán: %s\n"
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Minden fájl törlése a kamerán    : %s\n"
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Fájlelőnézet (bélyegkép) támogatás: %s\n"
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Fájlfeltöltés támogatás          : %s\n"
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "A portoknak így kell kinézniük: „serial:/dev/ttyS0” vagy „usb:”, de a(z) „%s” nem tartalmaz kettőspontot, ezért megpróbálom kitalálni, hogy lenne helyes."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"A portoknak így kell kinézniük: „serial:/dev/ttyS0” vagy „usb:”, de a(z) "
+"„%s” nem tartalmaz kettőspontot, ezért megpróbálom kitalálni, hogy lenne "
+"helyes."
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "A megadott port („%s”) nem található. Olyan portot adjon meg, amit a „gphoto2 --list-ports” parancs megtalált, és győződjön meg arról, hogy jól írta-e be (azaz „serial:” vagy „usb:” előtaggal)."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"A megadott port („%s”) nem található. Olyan portot adjon meg, amit a "
+"„gphoto2 --list-ports” parancs megtalált, és győződjön meg arról, hogy jól "
+"írta-e be (azaz „serial:” vagy „usb:” előtaggal)."
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "A kamerameghajtó névjegye:"
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Kamera összefoglaló:"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Kamera kézikönyv:"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Csak a soros portok sebessége adható meg."
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "OS/2-re átírta Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:907
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
@@ -377,300 +392,345 @@ msgstr ""
 "adni a GNU General Public License rendelkezései alapján. További \n"
 "információkért olvassa el a COPYING nevű fájlokat.\n"
 "\n"
-"A gphoto2 ezen verziója a következő programverziókat és kapcsolókat használja:\n"
+"A gphoto2 ezen verziója a következő programverziókat és kapcsolókat "
+"használja:\n"
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Nem sikerült megnyitni: „movie.mjpg”."
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Előnézeti képkockák rögzítése filmként a(z) „%s” helyre. A megszakításhoz nyomja meg a Ctrl+C billentyűket.\n"
+msgstr ""
+"Előnézeti képkockák rögzítése filmként a(z) „%s” helyre. A megszakításhoz "
+"nyomja meg a Ctrl+C billentyűket.\n"
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
-msgstr "Előnézeti képkockák rögzítése filmként a(z) „%s” helyre %d másodpercig.\n"
+msgstr ""
+"Előnézeti képkockák rögzítése filmként a(z) „%s” helyre %d másodpercig.\n"
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "%d előnézeti képkocka rögzítése filmként a(z) „%s” helyre.\n"
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Filmrögzítési hiba… Kilépés."
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Filmrögzítési hiba… Kezeletlen „%s” MIME-típus."
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ctrl-C megnyomva… Kilépés.\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "A filmrögzítés befejeződött (%d képkocka)\n"
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Várakozás a kamerából érkező eseményekre. A megszakításhoz nyomja meg a Ctrl+C billentyűket.\n"
+msgstr ""
+"Várakozás a kamerából érkező eseményekre. A megszakításhoz nyomja meg a Ctrl"
+"+C billentyűket.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
-msgstr "Várakozás a kamerából érkező %d képkockára. A megszakításhoz nyomja meg a Ctrl+C billentyűket.\n"
+msgstr ""
+"Várakozás a kamerából érkező %d képkockára. A megszakításhoz nyomja meg a "
+"Ctrl+C billentyűket.\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Várakozás %d ezredmásodpercig a kamerából érkező eseményekre. A megszakításhoz nyomja meg a Ctrl+C billentyűket.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Várakozás %d ezredmásodpercig a kamerából érkező eseményekre. A "
+"megszakításhoz nyomja meg a Ctrl+C billentyűket.\n"
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Várakozás %d másodpercig a kamerából érkező eseményekre. A megszakításhoz nyomja meg a Ctrl+C billentyűket.\n"
-
-#: gphoto2/actions.c:1121
-#, c-format
-msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
-msgstr "Várakozás a kamerából érkező %d eseményre. A megszakításhoz nyomja meg a Ctrl+C billentyűket.\n"
+msgstr ""
+"Várakozás %d másodpercig a kamerából érkező eseményekre. A megszakításhoz "
+"nyomja meg a Ctrl+C billentyűket.\n"
 
 #: gphoto2/actions.c:1125
 #, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
-msgstr "Várakozás a kamerából érkező %s eseményre. A megszakításhoz nyomja meg a Ctrl+C billentyűket.\n"
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Várakozás a kamerából érkező %d eseményre. A megszakításhoz nyomja meg a Ctrl"
+"+C billentyűket.\n"
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Várakozás a kamerából érkező %s eseményre. A megszakításhoz nyomja meg a Ctrl"
+"+C billentyűket.\n"
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "esemény található, várakozás leállítása!\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "esemény található, várakozás leállítása!\n"
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Nem sikerült beállítani a mappát."
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Nem sikerült lekérni a képet."
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "Hibás libcanon.so?"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Nem sikerült törölni a képet."
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr "A tároló információk lekérése nem támogatott ehhez a kamerához.\n"
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Írható-olvasható"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Csak olvasható"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Csak olvasható törléssel"
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "Rögzített ROM"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "Cserélhető ROM"
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "Rögzített RAM"
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "Cserélhető RAM"
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Nem meghatározott"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Általános lapos"
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Általános hierarchikus"
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Kamera elrendezés (DCIM)"
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "A 0x%x/0x%x USB gyártó/termék azonosító felülbírálása ezzel: 0x%x/0x%x"
 
-#: gphoto2/actions.c:1435
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "A KÖVETKEZŐ SOROKAT MINDIG ADJA MEG, HA HIBAKERESÉSI ÜZENETEKET KÜLD A LEVELEZŐLISTÁRA:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"A KÖVETKEZŐ SOROKAT MINDIG ADJA MEG, HA HIBAKERESÉSI ÜZENETEKET KÜLD A "
+"LEVELEZŐLISTÁRA:"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "A(z) %s a következő kapcsolókkal lett lefordítva:"
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "A(z) %s nem található a beállítási fában."
 
-#: gphoto2/actions.c:1630
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Nem sikerült lekérni a(z) %s szöveg felületi elem értékét."
 
-#: gphoto2/actions.c:1647
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Nem sikerült lekérni a(z) %s tartomány felületi elem értékeit."
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Nem sikerült lekérni a(z) %s váltó felületi elem értékeit."
 
-#: gphoto2/actions.c:1671
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Nem sikerült lekérni a(z) %s dátum/idő felületi elem értékeit."
 
-#: gphoto2/actions.c:1680
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "Beállításkor használja a „now” értéket aktuális időként.\n"
 
-#: gphoto2/actions.c:1702
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Nem sikerült lekérni a(z) %s rádió felületi elem értékeit."
 
-#: gphoto2/actions.c:1746
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "A(z) %s tulajdonság csak olvasható."
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Nem sikerült beállítani a(z) %s szöveg felületi elem értékét erre: %s."
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Az átadott %s érték nem lebegőpontos érték."
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "Az átadott %f érték nem az elvárt %f - %f tartományon belül van."
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
-msgstr "Nem sikerült beállítani a(z) %s tartomány felületi elem értékét erre: %f."
+msgstr ""
+"Nem sikerült beállítani a(z) %s tartomány felületi elem értékét erre: %f."
 
-#: gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "ki"
 
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "hamis"
 
-#: gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "be"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "igaz"
 
-#: gphoto2/actions.c:1802 gphoto2/actions.c:2039
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Az átadott %s érték nem érvényes váltó érték."
 
-#: gphoto2/actions.c:1808 gphoto2/actions.c:2045
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Nem sikerült beállítani a(z) %s váltó felületi elem %s értékeit."
 
-#: gphoto2/actions.c:1820
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "most"
 
-#: gphoto2/actions.c:1832 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "Az átadott %s érték nem érvényes idő vagy nem egész."
 
-#: gphoto2/actions.c:1840 gphoto2/actions.c:2065
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
-msgstr "Nem sikerült beállítani a(z) %s dátum/idő felületi elem új idejét erre: %s."
+msgstr ""
+"Nem sikerült beállítani a(z) %s dátum/idő felületi elem új idejét erre: %s."
 
-#: gphoto2/actions.c:1887 gphoto2/actions.c:1951 gphoto2/actions.c:2095
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "A(z) %s választás nem található a választások listájában."
 
-#: gphoto2/actions.c:1895 gphoto2/actions.c:2103
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "A(z) %s felületi elem nem állítható be."
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:1970 gphoto2/actions.c:2110
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
-msgstr "Nem sikerült az új %s konfigurációs érték beállítása a(z) %s konfigurációs bejegyzéshez."
+msgstr ""
+"Nem sikerült az új %s konfigurációs érték beállítása a(z) %s konfigurációs "
+"bejegyzéshez."
 
-#: gphoto2/actions.c:1963
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "A(z) %s felületi elemnek nincs indexelt választások listája. Használja a --set-config-value parancsot helyette."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"A(z) %s felületi elemnek nincs indexelt választások listája. Használja a --"
+"set-config-value parancsot helyette."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Hibás a fájlok száma. Ennyit adott meg: %i, de csak %i fájl érhető el a(z) „%s” mappában vagy az almappáiban. A helyes értéket a fájlok listázásából szerezheti meg."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Hibás a fájlok száma. Ennyit adott meg: %i, de csak %i fájl érhető el a(z) "
+"„%s” mappában vagy az almappáiban. A helyes értéket a fájlok listázásából "
+"szerezheti meg."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -679,25 +739,33 @@ msgstr "Nincsenek fájlok a(z) „%s” mappában."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Hibás a fájlok száma. Ennyit adott meg: %i, de csak 1 fájl érhető el ebben: „%s”."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Hibás a fájlok száma. Ennyit adott meg: %i, de csak 1 fájl érhető el ebben: "
+"„%s”."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Hibás a fájlok száma. Ennyit adott meg: %i, de csak %i fájl érhető el a(z) „%s” mappában. A helyes értéket a fájlok listázásából szerezheti meg."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Hibás a fájlok száma. Ennyit adott meg: %i, de csak %i fájl érhető el a(z) "
+"„%s” mappában. A helyes értéket a fájlok listázásából szerezheti meg."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Hiba ***               \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Nyomjon meg egy billentyűt a folytatáshoz.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Nincs elég memória."
@@ -706,206 +774,211 @@ msgstr "Nincs elég memória."
 msgid "Operation cancelled"
 msgstr "Művelet megszakítva"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Folytatás"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Mégse"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Hiba"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Nem sikerült beállítani a konfigurációt:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Kilépés"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Vissza"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Idő: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Érték: "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Igen"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Nem"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "A fájlnevekben lévő nulla kitöltő számok csak ezzel lehetséges: %%n."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "Nem használható a(z) „%%n” nulla kitöltés egy pontossági érték nélkül!"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "A kamera által megadott fájlnév („%s”) nem tartalmaz utótagot!"
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Érvénytelen formátum „%s” (hiba a pozíciónál: %i)."
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "A létező %s fájl kihagyása\n"
 
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "A(z) %s fájl létezik. Felülírja? [y|n] "
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Megad új fájlnevet? [y|n] "
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Új fájlnév megadása: "
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Fájl mentése mint %s\n"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Hozzáférés megtagadva"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Nem sikerült aktiválni a rögzítést."
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Az új fájl helye a kamerán: %s%s%s\n"
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "A(z) %s%s%s fájl megtartása a kamerán\n"
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "A(z) %s%s%s fájl törlése a kameráról\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "FOLDER_ADDED %s/%s esemény a várakozás közben, mellőzés.\n"
 
 #: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "FOLDER_ADDED %s/%s esemény a várakozás közben, mellőzés.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "UNKNOWN %s esemény a várakozás közben, mellőzés.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr "Ismeretlen %d eseménytípus az izzó várakozás közben, mellőzés.\n"
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Nem sikerült lekérni a képességeket?"
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Az idő múlás mód engedélyezve (időköz: %ds).\n"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Készen állunk a SIGUSR1 értékére várakozva a rögzítéshez.\n"
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Izzó mód engedélyezve (exponálási idő: %ds).\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "A #%d képkocka rögzítése…\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "A #%d/%d képkocka rögzítése…\n"
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Nem sikerült beállítani az izzó rögzítést, %d eredmény."
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Nem sikerült befejezni a rögzítést (izzó mód)."
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Nem sikerült aktiválni a képrögzítést."
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Nem sikerült rögzíteni a képet."
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "A rögzítés nem sikerült (automatikus fókusz probléma?)…\n"
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Nem sikerült rögzíteni."
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Várakozás a következő rögzítési résre %ld másodpercig…\n"
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "A SIGUSR1 felébresztette…\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "nem alszik (%ld másodperccel az ütemezés mögött)\n"
 
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "HIBA: "
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -914,12 +987,12 @@ msgstr ""
 "\n"
 "Megszakítás…\n"
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Megszakítva.\n"
 
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -928,21 +1001,26 @@ msgstr ""
 "\n"
 "Kilépés…\n"
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Használja az a:b=c:d szintaxist bármely USB-eszköz kezeléséhez, amely a:b-ként lett felismerve c:d helyett. Az a, b, c, d értékeknek „0x” kezdetű hexadecimális számoknak kell lenniük.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Használja az a:b=c:d szintaxist bármely USB-eszköz kezeléséhez, amely a:b-"
+"ként lett felismerve c:d helyett. Az a, b, c, d értékeknek „0x” kezdetű "
+"hexadecimális számoknak kell lenniük.\n"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "A gphoto2 CDK támogatás nélkül lett lefordítva."
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Művelet megszakítva.\n"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -951,7 +1029,7 @@ msgstr ""
 "*** Hiba: nem található kamera. ***\n"
 "\n"
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -960,7 +1038,7 @@ msgstr ""
 "*** Hiba (%i: „%s”) ***        \n"
 "\n"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -973,10 +1051,11 @@ msgstr ""
 "Hibakereső üzenetekhez használja a --debug kapcsolót.\n"
 "A hibakereső üzenetek segíthetnek megoldást találni a problémára.\n"
 "Ha szándékában áll hibajelentést küldeni a gphoto fejlesztők levelezési\n"
-"listájára <gphoto-devel@lists.sourceforge.net>, kérjük így futtassa a gphoto2 programot:\n"
+"listájára <gphoto-devel@lists.sourceforge.net>, kérjük így futtassa a "
+"gphoto2 programot:\n"
 "\n"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
@@ -985,393 +1064,402 @@ msgstr ""
 "Győződjön meg arról, hogy elegendő idézőjel van az argumentumok körül.\n"
 "\n"
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "A teljes súgóüzenet kinyomtatása a program használatáról"
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Rövid üzenet kinyomtatása a program használatáról"
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Hibakeresés bekapcsolása"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Hibakeresési szint beállítása [error|debug|data|all]"
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "A fájl neve, amelybe a hibakeresési információk lesznek írva"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "FÁJLNÉV"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Csendes kimenet (alapértelmezett = bőbeszédű)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Horog parancsfájl a letöltések, rögzítések, stb. utáni meghíváshoz."
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Eszköz port megadása"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Soros átviteli sebesség megadása"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "SEBESSÉG"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Kameramodell megadása"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODELL"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(csak szakértőknek) USB azonosítók felülbírálása"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBAZONOSÍTÓK"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Verzió megjelenítése és kilépés"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Támogatott kameramodellek listázása"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Támogatott port eszközök listázása"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Kamera/meghajtó képességeinek megjelenítése a libgphoto2 adatbázisban"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Beállítás"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Beállítási fa listázása"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Teljes beállítási fa kiírása"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Beállítási érték lekérése"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Beállítási érték vagy a választásokban lévő index beállítása"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "A választásokban lévő beállítási érték index beállítása"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Beállítási érték beállítása"
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Eszköz port visszaállítása"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Képek megtartása a kamerán a rögzítés után"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr "RAW képek megtartása a kamerán a rögzítés után"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Képek eltávolítása a kameráról a rögzítés után"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Várakozás a kamerából érkező eseményekre"
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr "DARAB, MÁSODPERCEK, EZREDMÁSODPERCEK vagy ILLESZTÉSSZÖVEG"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Várakozás a kamerából érkező eseményekre, és új képek letöltése"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Gyors előnézet rögzítése"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr "Gyors előnézet megjelenítése Ascii grafikaként"
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Izzó exponálási idő beállítása másodpercben"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "MÁSODPERC"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
-msgstr "A rögzítendő képkockák számának beállítása (alapértelmezett = végtelen)"
+msgstr ""
+"A rögzítendő képkockák számának beállítása (alapértelmezett = végtelen)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "SZÁM"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Rögzítési időköz beállítása másodpercben"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Rögzítési időköz visszaállítása a szignálon (alapértelmezett = nem)"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Kép rögzítése"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Egy kép rögzítésének aktiválója"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Egy kép rögzítése és letöltése"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Film rögzítése"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "SZÁM vagy MÁSODPERC"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Hangklip rögzítése"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Várakozás a zár kiengedésére a kamerán és letöltés"
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr "Képrögzítés aktiválás"
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Mappák listázása a mappában"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Fájlok listázása a mappában"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Könyvtár létrehozása"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "KÖNYVTÁRNÉV"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Könyvtár eltávolítása"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Fájlok számának megjelenítése"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Az adott tartományban lévő fájlok lekérése"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "TARTOMÁNY"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Az összes fájl lekérése a mappából"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Az adott tartományban lévő bélyegképek lekérése"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Az összes bélyegkép lekérése a mappából"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Az adott tartományban lévő metaadatok lekérése"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Az összes metaadat lekérése a mappából"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Metaadatok feltöltése a fájlhoz"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Az adott tartományban lévő nyers adatok lekérése"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Az összes nyers adat lekérése a mappából"
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Az adott tartományban lévő hangadatok lekérése"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Az összes hangadat lekérése a mappából"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Az adott tartományban lévő fájlok törlése"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Az összes fájl törlése a mappából (alapértelmezetten --no-recurse)"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Egy fájl feltöltése a kamerára"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Egy fájlnév vagy fájlnév minta megadása"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "FÁJLNÉV_MINTA"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Kameramappa megadása (alapértelmezett = „/”)"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "MAPPA"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Rekurzió (letöltéskor alapértelmezett)"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Nincs rekurzió (törléskor alapértelmezett)"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Csak az új fájlok feldolgozása"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Fájlok felülírása kérdezés nélkül"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Létező fájlok kihagyása"
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Fájl küldése a szabványos kimenetre"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Fájlméret kiírása az adatok előtt"
 
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Automatikusan felismert kamerák listázása"
 
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "JPEG képek EXIF-információinak megjelenítése"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
-msgstr "Képinformációk megjelenítése, mint például szélesség, magasság és a rögzítés ideje"
+msgstr ""
+"Képinformációk megjelenítése, mint például szélesség, magasság és a rögzítés "
+"ideje"
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr "Kameraösszegzés megjelenítése"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Kamerameghajtó kézikönyv megjelenítése"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "A kamerameghajtó kézikönyv névjegye"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Tároló-információk megjelenítése"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "gPhoto parancsértelmező"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Közös beállítások"
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Egyéb beállítások (rendezetlen)"
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
-msgstr "Információk lekérése a szoftverről és a gazda rendszerről (nem a kameráról)"
+msgstr ""
+"Információk lekérése a szoftverről és a gazda rendszerről (nem a kameráról)"
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "A használandó kamera megadása"
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Kamera és szoftverbeállítás"
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Egy kép rögzítése a kameráról vagy a kamerán"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Letöltés, feltöltés és fájlok manipulálása"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1380,7 +1468,7 @@ msgstr ""
 "%s\n"
 "A képek azonosítójának nullánál nagyobb számnak kell lennie."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1389,7 +1477,7 @@ msgstr ""
 "%s\n"
 "A kép azonosítója túl nagy (%i)."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1398,7 +1486,7 @@ msgstr ""
 "%s\n"
 "A tartományokat vesszővel kell elválasztani („,”)."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1407,7 +1495,7 @@ msgstr ""
 "%s\n"
 "A tartományoknak számmal kell kezdődniük."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1416,224 +1504,236 @@ msgstr ""
 "%s\n"
 "Nem várt karakter: „%c”."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"Csökkenő tartományok nincsenek megengedve. %i és %i között adott meg tartományt."
+"Csökkenő tartományok nincsenek megengedve. %i és %i között adott meg "
+"tartományt."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Hiba (%i: „%s”) ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Váltás a kamerán lévő könyvtárra"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "könyvtár"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Váltás a helyi meghajtón lévő könyvtárra"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Kilépés a gPhoto parancsértelmezőből"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Fájl letöltése"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[könyvtár/]fájlnév"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Fájl feltöltése"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Bélyegkép letöltése"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Nyers adatok letöltése"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Törlés"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Könyvtár létrehozása"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Könyvtár eltávolítása"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Megjeleníti a parancs használatát"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[parancs]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Az aktuális könyvtár tartalmának listázása"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[könyvtár/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Beállítási változók listázása"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Beállítási változó lekérése"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "név"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Beállítási változó beállítása"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "név=érték"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Beállítási változó index beállítása"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "név=értékindex"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Egy kép rögzítésének aktiválója"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Egyetlen kép rögzítése"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Egyetlen kép rögzítése és letöltése"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Előnézeti kép rögzítése"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Várakozás egy eseményre"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "szám vagy másodperc"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Várakozás a képek rögzítésére és letöltés"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Várakozás eseményekre és a képek rögzítésére, majd letöltés"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Érvénytelen parancs."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "A(z) „%s” parancs argumentumot igényel."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Érvénytelen útvonal."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Nem található a saját könyvtár."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Nem sikerült váltani a helyi „%s” könyvtárra."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "A helyi könyvtár most „%s”."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "A távoli könyvtár most „%s”."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "A set-config egy második argumentumot igényel.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "A set-config-value egy második argumentumot igényel.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "A set-config-index egy második argumentumot igényel.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "A(z) „%s” parancs nem található. Használja a „help” parancsot az elérhető parancsok listájához."
+msgstr ""
+"A(z) „%s” parancs nem található. Használja a „help” parancsot az elérhető "
+"parancsok listájához."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Segítség ehhez: „%s”:"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Használat:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Leírás:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* A szögletes zárójelben [] lévő paraméterek nem kötelezőek"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Elérhető parancsok:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Egy bizonyos paranccsal kapcsolatos súgóhoz gépelje be: „help parancs-neve”."
+msgstr ""
+"Egy bizonyos paranccsal kapcsolatos súgóhoz gépelje be: „help parancs-neve”."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Képrögzítés aktiválás"
 
 #~ msgid "Show info"
 #~ msgstr "Információk megjelenítése"
@@ -1791,11 +1891,21 @@ msgstr "Egy bizonyos paranccsal kapcsolatos súgóhoz gépelje be: „help paran
 #~ msgid "folder"
 #~ msgstr "könyvtár"
 
-#~ msgid "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
-#~ msgstr "A gPhoto2 OS/2-es verziója igényli a CAMLIBS környezeti változó beállítását. Oda mutasson, ahol a kamera függvénykönyvtárai vannak (például SET CAMLIBS=C:\\GPHOTO2\\CAM)\n"
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the "
+#~ "location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgstr ""
+#~ "A gPhoto2 OS/2-es verziója igényli a CAMLIBS környezeti változó "
+#~ "beállítását. Oda mutasson, ahol a kamera függvénykönyvtárai vannak "
+#~ "(például SET CAMLIBS=C:\\GPHOTO2\\CAM)\n"
 
-#~ msgid "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
-#~ msgstr "A gPhoto2 OS/2-es verziója igényli az IOLIBS környezeti változó beállítását. Oda mutasson, ahol az IO függvénykönyvtárak vannak (például SET IOLIBS=C:\\GPHOTO2\\IOLIBS)\n"
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the "
+#~ "location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgstr ""
+#~ "A gPhoto2 OS/2-es verziója igényli az IOLIBS környezeti változó "
+#~ "beállítását. Oda mutasson, ahol az IO függvénykönyvtárak vannak (például "
+#~ "SET IOLIBS=C:\\GPHOTO2\\IOLIBS)\n"
 
 #~ msgid "Usage:\n"
 #~ msgstr "Használat:\n"
@@ -1812,7 +1922,9 @@ msgstr "Egy bizonyos paranccsal kapcsolatos súgóhoz gépelje be: „help paran
 
 #~ msgid ""
 #~ "--------------------------------------------------------------------------------\n"
-#~ "[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
+#~ "[Use double-quotes around arguments]        [Picture numbers begin with "
+#~ "one (1)]\n"
 #~ msgstr ""
 #~ "--------------------------------------------------------------------------------\n"
-#~ "[Használj dupla-idézőjelet a paraméterek körül]  [A képek számozása 1-től kezdődik]\n"
+#~ "[Használj dupla-idézőjelet a paraméterek körül]  [A képek számozása 1-től "
+#~ "kezdődik]\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,144 +7,144 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.4\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2014-03-23 19:35+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2014-06-01 09:59+0700\n"
 "Last-Translator: Andhika Padmawan <andhika.padmawan@gmail.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
 "Language: id\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Jumlah berkas di folder '%s': %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "Ada %d folder di folder '%s'.\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Tidak ada berkas di folder '%s'.\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "Ada %d berkas di folder '%s'.\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Informasi di berkas '%s' (folder '%s'):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Berkas:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Tak ada yang tersedia.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Tipe mime:   '%s'\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Ukuran:        %lu bita\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Lebar:       %i piksel\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Tinggi:      %i piksel(s)\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Terunduh:  %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:712
-#: gphoto2/actions.c:715 gphoto2/actions.c:718 gphoto2/actions.c:721
-#: gphoto2/actions.c:724 gphoto2/actions.c:1737 gphoto2/actions.c:1964
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "ya"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:712
-#: gphoto2/actions.c:715 gphoto2/actions.c:718 gphoto2/actions.c:721
-#: gphoto2/actions.c:724 gphoto2/actions.c:1731 gphoto2/actions.c:1958
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "tidak"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Hak akses: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "baca/hapus"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "baca"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "hapus"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "tak ada"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Waktu:        %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Miniatur:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Data audio:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Tipe mime:  '%s'\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Ukuran:       %lu bita\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Terunduh: %s\n"
@@ -166,46 +166,46 @@ msgstr "Tag"
 msgid "Value"
 msgstr "Nilai"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Data EXIF berisi miniatur (%i bita)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 telah dikompilasi tanpa sokongan EXIF."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Jumlah kamera yang disokong: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Kamera disokong:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (PERCOBAAN)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (EKSPERIMENTAL)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Divais ditemukan: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -214,438 +214,504 @@ msgstr ""
 "Alamat                             Keterangan\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Model"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Pangkalan"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Kemampuan untuk kamera             : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Sokongan pangkalan serial              : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Sokongan USB                      : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Kecepatan transfer yang disokong        :\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Pilihan tangkap                  :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Gambar\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Audio\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Pratayang\n"
 
-#: gphoto2/actions.c:709
-#, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : Tangkap tidak disokong oleh penggerak\n"
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:711
+#: gphoto2/actions.c:700
+#, c-format
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : Tangkap tidak disokong oleh penggerak\n"
+
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Sokongan konfigurasi            : %s\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Hapus berkas terpilih pada kamera  : %s\n"
 
-#: gphoto2/actions.c:716
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Hapus semua berkas pada kamera       : %s\n"
 
-#: gphoto2/actions.c:719
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Sokongan pratayang (miniatur) berkas : %s\n"
 
-#: gphoto2/actions.c:722
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Sokongan unggah berkas              : %s\n"
 
-#: gphoto2/actions.c:739
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Pangkalan harus terlihat seperti 'serial:/dev/ttyS0' atau 'usb:', tapi '%s' kekurangan tanda titik dua jadi saya akan menduga apa maksud anda."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Pangkalan harus terlihat seperti 'serial:/dev/ttyS0' atau 'usb:', tapi '%s' "
+"kekurangan tanda titik dua jadi saya akan menduga apa maksud anda."
 
-#: gphoto2/actions.c:773
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Pangkalan yang anda tentukan ('%s') tak dapat ditemukan. Silakan tentukan satu dari pangkalan yang ditemukan oleh 'gphoto2 --list-ports' dan pastikan ejaannya benar (misalnya dengan awalan 'serial:' atau 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Pangkalan yang anda tentukan ('%s') tak dapat ditemukan. Silakan tentukan "
+"satu dari pangkalan yang ditemukan oleh 'gphoto2 --list-ports' dan pastikan "
+"ejaannya benar (misalnya dengan awalan 'serial:' atau 'usb:')."
 
-#: gphoto2/actions.c:806
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "Tentang penggerak kamera:"
 
-#: gphoto2/actions.c:819
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Ringkasan kamera:"
 
-#: gphoto2/actions.c:832
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Manual kamera:"
 
-#: gphoto2/actions.c:849
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Anda hanya dapat menentukan kecepatan untuk pangkalan serial."
 
-#: gphoto2/actions.c:899
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "Pangkalan OS/2 oleh Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:903
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
 "Hak cipta (c) 2000-%d Lutz Mueller dan lainnya\n"
 "%s\n"
-"gphoto2 hadir TANPA GARANSI, sampai batas yang diizinkan oleh hukum. Anda dapat\n"
-"mendistribusikan ulang salinan gphoto2 di bawah perjanjian Lisensi Publik Umum\n"
-"GNU. Untuk informasi lebih lanjut tentang masalah ini, lihat berkas yang bernama COPYING.\n"
+"gphoto2 hadir TANPA GARANSI, sampai batas yang diizinkan oleh hukum. Anda "
+"dapat\n"
+"mendistribusikan ulang salinan gphoto2 di bawah perjanjian Lisensi Publik "
+"Umum\n"
+"GNU. Untuk informasi lebih lanjut tentang masalah ini, lihat berkas yang "
+"bernama COPYING.\n"
 "\n"
 "Versi gphoto2 ini menggunakan versi perangkat lunak dan opsi berikut:\n"
 
-#: gphoto2/actions.c:1003
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Tak dapat membuka 'movie.mjpg'."
 
-#: gphoto2/actions.c:1010
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Menangkap bingkai pratilik ketika film ke '%s'. Tekan Ctrl-C untuk membatalkan.\n"
+msgstr ""
+"Menangkap bingkai pratilik ketika film ke '%s'. Tekan Ctrl-C untuk "
+"membatalkan.\n"
 
-#: gphoto2/actions.c:1014
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr "Menangkap bingkai pratilik ketika film ke '%s' selama %d detik.\n"
 
-#: gphoto2/actions.c:1019
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Menangkap bingkai pratilik %d ketika film k '%s'.\n"
 
-#: gphoto2/actions.c:1029
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Galat menangkap film... Keluar."
 
-#: gphoto2/actions.c:1034
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Galat menangkap film... Tipe MIME tak dapat ditangani '%s'."
 
-#: gphoto2/actions.c:1041
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ctrl-C ditekan ... Keluar.\n"
 
-#: gphoto2/actions.c:1055
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Menangkap film selesai (%d bingkai)\n"
 
-#: gphoto2/actions.c:1085
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "Menunggu peristiwa dari kamera. Tekan Ctrl-C untuk membatalkan.\n"
 
-#: gphoto2/actions.c:1091
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr "Menunggu %d bingkai dari kamera. Tekan Ctrl-C untuk membatalkan.\n"
 
-#: gphoto2/actions.c:1096
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Menunggu %d milidetik untuk peristiwa dari kamera. Tekan Ctrl-C untuk membatalkan.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Menunggu %d milidetik untuk peristiwa dari kamera. Tekan Ctrl-C untuk "
+"membatalkan.\n"
 
-#: gphoto2/actions.c:1101
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Menunggu %d detik untuk peristiwa dari kamera. Tekan Ctrl-C untuk membatalkan.\n"
+msgstr ""
+"Menunggu %d detik untuk peristiwa dari kamera. Tekan Ctrl-C untuk "
+"membatalkan.\n"
 
-#: gphoto2/actions.c:1105
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
 msgstr "Menunggu %d peristiwa dari kamera. Tekan Ctrl-C untuk membatalkan.\n"
 
-#: gphoto2/actions.c:1169 gphoto2/main.c:800
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr "Menunggu %d peristiwa dari kamera. Tekan Ctrl-C untuk membatalkan.\n"
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
+#, c-format
+msgid "event found, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Tak dapat mengatur folder."
 
-#: gphoto2/actions.c:1175 gphoto2/main.c:807
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Tak dapat mengambil gambar."
 
-#: gphoto2/actions.c:1182 gphoto2/main.c:814
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "libcanon.so bermasalah?"
 
-#: gphoto2/actions.c:1192 gphoto2/main.c:826
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Tak dapat menghapus gambar."
 
-#: gphoto2/actions.c:1216
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr "Mendapatkan informasi penyimpanan tak disokong untuk kamera ini.\n"
 
-#: gphoto2/actions.c:1231
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Baca-Tulis"
 
-#: gphoto2/actions.c:1234
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Hanya-Baca"
 
-#: gphoto2/actions.c:1237
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Hanya-baca dengan hapus"
 
-#: gphoto2/actions.c:1240 gphoto2/actions.c:1250
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Tak diketahui"
 
-#: gphoto2/actions.c:1253
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "ROM Tetap"
 
-#: gphoto2/actions.c:1256
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "ROM Dapat Dilepas"
 
-#: gphoto2/actions.c:1259
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "RAM Tetap"
 
-#: gphoto2/actions.c:1262
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "RAM Dapat Dilepas"
 
-#: gphoto2/actions.c:1272
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Tak Didefinisikan"
 
-#: gphoto2/actions.c:1275
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Rata Generik"
 
-#: gphoto2/actions.c:1278
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Hirarki Generik"
 
-#: gphoto2/actions.c:1281
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Tata letak kamera (DCIM)"
 
-#: gphoto2/actions.c:1319
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Menimpa id vendor/produk USB 0x%x/0x%x dengan 0x%x/0x%x"
 
-#: gphoto2/actions.c:1377
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
 msgstr "SELALU SERTAKAN BARIS BERIKUT KETIKA MENGIRIM PESAN AWAKUTU KE MILIS:"
 
-#: gphoto2/actions.c:1392
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s telah dikompilasi dengan opsi berikut:"
 
-#: gphoto2/actions.c:1523
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s tak ditemukan di pohon konfigurasi."
 
-#: gphoto2/actions.c:1572
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Gagal menerima nilai widget teks %s."
 
-#: gphoto2/actions.c:1589
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Gagal menerima nilai widget rentang %s."
 
-#: gphoto2/actions.c:1601
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Gagal menerima nilai widget ubah %s."
 
-#: gphoto2/actions.c:1613
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Gagal menerima nilai widget tanggal/waktu %s."
 
-#: gphoto2/actions.c:1643
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Gagal menerima nilai dari widget radio %s."
 
-#: gphoto2/actions.c:1687
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "Properti %s hanya baca."
 
-#: gphoto2/actions.c:1701 gphoto2/actions.c:1928
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Gagal mengatur nilai widget teks %s ke %s."
 
-#: gphoto2/actions.c:1711 gphoto2/actions.c:1938
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Nilai %s yang dilewatkan bukan nilai titik mengambang."
 
-#: gphoto2/actions.c:1716 gphoto2/actions.c:1943
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "Nilai %f yang dilewatkan tidak dalam rentang %f - %f yang diharapkan."
 
-#: gphoto2/actions.c:1722 gphoto2/actions.c:1949
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Gagal mengatur nilai rentang widget %s ke %f."
 
-#: gphoto2/actions.c:1731 gphoto2/actions.c:1958
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "mati"
 
-#: gphoto2/actions.c:1732 gphoto2/actions.c:1959
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "salah"
 
-#: gphoto2/actions.c:1737 gphoto2/actions.c:1964
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "hidup"
 
-#: gphoto2/actions.c:1738 gphoto2/actions.c:1965
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "benar"
 
-#: gphoto2/actions.c:1743 gphoto2/actions.c:1970
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Nilai %s yang dilewatkan bukan nilai ubah yang sah."
 
-#: gphoto2/actions.c:1749 gphoto2/actions.c:1976
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Gagal mengatur nilai %s dari widget ubah %s."
 
-#: gphoto2/actions.c:1756
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "sekarang"
 
-#: gphoto2/actions.c:1764 gphoto2/actions.c:1989
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "Nilai %s yang dilewatkan bukan waktu atau integer yang sah."
 
-#: gphoto2/actions.c:1771 gphoto2/actions.c:1996
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Gagal mengatur waktu baru dari widget tanggal/waktu %s ke %s."
 
-#: gphoto2/actions.c:1818 gphoto2/actions.c:1882 gphoto2/actions.c:2026
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Pilihan %s tak ditemukan di dalam senarai pilihan."
 
-#: gphoto2/actions.c:1826 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Widget %s tak dapat dikonfigurasi."
 
-#: gphoto2/actions.c:1833 gphoto2/actions.c:1901 gphoto2/actions.c:2041
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr "Gagal mengatur nilai konfigurasi baru %s untuk entri konfigurasi %s."
 
-#: gphoto2/actions.c:1894
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "Widget %s tidak memiliki senarai pilihan yang terindeks. Menggunakan --set-config-value."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"Widget %s tidak memiliki senarai pilihan yang terindeks. Menggunakan --set-"
+"config-value."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Jumlah berkas salah. Anda menentukan %i, tapi hanya ada %i berkas yang tersedia di '%s' atau subfoldernya. Silakan ambil jumlah berkas yang sah dari pengurutan berkas terlebih dahulu."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Jumlah berkas salah. Anda menentukan %i, tapi hanya ada %i berkas yang "
+"tersedia di '%s' atau subfoldernya. Silakan ambil jumlah berkas yang sah "
+"dari pengurutan berkas terlebih dahulu."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -654,25 +720,34 @@ msgstr "Tidak ada berkas di folder '%s'."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Jumlah berkas salah. Anda menentukan %i, tapi hanya ada 1 berkas yang tersedia di '%s'."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Jumlah berkas salah. Anda menentukan %i, tapi hanya ada 1 berkas yang "
+"tersedia di '%s'."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Jumlah berkas salah. Anda menentukan %i, tapi hanya ada %i berkas yang tersedia di '%s'. Silakan ambil jumlah berkas yang sah dari pengurutan berkas terlebih dahulu."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Jumlah berkas salah. Anda menentukan %i, tapi hanya ada %i berkas yang "
+"tersedia di '%s'. Silakan ambil jumlah berkas yang sah dari pengurutan "
+"berkas terlebih dahulu."
 
-#: gphoto2/gp-params.c:62
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Galat ***              \n"
 
-#: gphoto2/gp-params.c:237
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Silakan tekan tombol apapun untuk melanjutkan.\n"
 
-#: gphoto2/gp-params.c:259
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Tak cukup memori."
@@ -681,206 +756,211 @@ msgstr "Tak cukup memori."
 msgid "Operation cancelled"
 msgstr "Operasi dibatalkan"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Lanjutkan"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Batal"
 
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Galat"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Tak dapat mengatur konfigurasi:"
 
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Keluar"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Mundur"
 
-#: gphoto2/gphoto2-cmd-config.c:254
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Waktu:"
 
-#: gphoto2/gphoto2-cmd-config.c:313 gphoto2/gphoto2-cmd-config.c:341
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Nilai:"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Ya"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Tidak"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "Jumlah pengisian nol di nama berkas hanya dimungkinkan dengan %%n."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "Anda tak dapat menggunakan %%n pengisian nol tanpa nilai yang presisi!"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Nama berkas yang disediakan oleh kamera ('%s') tidak berisi awalan!"
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Format '%s' tidak sah (galat pada posisi %i)."
 
-#: gphoto2/main.c:382 gphoto2/main.c:561
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Lewati berkas yang ada %s\n"
 
-#: gphoto2/main.c:394
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Berkas %s ada. Timpa? [y|t]"
 
-#: gphoto2/main.c:406
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Tentukan nama berkas baru? [y|t]"
 
-#: gphoto2/main.c:418
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Masukkan nama berkas baru:"
 
-#: gphoto2/main.c:424
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Menyimpan berkas sebagai %s\n"
 
-#: gphoto2/main.c:599
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Hak akses ditolak"
 
-#: gphoto2/main.c:761
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Tak dapat memicu perekaman."
 
-#: gphoto2/main.c:791
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Berkas baru berada di lokasi %s%s%s di dalam kamera\n"
 
-#: gphoto2/main.c:821
-#, c-format
-msgid "Deleting file %s%s%s on the camera\n"
-msgstr "Menghapus berkas %s%s%s di camera\n"
-
-#: gphoto2/main.c:831
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Menyimpan berkas %s%s%s di camera\n"
 
-#: gphoto2/main.c:864
+#: gphoto2/main.c:868
+#, c-format
+msgid "Deleting file %s%s%s on the camera\n"
+msgstr "Menghapus berkas %s%s%s di camera\n"
+
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "Peristiwa FOLDER_DITAMBAHKAN %s/%s ketika menunggu, abaikan.\n"
 
-#: gphoto2/main.c:874
+#: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "Peristiwa FOLDER_DITAMBAHKAN %s/%s ketika menunggu, abaikan.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Peristiwa TAK DIKETAHUI %s ketika menunggu, abaikan.\n"
 
-#: gphoto2/main.c:880
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr "Tipe peristiwa tak diketahui %d ketika menunggu pijar, abaikan.\n"
 
-#: gphoto2/main.c:898
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Tak dapat mendapatkan kapabilitas?"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Mode jeda waktu diaktifkan (interval: %ds).\n"
 
-#: gphoto2/main.c:909
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Berdiri sambil menunggu SIGUSR1 untuk menangkap.\n"
 
-#: gphoto2/main.c:915
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Mode pijar diaktifkan (waktu pajanan: %dd).\n"
 
-#: gphoto2/main.c:928
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Menangkap bingkai #%d...\n"
 
-#: gphoto2/main.c:930
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Menangkap bingkai #%d/%d...\n"
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Tak dapat mengatur penangkapan pijar, menghasilkan %d."
 
-#: gphoto2/main.c:954
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Tak dapat mengakhiri penangkapan (mode pijar)."
 
-#: gphoto2/main.c:965
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Tak dapat memicu penangkapan gambar."
 
-#: gphoto2/main.c:971
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Tak dapat menangkap gambar."
 
-#: gphoto2/main.c:978
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Gagal menangkap (masalah fokus otomatis?)...\n"
 
-#: gphoto2/main.c:989
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Tak dapat menangkap."
 
-#: gphoto2/main.c:1021
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Menunggu slot penangkapan berikutnya %ld detik...\n"
 
-#: gphoto2/main.c:1030 gphoto2/main.c:1071
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Dibangunkan oleh SIGUSR1...\n"
 
-#: gphoto2/main.c:1043
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "tak tidur (%ld detik dibelakang jadwal)\n"
 
-#: gphoto2/main.c:1180
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "GALAT:"
 
-#: gphoto2/main.c:1203
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -889,12 +969,12 @@ msgstr ""
 "\n"
 "Membatalkan...\n"
 
-#: gphoto2/main.c:1209
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Dibatalkan.\n"
 
-#: gphoto2/main.c:1214
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -903,21 +983,26 @@ msgstr ""
 "\n"
 "Membatalkan...\n"
 
-#: gphoto2/main.c:1363
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Gunakan sintaksis berikut a:b=c:d untuk memperlakukan divais USB apapun yang terdeteksi sebagai a:b sebagai c:d. a b c d harus merupakan nomor heksadesimal yang dimulai dengan '0x'.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Gunakan sintaksis berikut a:b=c:d untuk memperlakukan divais USB apapun yang "
+"terdeteksi sebagai a:b sebagai c:d. a b c d harus merupakan nomor "
+"heksadesimal yang dimulai dengan '0x'.\n"
 
-#: gphoto2/main.c:1536
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 telah dikompilasi tanpa sokongan CDK."
 
-#: gphoto2/main.c:1800
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operasi dibatalkan.\n"
 
-#: gphoto2/main.c:1804
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -926,7 +1011,7 @@ msgstr ""
 "*** Galat: Tak ada kamera yang ditemukan. ***\n"
 "\n"
 
-#: gphoto2/main.c:1806
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -935,7 +1020,7 @@ msgstr ""
 "*** Galat (%i: '%s') ***       \n"
 "\n"
 
-#: gphoto2/main.c:1811
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -952,7 +1037,7 @@ msgstr ""
 "gphoto2 sebagai berikut:\n"
 "\n"
 
-#: gphoto2/main.c:1832
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
@@ -961,378 +1046,403 @@ msgstr ""
 "Tolong pastikan telah cukup ada kutipan di sekitar argumen.\n"
 "\n"
 
-#: gphoto2/main.c:1899
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Cetak pesan bantuan lengkap tentang penggunaan program"
 
-#: gphoto2/main.c:1901
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Cetak pesan pendek tentang penggunaan program"
 
-#: gphoto2/main.c:1903
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Aktifkan awakutu"
 
-#: gphoto2/main.c:1905
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
+
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Nama berkas untuk penulisan info awakutu"
 
-#: gphoto2/main.c:1905 gphoto2/main.c:1910 gphoto2/main.c:1916
-#: gphoto2/main.c:2040
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "NAMABERKAS"
 
-#: gphoto2/main.c:1907
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Keluaran senyap (standar=verbose)"
 
-#: gphoto2/main.c:1909
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Skrip kait untuk dipanggil setelah unduh, tangkap, dll."
 
-#: gphoto2/main.c:1916
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Tentukan pangkalan divais"
 
-#: gphoto2/main.c:1918
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Tentukan kecepatan transfer serial"
 
-#: gphoto2/main.c:1918
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "KECEPATAN"
 
-#: gphoto2/main.c:1920
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Tentukan model kamera"
 
-#: gphoto2/main.c:1920
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODEL"
 
-#: gphoto2/main.c:1922
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(hanya ahli) Timpa ID USB"
 
-#: gphoto2/main.c:1922
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "IDUSB"
 
-#: gphoto2/main.c:1928
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Tampilkan versi lalu keluar"
 
-#: gphoto2/main.c:1930
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Tampilkan model kamera yang didukung"
 
-#: gphoto2/main.c:1932
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Tampilkan divais pangkalan yang didukung"
 
-#: gphoto2/main.c:1934
-msgid "Display camera/driver abilities"
+#: gphoto2/main.c:2015
+#, fuzzy
+msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Tampilkan kemampuan kamera/penggerak"
 
-#: gphoto2/main.c:1941
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Konfigurasi"
 
-#: gphoto2/main.c:1944
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Tampilkan pohon konfigurasi"
 
-#: gphoto2/main.c:1946
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Buang seluruh pohon konfigurasi"
 
-#: gphoto2/main.c:1948
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Ambil nilai konfigurasi"
 
-#: gphoto2/main.c:1950
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Atur nilai konfigurasi atau indeks di pilihan"
 
-#: gphoto2/main.c:1952
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Atur indeks nilai konfigurasi di pilihan"
 
-#: gphoto2/main.c:1954
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Atur nilai konfigurasi"
 
-#: gphoto2/main.c:1956
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Atur ulang pangkalan divais"
 
-#: gphoto2/main.c:1962
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Simpan gambar di kamera setelah merekam"
 
-#: gphoto2/main.c:1964
+#: gphoto2/main.c:2045
+#, fuzzy
+msgid "Keep RAW images on camera after capturing"
+msgstr "Simpan gambar di kamera setelah merekam"
+
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Hapus gambar dari kamera setelah merekam"
 
-#: gphoto2/main.c:1966
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Tunggu peristiwa dari kamera"
 
-#: gphoto2/main.c:1966 gphoto2/main.c:1968 gphoto2/main.c:1975
-#: gphoto2/main.c:1991
-msgid "COUNT"
-msgstr "HITUNG"
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
 
-#: gphoto2/main.c:1968
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Tunggu peristiwa dari kamera dan unduh gambar baru"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Tangkap pratayang cepat"
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
+
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Atur waktu pajanan pijar dalam detik"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1977
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "DETIK"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Atur jumlah bingkai yang ingin ditangkap (standar=tak terbatas)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr "HITUNG"
+
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Atur interval tangkap dalam detik"
 
-#: gphoto2/main.c:1979
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Atur ulang interval tangkap pada sinyal (standar=tidak)"
 
-#: gphoto2/main.c:1981
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Tangkap gambar"
 
-#: gphoto2/main.c:1983
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Picu rekam sebuah gambar"
 
-#: gphoto2/main.c:1985
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Tangkap gambar lalu unduh gambar tersebut"
 
-#: gphoto2/main.c:1987
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Tangkap film"
 
-#: gphoto2/main.c:1987
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "HITUNGAN atau DETIK"
 
-#: gphoto2/main.c:1989
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Tangkap klip audio"
 
-#: gphoto2/main.c:1991
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Tunggu sampai shutter kamera dilepas lalu unduh"
 
-#: gphoto2/main.c:1993
-msgid "Trigger image capture"
-msgstr "Picu perekaman gambar"
-
-#: gphoto2/main.c:1999
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Tampilkan folder di folder"
 
-#: gphoto2/main.c:2001
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Tampilkan berkas di folder"
 
-#: gphoto2/main.c:2003
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Buat direktori"
 
-#: gphoto2/main.c:2003 gphoto2/main.c:2005
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "NAMADIREKTORI"
 
-#: gphoto2/main.c:2005
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Hapus direktori"
 
-#: gphoto2/main.c:2007
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Tampilkan jumlah berkas"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Ambil berkas yang diberikan dalam jangkauan"
 
-#: gphoto2/main.c:2009 gphoto2/main.c:2013 gphoto2/main.c:2018
-#: gphoto2/main.c:2025 gphoto2/main.c:2031 gphoto2/main.c:2036
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "RENTANG"
 
-#: gphoto2/main.c:2011
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Ambil semua berkas dari folder"
 
-#: gphoto2/main.c:2013
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Ambil miniatur yang diberikan dalam jangkauan"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Ambil semua miniatur dari folder"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Ambil miniatur yang diberikan dalam jangkauan"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Ambil semua metadata dari folder"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Unggah metadata untuk berkas"
 
-#: gphoto2/main.c:2025
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Ambil data mentah yang diberikan dalam jangkauan"
 
-#: gphoto2/main.c:2028
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Ambil semua data mentah dari folder"
 
-#: gphoto2/main.c:2031
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Ambil data audio yang diberikan dalam jangkauan"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Ambil semua data audio dari folder"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Hapus berkas yang diberikan dalam jangkauan"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Hapus semua berkas dalam folder (standarnya --no-recurse)"
 
-#: gphoto2/main.c:2040
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Unggah berkas ke kamera"
 
-#: gphoto2/main.c:2042
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Tentukan nama berkas atau pola nama berkas"
 
-#: gphoto2/main.c:2042
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "POLA_NAMA_BERKAS"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Tentukan folder kamera (standar=\"/\")"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "FOLDER"
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Rekursi (standar untuk unduh)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Tanpa rekursi (standar untuk penghapusan)"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Proses hanya berkas baru"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Timpa berkas tanpa bertanya"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Lewati berkas yang ada"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Kirik berkas ke stdout"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Cetak ukuran berkas sebelum data"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Tampilkan kamera otomatis terdeteksi"
 
-#: gphoto2/main.c:2068 gphoto2/shell.c:138
-msgid "Show EXIF information"
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
 msgstr "Tampilkan informasi EXIF"
 
-#: gphoto2/main.c:2071 gphoto2/shell.c:132
-msgid "Show info"
-msgstr "Tampilkan info"
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
 
-#: gphoto2/main.c:2073
-msgid "Show summary"
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "Tampilkan ringkasan"
 
-#: gphoto2/main.c:2075
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Tampilkan manual penggerak kamera"
 
-#: gphoto2/main.c:2077
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Tentang manual penggerak kamera"
 
-#: gphoto2/main.c:2079
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Tampilkan informasi penyimpanan"
 
-#: gphoto2/main.c:2081
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "cangkang gPhoto"
 
-#: gphoto2/main.c:2087
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Opsi umum"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Opsi lainnya (tak diurutkan)"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
-msgstr "Ambil informasi tentang perangkat lunak dan sistem host (bukan dari kamera)"
+msgstr ""
+"Ambil informasi tentang perangkat lunak dan sistem host (bukan dari kamera)"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Tentukan kamera yang digunakan"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Konfigurasi kamera dan perangkat lunak"
 
-#: gphoto2/main.c:2097
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Tangkap gambar dari atau di kamera"
 
-#: gphoto2/main.c:2099
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Mengunduh, mengunggah dan memanipulasi berkas"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1341,7 +1451,7 @@ msgstr ""
 "%s\n"
 "ID gambar harus nomor yang lebih besar dari nol."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1350,7 +1460,7 @@ msgstr ""
 "%s\n"
 "ID gambar %i terlalu tinggi."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1359,7 +1469,7 @@ msgstr ""
 "%s\n"
 "Rentang harus dipisahkan oleh ','."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1368,7 +1478,7 @@ msgstr ""
 "%s\n"
 "Rentang perlu dijalankan dengan nomor."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1377,230 +1487,249 @@ msgstr ""
 "%s\n"
 "Karakter tak diharapkan '%c'."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"Menurunkan jangkauan tidak diizinkan. Anda perlu menentukan jangkauan dari %i ke %i."
+"Menurunkan jangkauan tidak diizinkan. Anda perlu menentukan jangkauan dari "
+"%i ke %i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Galat (%i: '%s') ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Ubah ke direktori di kamera"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "direktori"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Ubah ke direktori di penggerak lokal"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Keluar cangkang gPhoto"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Unduh berkas"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[direktori/]nama berkas"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Unggah berkas"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Unduh miniatur"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Unduh data mentah"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Hapus"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Buat Direktori"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Hapus Direktori"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Tampilkan perintah pengunaan"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[perintah]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Tampilkan isi direktori saat ini"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[direktori/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Senarai variabel konfigurasi"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Ambil variabel konfigurasi"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "nama"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Atur variabel konfigurasi"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "nama=nilai"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Atur indeks variabel konfigurasi"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "nama=indeksnilai"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Picu rekam sebuah gambar"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Tangkap sebuah gambar"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Tangkap sebuah gambar lalu unduh gambar tersebut"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Tangkap sebuah gambar pratilik"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Tunggu peristiwa"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "hitungan atau detik"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Tunggu sampai gambar ditangkap lalu unduh gambar tersebut"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
-msgstr "Tangkap sampai peristiwa dan gambar ditangkap lalu unduh gambar tersebut"
+msgstr ""
+"Tangkap sampai peristiwa dan gambar ditangkap lalu unduh gambar tersebut"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Perintah tidak sah."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Perintah '%s' memerlukan argumen."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Alamat tidak sah."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Tak dapat menemukan direktori rumah."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Tak dapat mengubah ke direktori lokal '%s'."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Direktori lokal sekarang '%s'."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Direktori jarak jauh sekarang '%s'."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config memerlukan argumen kedua.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "set-config-value memerlukan argumen kedua.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "set-config-index memerlukan argumen kedua.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Perintah '%s' tak ditemukan. Gunakan 'help' untuk mendapatkan senarai perintah yang tersedia."
+msgstr ""
+"Perintah '%s' tak ditemukan. Gunakan 'help' untuk mendapatkan senarai "
+"perintah yang tersedia."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Bantuan di \"%s\":"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Penggunaan:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Keterangan"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Argumen di kurawal [] adalah opsional"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Perintah yang tersedia:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Untuk mendapatkan bantuan untuk perintah tertentu, ketik 'help nama-perintah'."
+msgstr ""
+"Untuk mendapatkan bantuan untuk perintah tertentu, ketik 'help nama-"
+"perintah'."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Picu perekaman gambar"
+
+#~ msgid "Show info"
+#~ msgstr "Tampilkan info"
 
 #~ msgid "  Name:        '%s'\n"
 #~ msgstr "  Nama:        '%s'\n"
 
 #~ msgid "You cannot use '%%n' in combination with non-persistent files!"
-#~ msgstr "Anda tak dapat menggunakan '%%n' dalam kombinasi dengan berkas tidak tetap!"
+#~ msgstr ""
+#~ "Anda tak dapat menggunakan '%%n' dalam kombinasi dengan berkas tidak "
+#~ "tetap!"
 
 #~ msgid "Could not get filename (bulb mode)."
 #~ msgstr "Tak dapat mendapatkan nama berkas (mode pijar)."

--- a/po/is.po
+++ b/po/is.po
@@ -7,147 +7,147 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2-2.5.9\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-11-18 22:19+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2016-08-11 18:31+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic <translation-team-is@lists.sourceforge.net>\n"
 "Language: is\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr ""
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr ""
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr ""
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Skrá:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Ekki tiltækt.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Mime tegund:   '%s'\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Stærð:        %lu bæti\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Breidd:       %i mynddílar\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Hæð:      %i mynddílar\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Náð í:  %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "já"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "nei"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Heimildir: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "lesa/eyða"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "lesa"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "eyða"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "ekkert"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Tími:        %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Smámynd:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Hljóðgögn:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Mime tegund:  '%s'\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Stærð:       %lu bæti\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Sótt: %s\n"
@@ -169,46 +169,46 @@ msgstr "Merki"
 msgid "Value"
 msgstr "Gildi"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "EXIF-gögnin innihalda smámynd (%i bæti)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 hefur verið vistþýtt án stuðnings við EXIF"
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Fjöldi nothæfra myndavéla: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Studdar myndavélar:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (PRÓFUN)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr ""
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Tæki fundust: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -217,448 +217,476 @@ msgstr ""
 "Slóð                             Lýsing\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Tegund"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Gátt"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Eiginleikar myndavélar          : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Stuðningur við raðtengi             : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Stuðningur við USB                    : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Stuðningur við flutningshraða       :\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr ""
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr ""
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr ""
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr ""
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr ""
 
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr ""
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
 msgstr ""
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr ""
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
 msgstr ""
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
 msgstr ""
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr ""
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Yfirlit um myndavél:"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Handbók myndavélar:"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr ""
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr ""
 
-#: gphoto2/actions.c:907
+#: gphoto2/actions.c:894
 #, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Gat ekki opnað 'movie.mjpg'."
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr ""
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr ""
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ýtt á Ctrl-C   ... Hætti.\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr ""
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1121
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1125
+#: gphoto2/actions.c:1129
 #, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr ""
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr ""
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr ""
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "Calli í libcanon.so?"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr ""
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Lesa-Skrifa"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Skrifvarið"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr ""
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Óþekkt"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr ""
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr ""
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr ""
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr ""
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Óskilgreint"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr ""
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr ""
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr ""
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr ""
 
-#: gphoto2/actions.c:1435
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "ALLTAF LÁTA EFTIRFARANDI LÍNUR FYLGJA MEÐ ÞEGAR VILLUSKÝRSLA ER SEND Á PÓSTLISTA:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"ALLTAF LÁTA EFTIRFARANDI LÍNUR FYLGJA MEÐ ÞEGAR VILLUSKÝRSLA ER SEND Á "
+"PÓSTLISTA:"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr ""
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr ""
 
-#: gphoto2/actions.c:1630
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr ""
 
-#: gphoto2/actions.c:1647
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr ""
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr ""
 
-#: gphoto2/actions.c:1671
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr ""
 
-#: gphoto2/actions.c:1680
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1702
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr ""
 
-#: gphoto2/actions.c:1746
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr ""
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr ""
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr ""
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr ""
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr ""
 
-#: gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "slökkt"
 
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "ósatt"
 
-#: gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "kveikt"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "satt"
 
-#: gphoto2/actions.c:1802 gphoto2/actions.c:2039
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr ""
 
-#: gphoto2/actions.c:1808 gphoto2/actions.c:2045
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr ""
 
-#: gphoto2/actions.c:1820
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "núna"
 
-#: gphoto2/actions.c:1832 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr ""
 
-#: gphoto2/actions.c:1840 gphoto2/actions.c:2065
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr ""
 
-#: gphoto2/actions.c:1887 gphoto2/actions.c:1951 gphoto2/actions.c:2095
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr ""
 
-#: gphoto2/actions.c:1895 gphoto2/actions.c:2103
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr ""
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:1970 gphoto2/actions.c:2110
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr ""
 
-#: gphoto2/actions.c:1963
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
 msgstr ""
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
 msgstr ""
 
 #: gphoto2/foreach.c:285
@@ -668,25 +696,29 @@ msgstr ""
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
 msgstr ""
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
 msgstr ""
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Villa ***              \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Ýttu á einhvern lykil til að halda áfram.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Ekki nægilegt minni."
@@ -695,253 +727,260 @@ msgstr "Ekki nægilegt minni."
 msgid "Operation cancelled"
 msgstr "Hætt var við aðgerð"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Halda áfram"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Hætta við"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Villa"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Gat ekki framkvæmt stillingar:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Hætta"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Til baka"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Tími: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Gildi: "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Já"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Nei"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr ""
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr ""
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr ""
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr ""
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr ""
 
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr ""
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Tilgreina nýtt skráarheiti? [j|n] "
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Settu inn nýtt skráarheiti: "
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Vista skrá sem %s\n"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Aðgangi hafnað"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Ekki tókst að hleypa af myndatöku."
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr ""
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr ""
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr ""
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr ""
 
 #: gphoto2/main.c:916
 #, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:926
+#, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr ""
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr ""
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr ""
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr ""
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr ""
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr ""
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr ""
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr ""
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr ""
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr ""
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr ""
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Gat ekki náð í mynd."
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr ""
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Ekki tókst að ná í mynd."
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr ""
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr ""
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr ""
 
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "VILLA: "
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
 "Aborting...\n"
 msgstr ""
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr ""
 
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
 "Cancelling...\n"
 msgstr ""
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
 msgstr ""
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr ""
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
 "\n"
 msgstr ""
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
 "\n"
 msgstr ""
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -952,647 +991,656 @@ msgid ""
 "\n"
 msgstr ""
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
 "\n"
 msgstr ""
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr ""
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr ""
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr ""
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr ""
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr ""
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "SKRÁARHEITI"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr ""
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr ""
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr ""
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr ""
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "HRAÐI"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr ""
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "GERÐ"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr ""
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBIDs"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr ""
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr ""
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr ""
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr ""
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Stilla"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr ""
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr ""
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr ""
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr ""
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr ""
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr ""
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr ""
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr ""
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr ""
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr ""
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr ""
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr ""
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr ""
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr ""
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr ""
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr ""
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SEKÚNDUR"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr ""
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "TALNING"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr ""
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr ""
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr ""
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr ""
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr ""
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr ""
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr ""
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr ""
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr ""
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr ""
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr ""
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr ""
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr ""
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "MÖPPUHEITI"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr ""
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr ""
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr ""
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "SVIÐ"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr ""
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr ""
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr ""
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr ""
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr ""
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr ""
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr ""
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr ""
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr ""
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr ""
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr ""
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr ""
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr ""
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr ""
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr ""
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr ""
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "MAPPA"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr ""
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr ""
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr ""
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr ""
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Sleppa fyrirliggjandi skrám"
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr ""
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr ""
 
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr ""
 
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "Birta EXIF upplýsingar úr JPEG myndum"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
 msgstr ""
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr ""
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr ""
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr ""
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr ""
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr ""
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr ""
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr ""
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr ""
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr ""
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr ""
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr ""
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr ""
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
 "Image IDs must be a number greater than zero."
 msgstr ""
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
 "Image ID %i too high."
 msgstr ""
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
 "Ranges must be separated by ','."
 msgstr ""
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
 "Ranges need to start with a number."
 msgstr ""
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
 "Unexpected character '%c'."
 msgstr ""
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Villa (%i: '%s') ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr ""
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "mappa"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr ""
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr ""
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr ""
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr ""
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr ""
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr ""
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr ""
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Eyða"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Búa til möppu"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr ""
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr ""
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[skipun]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr ""
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[mappa/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr ""
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr ""
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "heiti"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr ""
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr ""
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr ""
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr ""
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+msgid "Triggers the capture of a single image"
+msgstr ""
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr ""
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr ""
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr ""
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr ""
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr ""
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr ""
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr ""
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Ógild skipun."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr ""
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Ógild slóð."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr ""
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr ""
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr ""
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr ""
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr ""
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr ""
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr ""
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
 msgstr ""
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Hjálp með \"%s\":"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Notkun:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Lýsing:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr ""
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Skipanir í boði:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -9,146 +9,146 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.8\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-07-05 22:44+0200\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2015-08-05 12:59+0100\n"
 "Last-Translator: Marco Colombo <m.colombo@ed.ac.uk>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
 "Language: it\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Numero di file nella cartella \"%s\": %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "C'è %d cartella nella cartella \"%s\".\n"
 msgstr[1] "Ci sono %d cartelle nella cartella \"%s\".\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Non ci sono file nella cartella \"%s\".\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "C'è %d file nella cartella \"%s\".\n"
 msgstr[1] "Ci sono %d file nella cartella \"%s\".\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Informazioni sul file \"%s\" (cartella \"%s\"):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "File:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Nessuno disponibile.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Tipo Mime:   \"%s\"\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Dimensione:  %lu byte\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Larghezza:   %i pixel\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Altezza:     %i pixel\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Scaricati:   %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:712
-#: gphoto2/actions.c:715 gphoto2/actions.c:718 gphoto2/actions.c:721
-#: gphoto2/actions.c:724 gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "sì"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:712
-#: gphoto2/actions.c:715 gphoto2/actions.c:718 gphoto2/actions.c:721
-#: gphoto2/actions.c:724 gphoto2/actions.c:1785 gphoto2/actions.c:2022
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "no"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Permessi: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "leggi/elimina"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "leggi"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "elimina"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "nessuno"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Ora:         %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Miniatura:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Dati audio:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Tipo MIME:  \"%s\"\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Dimensione: %lu byte\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Scaricati:  %s\n"
@@ -171,47 +171,47 @@ msgstr "Campo"
 msgid "Value"
 msgstr "Valore"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "I dati EXIF contengono una miniatura (%i byte)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 è stato compilato senza supporto EXIF."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Numero di fotocamere supportate: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Fotocamere supportate:\n"
 
 # FIXME
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (DI TEST)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (SPERIMENTALE)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Dispositivi trovati: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -220,161 +220,179 @@ msgstr ""
 "Percorso                         Descrizione\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Modello"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Porta"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
 # FIXME: abilities: capacità? funzionalità?
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Capacità della fotocamera        : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Supporto porta seriale           : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Supporto USB                     : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Velocità di trasferimento gestite:\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Scelte di cattura                :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Immagine\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Audio\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Anteprima\n"
 
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
+
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
 msgstr "                                 : Cattura non gestita dal driver\n"
 
-#: gphoto2/actions.c:711
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Supporto per la configurazione   : %s\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Elimina file selezionati su fotocamera : %s\n"
 
-#: gphoto2/actions.c:716
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Elimina tutti i file su fotocamera : %s\n"
 
-#: gphoto2/actions.c:719
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Supporto per l'anteprima dei file: %s\n"
 
-#: gphoto2/actions.c:722
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Supporto caricamento file        : %s\n"
 
-#: gphoto2/actions.c:739
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Le porte sono qualcosa come \"serial:/dev/ttyS0\" o \"usb:\", ma in \"%s\" manca un \":\". Verrà tentato di indovinare cosa si intende."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Le porte sono qualcosa come \"serial:/dev/ttyS0\" o \"usb:\", ma in \"%s\" "
+"manca un \":\". Verrà tentato di indovinare cosa si intende."
 
-#: gphoto2/actions.c:773
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
 msgstr ""
 "La porta specificata (\"%s\") non è stata trovata. Indicare una delle porte\n"
-"trovate da \"gphoto2 --list-ports\" e assicurarsi che la sintassi sia corretta\n"
+"trovate da \"gphoto2 --list-ports\" e assicurarsi che la sintassi sia "
+"corretta\n"
 "(cioè usando il prefisso \"serial:\" o \"usb:\")."
 
-#: gphoto2/actions.c:806
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "Informazioni sul driver della fotocamera:"
 
-#: gphoto2/actions.c:819
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Sommario della fotocamera:"
 
-#: gphoto2/actions.c:832
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Manuale della fotocamera:"
 
-#: gphoto2/actions.c:849
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Le velocità possono essere indicate solo per le porte seriali."
 
-#: gphoto2/actions.c:899
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "Versione per OS/2 di Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:903
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
 "Copyright (c) 2000-%d Lutz Mueller e altri\n"
 "%s\n"
-"gphoto2 è distribuito senza ALCUNA GARANZIA, negli estremi permessi dalla legge.\n"
-"È possibile distribuire copie di gphoto2 secondo i termini della GNU General\n"
+"gphoto2 è distribuito senza ALCUNA GARANZIA, negli estremi permessi dalla "
+"legge.\n"
+"È possibile distribuire copie di gphoto2 secondo i termini della GNU "
+"General\n"
 "Public License. Per ulteriori informazioni, consultare il file COPYING.\n"
 "\n"
 "Questa versione di gphoto2 utilizza il seguente software:\n"
@@ -386,309 +404,350 @@ msgstr "Impossibile aprire 'movie.mjpg'."
 #: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Cattura di fotogrammi di anteprima come filmato in '%s'. Premere Ctrl-C per interrompere.\n"
+msgstr ""
+"Cattura di fotogrammi di anteprima come filmato in '%s'. Premere Ctrl-C per "
+"interrompere.\n"
 
 #: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
-msgstr "Cattura di fotogrammi di anteprima come filmato in '%s' per %d secondi.\n"
+msgstr ""
+"Cattura di fotogrammi di anteprima come filmato in '%s' per %d secondi.\n"
 
 #: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Cattura di %d fotogrammi di anteprima come filmato in '%s'.\n"
 
-#: gphoto2/actions.c:1041
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Errore nella cattura del filmato... In uscita."
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Errore nella cattura del filmato... Tipo MIME '%s' non gestito."
 
-#: gphoto2/actions.c:1053
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Premuto Ctrl-C... In uscita.\n"
 
-#: gphoto2/actions.c:1067
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Cattura filmato completata (%d fotogrammi)\n"
 
-#: gphoto2/actions.c:1097
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
-msgstr "In attesa di un evento dalla fotocamera. Premere Ctrl-C per interrompere.\n"
+msgstr ""
+"In attesa di un evento dalla fotocamera. Premere Ctrl-C per interrompere.\n"
 
-#: gphoto2/actions.c:1103
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
-msgstr "In attesa di %d fotogrammi dalla fotocamera. Premere Ctrl-C per interrompere.\n"
+msgstr ""
+"In attesa di %d fotogrammi dalla fotocamera. Premere Ctrl-C per "
+"interrompere.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "In attesa (%d millisecondi) di un evento dalla fotocamera. Premere Ctrl-C per interrompere.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"In attesa (%d millisecondi) di un evento dalla fotocamera. Premere Ctrl-C "
+"per interrompere.\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "In attesa (%d secondi) di un evento dalla fotocamera. Premere Ctrl-C per interrompere.\n"
+msgstr ""
+"In attesa (%d secondi) di un evento dalla fotocamera. Premere Ctrl-C per "
+"interrompere.\n"
 
-#: gphoto2/actions.c:1116
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
-msgstr "In attesa di %d eventi dalla fotocamera. Premere Ctrl-C per interrompere.\n"
+msgstr ""
+"In attesa di %d eventi dalla fotocamera. Premere Ctrl-C per interrompere.\n"
 
-#: gphoto2/actions.c:1120
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"In attesa di %s eventi dalla fotocamera. Premere Ctrl-C per interrompere.\n"
+
+#: gphoto2/actions.c:1144
 #, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
-msgstr "In attesa di %s eventi dalla fotocamera. Premere Ctrl-C per interrompere.\n"
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
 
-#: gphoto2/actions.c:1164 gphoto2/actions.c:1178 gphoto2/actions.c:1194
-#: gphoto2/actions.c:1232 gphoto2/actions.c:1240
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "trovato evento, conclusione dell'attesa!\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "trovato evento, conclusione dell'attesa!\n"
 
-#: gphoto2/actions.c:1204 gphoto2/main.c:824
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Impossibile impostare la cartella."
 
-#: gphoto2/actions.c:1210 gphoto2/main.c:839
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Impossibile ottenere l'immagine."
 
-#: gphoto2/actions.c:1217 gphoto2/main.c:846
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "libcanon.so ha dei bug?"
 
-#: gphoto2/actions.c:1227 gphoto2/main.c:858
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Impossibile eliminare l'immagine."
 
-#: gphoto2/actions.c:1259
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
-msgstr "Lettura delle informazioni sulla memoria non gestita su questa fotocamera.\n"
+msgstr ""
+"Lettura delle informazioni sulla memoria non gestita su questa fotocamera.\n"
 
-#: gphoto2/actions.c:1274
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Lettura-Scrittura"
 
-#: gphoto2/actions.c:1277
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Solo lettura"
 
 # FIXME
-#: gphoto2/actions.c:1280
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Solo lettura con eliminazione"
 
-#: gphoto2/actions.c:1283 gphoto2/actions.c:1293
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: gphoto2/actions.c:1296
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "ROM fissa"
 
-#: gphoto2/actions.c:1299
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "ROM removibile"
 
-#: gphoto2/actions.c:1302
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "RAM fissa"
 
-#: gphoto2/actions.c:1305
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "RAM removibile"
 
-#: gphoto2/actions.c:1315
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Non definito"
 
 # FIXME
-#: gphoto2/actions.c:1318
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Generico piatto"
 
 # FIXME
-#: gphoto2/actions.c:1321
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Generico gerarchico"
 
 # FIXME
-#: gphoto2/actions.c:1324
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Disposizione fotocamera (DCIM)"
 
-#: gphoto2/actions.c:1362
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Id vendor/prodotto USB 0x%x/0x%x cambiato in 0x%x0x%x"
 
-#: gphoto2/actions.c:1430
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "INCLUDERE SEMPRE LE RIGHE SEGUENTI QUANDO SI SPEDISCONO MESSAGGI DI DEBUG ALLA MAILING LIST:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"INCLUDERE SEMPRE LE RIGHE SEGUENTI QUANDO SI SPEDISCONO MESSAGGI DI DEBUG "
+"ALLA MAILING LIST:"
 
-#: gphoto2/actions.c:1445
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s è stato compilato con le seguente opzioni:"
 
-#: gphoto2/actions.c:1576
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s non trovato nell'albero di configurazione."
 
 # FIXME
-#: gphoto2/actions.c:1625
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Recupero del valore del widget di testo %s non riuscito."
 
 # FIXME
-#: gphoto2/actions.c:1642
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Recupero dei valori del widget di intervallo %s non riuscito."
 
-#: gphoto2/actions.c:1654
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Recupero dei valori del widget selettore %s non riuscito."
 
 # FIXME
-#: gphoto2/actions.c:1666
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Recupero dei valori del widget di data/ora %s non riuscito."
 
 # FIXME
-#: gphoto2/actions.c:1675
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "Usare 'now' per l'impostazione dell'ora corrente.\n"
 
 # FIXME
-#: gphoto2/actions.c:1697
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Recupero dei valori del radio widget %s non riuscito."
 
-#: gphoto2/actions.c:1741
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "La proprietà \"%s\" è di sola lettura."
 
 # FIXME
-#: gphoto2/actions.c:1755 gphoto2/actions.c:1992
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Impostazione del valore del widget di testo %s a %s non riuscita."
 
-#: gphoto2/actions.c:1765 gphoto2/actions.c:2002
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Il valore %s fornito non è un valore in virgola mobile."
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "Il valore %f fornito non è nell'intervallo %f - %f."
 
 # FIXME
-#: gphoto2/actions.c:1776 gphoto2/actions.c:2013
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Impostazione del valore del widget di intervallo %s a %f non riuscita."
 
 # FIXME: femminile?
-#: gphoto2/actions.c:1785 gphoto2/actions.c:2022
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "spento"
 
-#: gphoto2/actions.c:1786 gphoto2/actions.c:2023
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "falso"
 
 # FIXME: femminile?
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "acceso"
 
-#: gphoto2/actions.c:1792 gphoto2/actions.c:2029
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "vero"
 
 # FIXME
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Il valore %s fornito non è un valore valido per il selettore."
 
-#: gphoto2/actions.c:1803 gphoto2/actions.c:2040
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Impostazione dei valori %s del widget selettore %s non riuscita."
 
-#: gphoto2/actions.c:1815
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "adesso"
 
-#: gphoto2/actions.c:1827 gphoto2/actions.c:2053
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "Il valore %s fornito non è né un orario valido né un intero."
 
 # FIXME
-#: gphoto2/actions.c:1835 gphoto2/actions.c:2060
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
-msgstr "Impostazione del nuovo orario del widget di data/ora %s a %s non riuscita."
+msgstr ""
+"Impostazione del nuovo orario del widget di data/ora %s a %s non riuscita."
 
 # FIXME
-#: gphoto2/actions.c:1882 gphoto2/actions.c:1946 gphoto2/actions.c:2090
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "La scelta %s non si trova nell'elenco delle scelte possibili."
 
 # FIXME
-#: gphoto2/actions.c:1890 gphoto2/actions.c:2098
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Il widget %s non è configurabile."
 
-#: gphoto2/actions.c:1897 gphoto2/actions.c:1965 gphoto2/actions.c:2105
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
-msgstr "Impostazione del nuovo valore di configurazione %s per la voce %s non riuscita."
+msgstr ""
+"Impostazione del nuovo valore di configurazione %s per la voce %s non "
+"riuscita."
 
 # FIXME
-#: gphoto2/actions.c:1958
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "Il widget %s non ha un elenco di scelte. Usare --set-config-value al suo posto."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"Il widget %s non ha un elenco di scelte. Usare --set-config-value al suo "
+"posto."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Numero di file non valido. È stato indicato %i, ma ci sono solo %i file disponibili in \"%s\" o nelle sue sottocartelle. Scegliere un numero di file valido dall'elenco dei file."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Numero di file non valido. È stato indicato %i, ma ci sono solo %i file "
+"disponibili in \"%s\" o nelle sue sottocartelle. Scegliere un numero di file "
+"valido dall'elenco dei file."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -697,25 +756,34 @@ msgstr "Non ci sono file nella cartella \"%s\"."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Numero di file non valido. È stato indicato %i, ma c'è solo 1 file disponibile in \"%s\"."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Numero di file non valido. È stato indicato %i, ma c'è solo 1 file "
+"disponibile in \"%s\"."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Numero di file non valido. È stato indicato %i, ma ci sono solo %i file disponibili in \"%s\". Scegliere un numero di file valido dall'elenco dei file."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Numero di file non valido. È stato indicato %i, ma ci sono solo %i file "
+"disponibili in \"%s\". Scegliere un numero di file valido dall'elenco dei "
+"file."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Errore ***             \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Premere un tasto per continuare.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Memoria insufficiente."
@@ -724,213 +792,220 @@ msgstr "Memoria insufficiente."
 msgid "Operation cancelled"
 msgstr "Operazione annullata"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Continua"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Annulla"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Errore"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Impossibile impostare la configurazione:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Esci"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Indietro"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Ora: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Valore: "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Sì"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "No"
 
 # FIXME
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "Il riempimento con zeri nei nomi di file è possibile solo con %%n."
 
 # FIXME
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
-msgstr "Non è possibile usare riempimento con zeri %%n senza un valore di precisione."
+msgstr ""
+"Non è possibile usare riempimento con zeri %%n senza un valore di precisione."
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
-msgstr "Il nome di file fornito dalla fotocamera (\"%s\") non contiene un suffisso."
+msgstr ""
+"Il nome di file fornito dalla fotocamera (\"%s\") non contiene un suffisso."
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Formato \"%s\" non valido (errore alla posizione %i)."
 
 # NdT: è il nome di un file.
-#: gphoto2/main.c:382 gphoto2/main.c:585
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Ignorato il file esistente \"%s\"\n"
 
-#: gphoto2/main.c:394
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Il file \"%s\" esiste. Sovrascrivere? [y|n] "
 
-#: gphoto2/main.c:406
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Specificare il nuovo nome del file? [y|n] "
 
-#: gphoto2/main.c:418
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Inserire il nuovo nome del file: "
 
 # NdT: è il nome di un file.
-#: gphoto2/main.c:424
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "File salvato come \"%s\"\n"
 
-#: gphoto2/main.c:623
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Permesso negato"
 
-#: gphoto2/main.c:785
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Impossibile far partire la cattura dell'immagine."
 
-#: gphoto2/main.c:815
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Il nuovo file è alla posizione %s%s%s sulla fotocamera\n"
 
-#: gphoto2/main.c:832 gphoto2/main.c:863
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "File %s%s%s lasciato sulla fotocamera\n"
 
-#: gphoto2/main.c:853
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Eliminazione del file %s%s%s sulla fotocamera\n"
 
-#: gphoto2/main.c:896
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "Evento FOLDER_ADDED %s/%s durante l'attesa, ignorato.\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "Evento FOLDER_ADDED %s/%s durante l'attesa, ignorato.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Evento UNKNOWN %s durante l'attesa, ignorato.\n"
 
-#: gphoto2/main.c:912
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr "Event sconosciuto tipo %d durante l'attesa di posa bulb, ignorato.\n"
 
 # FIXME
-#: gphoto2/main.c:930
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Impossibile ottenere le capacità."
 
 # FIXME
-#: gphoto2/main.c:938
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Modalità intervallo abilitata (intervallo: %ds).\n"
 
-#: gphoto2/main.c:941
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "In attesa di SIGUSR1 per catturare.\n"
 
-#: gphoto2/main.c:947
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Modalità posa bulb abilitata (intervallo: %ds).\n"
 
-#: gphoto2/main.c:960
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Cattura fotogramma #%d...\n"
 
-#: gphoto2/main.c:962
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Cattura fotogramma #%d/%d...\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Impossibile impostare la cattura in posa bulb, risultato %d."
 
-#: gphoto2/main.c:986
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Impossibile terminare la cattur (modalità posa bulb)."
 
-#: gphoto2/main.c:999
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Impossibile far partire la cattura dell'immagine."
 
-#: gphoto2/main.c:1006
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Impossibile catturare l'immagine."
 
-#: gphoto2/main.c:1013
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Cattura non riuscita (problema di messa a fuoco automatica?)...\n"
 
-#: gphoto2/main.c:1024
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Impossibile catturare."
 
-#: gphoto2/main.c:1056
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Attesa del prossimo periodo di cattura %ld secondi...\n"
 
-#: gphoto2/main.c:1065 gphoto2/main.c:1106
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Svegliato da SIGUSR1...\n"
 
 # FIXME
-#: gphoto2/main.c:1078
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "non in pausa (%ld secondi di ritardo)\n"
 
-#: gphoto2/main.c:1221
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "ERRORE: "
 
-#: gphoto2/main.c:1244
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -939,12 +1014,12 @@ msgstr ""
 "\n"
 "Interruzione...\n"
 
-#: gphoto2/main.c:1250
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Interrotto.\n"
 
-#: gphoto2/main.c:1255
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -953,21 +1028,26 @@ msgstr ""
 "\n"
 "Annullamento...\n"
 
-#: gphoto2/main.c:1406
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Usare la sintassi \"a:b=c:d\" per trattare come \"c:d\" ogni dispositivo USB rilevato come \"a:b\". a b c d sono numeri esadecimali che iniziano con \"0x\".\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Usare la sintassi \"a:b=c:d\" per trattare come \"c:d\" ogni dispositivo USB "
+"rilevato come \"a:b\". a b c d sono numeri esadecimali che iniziano con \"0x"
+"\".\n"
 
-#: gphoto2/main.c:1586
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 è stato compilato senza supporto per CDK."
 
-#: gphoto2/main.c:1850
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operazione annullata.\n"
 
-#: gphoto2/main.c:1854
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -976,7 +1056,7 @@ msgstr ""
 "*** Errore: Nessuna fotocamera trovata. ***\n"
 "\n"
 
-#: gphoto2/main.c:1856
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -985,7 +1065,7 @@ msgstr ""
 "*** Errore (%i: \"%s\") ***       \n"
 "\n"
 
-#: gphoto2/main.c:1861
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -1002,7 +1082,7 @@ msgstr ""
 "gphoto2 come segue:\n"
 "\n"
 
-#: gphoto2/main.c:1882
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
@@ -1011,400 +1091,407 @@ msgstr ""
 "Assicurarsi che gli argomenti siano sufficientemente quotati.\n"
 "\n"
 
-#: gphoto2/main.c:1949
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Stampa un messaggio d'aiuto completo"
 
-#: gphoto2/main.c:1951
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Stampa informazioni sull'uso"
 
-#: gphoto2/main.c:1953
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Attiva i messaggi di debug"
 
-#: gphoto2/main.c:1955
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Imposta il livello di debug [error|debug|data|all]"
 
-#: gphoto2/main.c:1957
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Nome del file in cui scrivere le informazioni di debug"
 
-#: gphoto2/main.c:1957 gphoto2/main.c:1962 gphoto2/main.c:1968
-#: gphoto2/main.c:2097
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "NOMEFILE"
 
-#: gphoto2/main.c:1959
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Output silenzioso (predefinito: prolisso)"
 
-#: gphoto2/main.c:1961
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Collega script da eseguire dopo scaricamenti, catture, ecc."
 
-#: gphoto2/main.c:1968
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Specifica la porta del dispositivo"
 
-#: gphoto2/main.c:1970
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Specifica la velocità di trasferimento seriale"
 
-#: gphoto2/main.c:1970
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "VELOCITÀ"
 
-#: gphoto2/main.c:1972
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Specifica il modello di fotocamera"
 
-#: gphoto2/main.c:1972
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODELLO"
 
 # In questo ordine stanno meglio
-#: gphoto2/main.c:1974
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "Cambia gli ID USB (solo esperti)"
 
-#: gphoto2/main.c:1974
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBID"
 
-#: gphoto2/main.c:1980
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Stampa le informazioni sulla versione ed esce"
 
-#: gphoto2/main.c:1982
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Elenca i modelli di fotocamera supportati"
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Elenca i dispositivi di porta supportati"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
-msgstr "Mostra le capacità della fotocamera o del driver nel database di libgphoto2"
+msgstr ""
+"Mostra le capacità della fotocamera o del driver nel database di libgphoto2"
 
-#: gphoto2/main.c:1993
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Configura"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Elenca l'albero di configurazione"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Stampa l'intero albero di configurazione"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Ottiene valore di configurazione"
 
 # FIXME
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Imposta un valore di configurazione o un indice nelle scelte"
 
 # FIXME
-#: gphoto2/main.c:2004
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Imposta indice di valore di configurazione nelle scelte"
 
-#: gphoto2/main.c:2006
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Imposta valore di configurazione"
 
-#: gphoto2/main.c:2008
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Reimposta la porta del dispositivo"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Lascia le immagini sulla fotocamera dopo la cattura"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr "Lascia le immagini RAW sulla fotocamera dopo la cattura"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Rimuovi le immagini dalla fotocamera dopo la cattura"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Attende uno o più eventi della fotocamera"
 
 # FIXME: MATCHSTRING?
-#: gphoto2/main.c:2020 gphoto2/main.c:2022 gphoto2/main.c:2048
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr "NUMERO, SECONDI, MILLISECONDI o STRINGA"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Attendi eventi dalla fotocamera e scarica nuove immagini"
 
-#: gphoto2/main.c:2025
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Cattura un'anteprima veloce"
 
-#: gphoto2/main.c:2028
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr "Mostra un'anteprima come Ascii Art"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Imposta l'intervallo di esposizione in posa bulb in secondi"
 
-#: gphoto2/main.c:2030 gphoto2/main.c:2034
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SECONDI"
 
 # FIXME: frame???
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Imposta il numero di fotogrammi da catturare (predefinito: infiniti)"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "NUMERO"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Imposta l'intervallo di cattura in secondi"
 
 # FIXME
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Reimposta l'intervallo di cattura sul segnale (predefinito: no)"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Cattura un'immagine"
 
-#: gphoto2/main.c:2040
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Cattura un'immagine"
 
-#: gphoto2/main.c:2042
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Cattura un'immagine e scaricala"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Cattura un filmato"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "NUMERO o SECONDI"
 
 # FIXME: clip? invariato? spezzone? brano?
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Cattura un clip audio"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Attendi la chiusura dell'otturatore e scarica"
 
-#: gphoto2/main.c:2050
-msgid "Trigger image capture"
-msgstr "Impossibile far partire la cattura dell'immagine."
-
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Elenca le cartelle nella cartella"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Elenca i file nalla cartella"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Crea una directory"
 
-#: gphoto2/main.c:2060 gphoto2/main.c:2062
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "NOMEDIRECTORY"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Rimuove una directory"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Mostra il numero di file"
 
-#: gphoto2/main.c:2066
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Scarica i file nell'intervallo indicato"
 
-#: gphoto2/main.c:2066 gphoto2/main.c:2070 gphoto2/main.c:2075
-#: gphoto2/main.c:2082 gphoto2/main.c:2088 gphoto2/main.c:2093
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "INTERVALLO"
 
-#: gphoto2/main.c:2068
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Scarica tutti i file dalla cartella"
 
-#: gphoto2/main.c:2070
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Scarica le miniature nell'intervallo indicato"
 
-#: gphoto2/main.c:2073
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Scarica tutte le miniature dalla cartella"
 
-#: gphoto2/main.c:2075
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Scarica i metadati nell'intervallo indicato"
 
-#: gphoto2/main.c:2077
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Scarica tutti i metadati dalla cartella"
 
-#: gphoto2/main.c:2079
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Carica i metadati per il file"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Scarica i dati grezzi nell'intervallo indicato"
 
-#: gphoto2/main.c:2085
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Scarica tutti i dati grezzi dalla cartella"
 
-#: gphoto2/main.c:2088
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Scarica i dati audio nell'intervallo indicato"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Scarica tutti i dati audio dalla cartella"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Elimina i file nell'intervallo indicato"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Elimina tutti i file nella cartella (predefinito: --no-recurse)"
 
-#: gphoto2/main.c:2097
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Carica un file sulla fotocamera"
 
-#: gphoto2/main.c:2099
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Specifica un nome di file o un modello di nome"
 
-#: gphoto2/main.c:2099
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "MODELLO_NOMEFILE"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Specifica una cartella per la fotocamera (predefinito=\"/\")"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "CARTELLA"
 
-#: gphoto2/main.c:2103
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Ricorsione (predefinito per lo scaricamento)"
 
-#: gphoto2/main.c:2105
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Nessuna ricorsione (predefinito per l'eliminazione)"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Elabora solo i nuovi file"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Sovrascrive i file senza chiedere conferma"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Salta i file esistenti"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Manda i file su standard output"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Stampa la dimensione dei file prima dei dati"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Elenca le fotocamere riconosciute automaticamente"
 
-#: gphoto2/main.c:2125 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "Mostra le informazioni EXIF delle immagini JPEG"
 
-#: gphoto2/main.c:2128 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
-msgstr "Mostra informazioni sull'immagine, come larghezza, altezza e orario di scatto"
+msgstr ""
+"Mostra informazioni sull'immagine, come larghezza, altezza e orario di scatto"
 
-#: gphoto2/main.c:2130
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr "Mostra sommario della fotocamera"
 
-#: gphoto2/main.c:2132
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Mostra il manuale del driver della fotocamera"
 
-#: gphoto2/main.c:2134
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Informazioni sul manuale del driver della fotocamera"
 
-#: gphoto2/main.c:2136
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Mostra le informazioni sulla memoria"
 
-#: gphoto2/main.c:2138
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "Shell di gPhoto"
 
-#: gphoto2/main.c:2144
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Opzioni comuni"
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Opzioni varie (non ordinate)"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "Informazioni sul software e sul sistema (non dalla fotocamera)"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Specifica la fotocamera da usare"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Configurazione fotocamera e software"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Cattura un'immagine dalla o sulla fotocamera"
 
-#: gphoto2/main.c:2156
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Scaricamento, caricamento e manipolazione file"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1413,7 +1500,7 @@ msgstr ""
 "%s\n"
 "Gli ID delle immagini sono numeri maggiori di zero."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1422,7 +1509,7 @@ msgstr ""
 "%s\n"
 "ID dell'immagine %i troppo grande."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1431,7 +1518,7 @@ msgstr ""
 "%s\n"
 "Gli intervalli devono essere separati da virgole."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1440,7 +1527,7 @@ msgstr ""
 "%s\n"
 "Gli intervalli devono iniziare con un numero."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1450,224 +1537,236 @@ msgstr ""
 "Carattere \"%c\" non previsto."
 
 # FIXME
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"Intervalli decrescenti non permessi. È stato indicato un intervallo da %i a %i."
+"Intervalli decrescenti non permessi. È stato indicato un intervallo da %i a "
+"%i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Errore (%i: \"%s\") ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Cambia directory sulla fotocamera"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "directory"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Cambia directory sul disco locale"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Esce dalla shell di gPhoto"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Scarica un file"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[directory/]nomefile"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Carica un file"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Scarica una miniatura"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Scarica i dati grezzi"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Elimina"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Crea directory"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Rimuovi directory"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Mostra un aiuto sui comandi"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[comando]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Elenca i contenuti della directory corrente"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[directory/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Elenca le variabili di configurazione"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Ottiene una variabile di configurazione"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "nome"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Imposta una variabile di configurazione"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "nome=valore"
 
 # FIXME
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Imposta un indice di variabile di configurazione"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "nome=indicevalore"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Cattura un'immagine"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Cattura un'immagine singola"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Cattura un'immagine singola e scaricala"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Cattura un'immagine di anteprima"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Attende un evento"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "numero o secondi"
 
 # FIXME UPSTREAM: download it -> download them?
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Attendi la cattura delle immagini e scaricale"
 
 # FIXME
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Attendi eventi e cattura delle immagini e scaricale"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Comando non valido."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Il comando \"%s\" richiede un argomento."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Percorso non valido."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Impossibile trovare la directory home."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Impossibile entrare nella directory locale \"%s\"."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "La directory locale è ora \"%s\"."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "La directory remota è ora \"%s\"."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config richiede un secondo argomento.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "set-config-value richiede un secondo argomento.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "set-config-index richiede un secondo argomento.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Comando \"%s\" non trovato. Usare \"help\" per l'elenco dei comandi disponibili."
+msgstr ""
+"Comando \"%s\" non trovato. Usare \"help\" per l'elenco dei comandi "
+"disponibili."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Aiuto su \"%s\":"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Uso:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Descrizione:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Gli argomenti tra parentesi quadre [] sono opzionali"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Comandi disponibili:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Per ricevere aiuto su un particolare comando, digitare \"help nome-comando\"."
+msgstr ""
+"Per ricevere aiuto su un particolare comando, digitare \"help nome-comando\"."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Impossibile far partire la cattura dell'immagine."

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,167 +8,162 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.4.14\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2012-04-15 18:07+0200\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2012-04-18 04:13+0900\n"
 "Last-Translator: Tadashi Jokagi <elf2000@users.sourceforge.net>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
 "Language: ja\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: gphoto2/actions.c:170
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "フォルダ '%s' 内のファイルの数: %i\n"
 
-#: gphoto2/actions.c:190
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "フォルダ '%2$s' の中にフォルダが %1$d 個あります。\n"
 
-#: gphoto2/actions.c:230
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "フォルダ '%s' の中にファイルがありません。\n"
 
-#: gphoto2/actions.c:233
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "フォルダ '%2$s' の中にファイルが %1$d 個あります。\n"
 
-#: gphoto2/actions.c:254
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "ファイル '%s' (フォルダ '%s') の情報:\n"
 
-#: gphoto2/actions.c:256
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "ファイル:\n"
 
-#: gphoto2/actions.c:258 gphoto2/actions.c:292 gphoto2/actions.c:308
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr " 使用不可です。\n"
 
-#: gphoto2/actions.c:261
-#, c-format
-msgid "  Name:        '%s'\n"
-msgstr "  名前:        '%s'\n"
-
-#: gphoto2/actions.c:263 gphoto2/actions.c:295
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  MIME 型:     '%s'\n"
 
-#: gphoto2/actions.c:265 gphoto2/actions.c:297
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "    容量:      %lu バイト\n"
 
-#: gphoto2/actions.c:267 gphoto2/actions.c:299
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  横:          %i ピクセル\n"
 
-#: gphoto2/actions.c:269 gphoto2/actions.c:301
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  縦:          %i ピクセル\n"
 
-#: gphoto2/actions.c:271 gphoto2/actions.c:303
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr " ダウンロード済:  %s\n"
 
-#: gphoto2/actions.c:272 gphoto2/actions.c:304 gphoto2/actions.c:316
-#: gphoto2/actions.c:666 gphoto2/actions.c:668 gphoto2/actions.c:696
-#: gphoto2/actions.c:699 gphoto2/actions.c:702 gphoto2/actions.c:705
-#: gphoto2/actions.c:708 gphoto2/actions.c:1673 gphoto2/actions.c:1898
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "はい"
 
-#: gphoto2/actions.c:272 gphoto2/actions.c:304 gphoto2/actions.c:316
-#: gphoto2/actions.c:666 gphoto2/actions.c:668 gphoto2/actions.c:696
-#: gphoto2/actions.c:699 gphoto2/actions.c:702 gphoto2/actions.c:705
-#: gphoto2/actions.c:708 gphoto2/actions.c:1667 gphoto2/actions.c:1892
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "いいえ"
 
-#: gphoto2/actions.c:274
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  権限: "
 
-#: gphoto2/actions.c:277
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "読み込み/削除"
 
-#: gphoto2/actions.c:279
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "読み込み"
 
-#: gphoto2/actions.c:281
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "削除"
 
-#: gphoto2/actions.c:283
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "なし"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  時間:        %s"
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "サムネイル:\n"
 
-#: gphoto2/actions.c:306
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "オーディオデータ:\n"
 
-#: gphoto2/actions.c:311
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  MIME 型:    '%s'\n"
 
-#: gphoto2/actions.c:313
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "    容量:     %lu バイト\n"
 
-#: gphoto2/actions.c:315
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr " ダウンロード済: %s\n"
 
-#: gphoto2/actions.c:491
+#: gphoto2/actions.c:504
 msgid "Could not parse EXIF data."
 msgstr "EXIF データを解析できませんでした。"
 
-#: gphoto2/actions.c:495
+#: gphoto2/actions.c:508
 #, c-format
 msgid "EXIF tags:"
 msgstr "EXIF タグ:"
 
-#: gphoto2/actions.c:498
+#: gphoto2/actions.c:511
 msgid "Tag"
 msgstr "タグ"
 
-#: gphoto2/actions.c:500
+#: gphoto2/actions.c:513
 msgid "Value"
 msgstr "値"
 
@@ -220,431 +215,541 @@ msgstr ""
 "パス名                           説明\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:645 gphoto2/actions.c:650
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:645
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "型式"
 
-#: gphoto2/actions.c:645
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "ポート"
 
-#: gphoto2/actions.c:646
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:664
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "カメラの性能                     : %s\n"
 
-#: gphoto2/actions.c:665
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "シリアルポートのサポート         : %s\n"
 
-#: gphoto2/actions.c:667
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB サポート                     : %s\n"
 
-#: gphoto2/actions.c:670
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "サポートする転送スピード         :\n"
 
-#: gphoto2/actions.c:672
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:675
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "取り込みの選択                   :\n"
 
-#: gphoto2/actions.c:677
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : 画像\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : ビデオ\n"
 
-#: gphoto2/actions.c:685
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : オーディオ\n"
 
-#: gphoto2/actions.c:689
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : プレビュー\n"
 
-#: gphoto2/actions.c:693
-#, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : ドライバーで取り込みが未サポートです\n"
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:695
+#: gphoto2/actions.c:700
+#, c-format
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : ドライバーで取り込みが未サポートです\n"
+
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "セッティングのサポート           : %s\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "カメラ内の選択ファイルの削除     : %s\n"
 
-#: gphoto2/actions.c:700
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "カメラ内の全ファイルの削除       : %s\n"
 
-#: gphoto2/actions.c:703
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "プレビューのサポート             : %s\n"
 
-#: gphoto2/actions.c:706
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "ファイルアップロードのサポート   : %s\n"
 
-#: gphoto2/actions.c:722
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "ポートは 'serial:/dev/ttyS0' または 'USB:' のようですが、'%s' はコロン ':' がないので適用することができません。"
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"ポートは 'serial:/dev/ttyS0' または 'USB:' のようですが、'%s' はコロン ':' が"
+"ないので適用することができません。"
 
-#: gphoto2/actions.c:756
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "指定したポート ('%s') が見つかりません。'gphoto2 --list-ports' で示されるポートの一つを指定して、ポート名のスペルが正しいか確認して下さい (接頭子 'serial:' または 'usb:')。"
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"指定したポート ('%s') が見つかりません。'gphoto2 --list-ports' で示されるポー"
+"トの一つを指定して、ポート名のスペルが正しいか確認して下さい (接頭子 "
+"'serial:' または 'usb:')。"
 
-#: gphoto2/actions.c:788
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "カメラのドライバ情報"
 
-#: gphoto2/actions.c:801
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "カメラのサマリ:"
 
-#: gphoto2/actions.c:814
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "カメラのマニュアル:"
 
-#: gphoto2/actions.c:829
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "シリアルポートの転送速度のみ指定することが可能です。"
 
-#: gphoto2/actions.c:879
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "Bart van Leeuwen : OS/2 のポーティング担当\n"
 
-#: gphoto2/actions.c:883
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
 "Copyright (C) 2000-%d Lutz Mueller 氏とその他の方々\n"
 "%s\n"
 "gphoto2 は法律により許可された範囲で完全無保証です。\n"
-"あなたは GNU 公有使用許諾契約書の下で gphoto2 の複製を再配布することができます。\n"
+"あなたは GNU 公有使用許諾契約書の下で gphoto2 の複製を再配布することができま"
+"す。\n"
 "これらの内容について詳細な情報については COPYING ファイルを参照ください。\n"
 "\n"
-"このバージョンの gphoto2 は次のソフトウェア・バージョンとオプションを使用します:\n"
+"このバージョンの gphoto2 は次のソフトウェア・バージョンとオプションを使用しま"
+"す:\n"
 
-#: gphoto2/actions.c:982
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "「movie.mjpg」が開けません。"
 
-#: gphoto2/actions.c:989
+#: gphoto2/actions.c:1022
 #, fuzzy, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
 msgstr "カメラからのイベントを待っています。[Ctrl][C] を押すと中断します。\n"
 
-#: gphoto2/actions.c:993
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr ""
 
-#: gphoto2/actions.c:998
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1007
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "動画のキャプチャーでエラーです…終了します。"
 
-#: gphoto2/actions.c:1012
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "動画のキャプチャーでエラーです…制御できない MIME タイプ「%s」です。"
 
-#: gphoto2/actions.c:1017
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ctrl-C が押されました…終了します。\n"
 
-#: gphoto2/actions.c:1101 gphoto2/main.c:641
+#: gphoto2/actions.c:1074
+#, c-format
+msgid "Movie capture finished (%d frames)\n"
+msgstr ""
+
+#: gphoto2/actions.c:1106
+#, c-format
+msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
+msgstr "カメラからのイベントを待っています。[Ctrl][C] を押すと中断します。\n"
+
+#: gphoto2/actions.c:1112
+#, fuzzy, c-format
+msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"カメラから %d 回のイベントを待っています。[Ctrl][C] を押すと中断します。\n"
+
+#: gphoto2/actions.c:1117
+#, fuzzy, c-format
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"カメラからのイベントを %d 秒待っています。[Ctrl][C] を押すと中断します。\n"
+
+#: gphoto2/actions.c:1122
+#, c-format
+msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"カメラからのイベントを %d 秒待っています。[Ctrl][C] を押すと中断します。\n"
+
+#: gphoto2/actions.c:1125
+#, c-format
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"カメラから %d 回のイベントを待っています。[Ctrl][C] を押すと中断します。\n"
+
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"カメラから %d 回のイベントを待っています。[Ctrl][C] を押すと中断します。\n"
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
+#, c-format
+msgid "event found, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "フォルダを設定できませんでした。"
 
-#: gphoto2/actions.c:1107 gphoto2/main.c:648
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "画像を取得できませんでした。"
 
-#: gphoto2/actions.c:1114 gphoto2/main.c:655
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "libcanon.so のバグ?"
 
-#: gphoto2/actions.c:1123 gphoto2/main.c:666
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "画像の削除ができませんでした。"
 
-#: gphoto2/actions.c:1146
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr "このカメラはストレージ情報の取得をサポートしていませんでした。\n"
 
-#: gphoto2/actions.c:1161
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "読み書き"
 
-#: gphoto2/actions.c:1164
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "読み込み専用"
 
-#: gphoto2/actions.c:1167
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "読み込み専用と削除"
 
-#: gphoto2/actions.c:1170 gphoto2/actions.c:1180
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "不明"
 
-#: gphoto2/actions.c:1183
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "固定 ROM"
 
-#: gphoto2/actions.c:1186
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "リムーバブル ROM"
 
-#: gphoto2/actions.c:1189
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "固定 RAM"
 
-#: gphoto2/actions.c:1192
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "リムーバブル RAM"
 
-#: gphoto2/actions.c:1202
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "未定義"
 
-#: gphoto2/actions.c:1205
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "一般フラット"
 
-#: gphoto2/actions.c:1208
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "一般階層"
 
-#: gphoto2/actions.c:1211
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "カメラレイアウト (DCIM)"
 
-#: gphoto2/actions.c:1249
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "USB ベンダー/製品 ID 0x%x/0x%x と 0x%x/0x%x を上書きしています"
 
-#: gphoto2/actions.c:1313
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "メーリングリストにデバッグメッセージを送信する場合は、必ず次の行を挿入して下さい:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"メーリングリストにデバッグメッセージを送信する場合は、必ず次の行を挿入して下"
+"さい:"
 
-#: gphoto2/actions.c:1328
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s は次のオプションでコンパイルされました:"
 
-#: gphoto2/actions.c:1459
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s は設定ツリーで見つけられませんでした。"
 
-#: gphoto2/actions.c:1508
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "ウィジェット %s のテキストの値を取得できませんでした。"
 
-#: gphoto2/actions.c:1525
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "ウィジェット %s の範囲の値を取得できませんでした。"
 
-#: gphoto2/actions.c:1537
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "ウィジェット %s のトグルの値を取得できませんでした。"
 
-#: gphoto2/actions.c:1549
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "ウィジェット %s の日時の値を取得できませんでした。"
 
-#: gphoto2/actions.c:1579
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "ウィジェット %s の比率の値を取得できませんでした。"
 
-#: gphoto2/actions.c:1623
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "プロパティ %s は読み込み専用です。"
 
-#: gphoto2/actions.c:1637 gphoto2/actions.c:1862
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "ウィジェット %s のテキストの値を %s に設定できませんでした。"
 
-#: gphoto2/actions.c:1647 gphoto2/actions.c:1872
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "渡された値 %s は浮動小数点値ではありませんでした。"
 
-#: gphoto2/actions.c:1652 gphoto2/actions.c:1877
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "渡された値 %f は期待された範囲(%f～%f)ではありませんでした。"
 
-#: gphoto2/actions.c:1658 gphoto2/actions.c:1883
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "ウィジェット %s の範囲の値を %f に設定できませんでした。<"
 
-#: gphoto2/actions.c:1667 gphoto2/actions.c:1892
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "オフ"
 
-#: gphoto2/actions.c:1668 gphoto2/actions.c:1893
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "偽(false)"
 
-#: gphoto2/actions.c:1673 gphoto2/actions.c:1898
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "オン"
 
-#: gphoto2/actions.c:1674 gphoto2/actions.c:1899
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "真(true)"
 
-#: gphoto2/actions.c:1679 gphoto2/actions.c:1904
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "渡された値 %s は正しいトグル値ではありませんでした。"
 
-#: gphoto2/actions.c:1685 gphoto2/actions.c:1910
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "ウィジェット %s のトグルの値を %s に設定できませんでした．"
 
-#: gphoto2/actions.c:1698 gphoto2/actions.c:1923
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
+#, fuzzy
+msgid "now"
+msgstr "いいえ"
+
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "渡された値 %s は整数か正しい時間のどちらでもありませんでした。"
 
-#: gphoto2/actions.c:1705 gphoto2/actions.c:1930
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "ウィジェット %s の日時を新しい時間 %s に設定できませんでした。"
 
-#: gphoto2/actions.c:1752 gphoto2/actions.c:1816 gphoto2/actions.c:1960
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "選択した %s は選択肢中で見つけられませんでした。"
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1968
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "ウィジェット %s は設定できません。"
 
-#: gphoto2/actions.c:1767 gphoto2/actions.c:1835 gphoto2/actions.c:1975
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr "設定エントリー %2$s への新しい設定値 %1$s の設定に失敗しました。"
 
-#: gphoto2/actions.c:1828
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "ウィジェット %s は選択された一覧でインデックスが作成されていません。代わりに --set-config-value を使用してください。"
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"ウィジェット %s は選択された一覧でインデックスが作成されていません。代わりに "
+"--set-config-value を使用してください。"
 
-#: gphoto2/foreach.c:254
+#: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "ファイル番号がおかしいです。%i を指定しましたが、%i 個のファイルしか '%s' の中にはないか、またはサブフォルダのようです。まず最初にファイル一覧から正しい番号を取得して下さい。"
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"ファイル番号がおかしいです。%i を指定しましたが、%i 個のファイルしか '%s' の"
+"中にはないか、またはサブフォルダのようです。まず最初にファイル一覧から正しい"
+"番号を取得して下さい。"
 
-#: gphoto2/foreach.c:279
+#: gphoto2/foreach.c:285
 #, c-format
 msgid "There are no files in folder '%s'."
 msgstr "フォルダ '%s' の中にファイルはありません。"
 
-#: gphoto2/foreach.c:285
+#: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "ファイル番号がおかしいです。%i を指定しましたが、1個のファイルしか '%s' の中にありません。"
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"ファイル番号がおかしいです。%i を指定しましたが、1個のファイルしか '%s' の中"
+"にありません。"
 
-#: gphoto2/foreach.c:293
+#: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "ファイル番号がおかしいです。%1$i を指定ましたが、'%3$s' の中には有効なファイルは %2$i 個しかありません。まず最初にファイル一覧から正しい番号を取得してください。"
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"ファイル番号がおかしいです。%1$i を指定ましたが、'%3$s' の中には有効なファイ"
+"ルは %2$i 個しかありません。まず最初にファイル一覧から正しい番号を取得してく"
+"ださい。"
 
 #: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** エラー ***             \n"
 
-#: gphoto2/gp-params.c:253
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "何かキーを押すと続けます。\n"
 
-#: gphoto2/gp-params.c:275
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "メモリが足りません。"
@@ -653,196 +758,216 @@ msgstr "メモリが足りません。"
 msgid "Operation cancelled"
 msgstr "操作を取り消しました"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>続行"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>キャンセル"
 
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>エラー"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "設定を有効にすることが出来ませんでした:"
 
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "終了"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "戻る"
 
-#: gphoto2/gphoto2-cmd-config.c:254
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "時刻: "
 
-#: gphoto2/gphoto2-cmd-config.c:313 gphoto2/gphoto2-cmd-config.c:341
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "値: "
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "はい"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "いいえ"
 
-#: gphoto2/main.c:236
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "ファイル名のゼロパディングは %%n でのみ可能です。"
 
-#: gphoto2/main.c:245
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "正確な値なしで %%n ゼロパディングを使うことはできません!"
 
-#: gphoto2/main.c:278
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "カメラが提供するファイル名 ('%s') には拡張子がありません！"
 
-#: gphoto2/main.c:333
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "不正な書式 '%s' (%i でエラー) です。"
 
-#: gphoto2/main.c:386
+#: gphoto2/main.c:386 gphoto2/main.c:592
+#, fuzzy, c-format
+msgid "Skip existing file %s\n"
+msgstr "ファイルを %s で保存します\n"
+
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "ファイル %s は存在します。上書きしますか？ [y|n] "
 
-#: gphoto2/main.c:398
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "新しいファイル名を指定しますか？ [y|n] "
 
-#: gphoto2/main.c:408
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "新しいファイル名: "
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "ファイルを %s で保存します\n"
 
-#: gphoto2/main.c:507
+#: gphoto2/main.c:630
 #, fuzzy
 msgid "Permission denied"
 msgstr "  権限: "
 
-#: gphoto2/main.c:632
+#: gphoto2/main.c:800
+#, fuzzy
+msgid "Could not trigger capture."
+msgstr "画像を取得できませんでした。"
+
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "新しいファイルの格納場所: %s%s%s\n"
 
-#: gphoto2/main.c:661
+#: gphoto2/main.c:847 gphoto2/main.c:878
+#, fuzzy, c-format
+msgid "Keeping file %s%s%s on the camera\n"
+msgstr "カメラ内のファイル %s%s%s の削除をしています\n"
+
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "カメラ内のファイル %s%s%s の削除をしています\n"
 
-#: gphoto2/main.c:699
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr ""
 
-#: gphoto2/main.c:709
+#: gphoto2/main.c:916
+#, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr ""
 
-#: gphoto2/main.c:715
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr ""
 
-#: gphoto2/main.c:733
+#: gphoto2/main.c:950
 #, fuzzy
 msgid "Could not get capabilities?"
 msgstr "画像を取得できませんでした。"
 
-#: gphoto2/main.c:741
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "コマドリモードを有効にしました(間隔: %d 秒)。\n"
 
-#: gphoto2/main.c:744
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "取り込みをするために SIGUSR1 の待ちの待機をしています。\n"
 
-#: gphoto2/main.c:750
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "白熱灯モードを有効にしました (露出時間: %d 秒)。\n"
 
-#: gphoto2/main.c:763
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "フレーム #%d の取り込み中です...\n"
 
-#: gphoto2/main.c:765
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "フレーム #%d/%d の取り込み中です...\n"
 
-#: gphoto2/main.c:775
+#: gphoto2/main.c:987
 #, fuzzy, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "取り込みを終了できませんでした (白熱灯モード)。"
 
-#: gphoto2/main.c:789
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "取り込みを終了できませんでした (白熱灯モード)。"
 
-#: gphoto2/main.c:801
+#: gphoto2/main.c:1014
 #, fuzzy
 msgid "Could not trigger image capture."
 msgstr "画像を取得できませんでした。"
 
-#: gphoto2/main.c:810
+#: gphoto2/main.c:1021
 #, fuzzy
 msgid "Could not capture image."
 msgstr "取り込みできませんでした。"
 
-#: gphoto2/main.c:818
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "取り込みに失敗しました (オートフォーカスの問題?)...\n"
 
-#: gphoto2/main.c:828
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "取り込みできませんでした。"
 
-#: gphoto2/main.c:853
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr ""
 
-#: gphoto2/main.c:862 gphoto2/main.c:906
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "SIGUSR1 で目覚めます...\n"
 
-#: gphoto2/main.c:878
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "スリープしていません (%ld 秒スケジュール遅れ)\n"
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "エラー: "
 
-#: gphoto2/main.c:1032
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -851,12 +976,12 @@ msgstr ""
 "\n"
 "停止中...\n"
 
-#: gphoto2/main.c:1038
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "停止しました。\n"
 
-#: gphoto2/main.c:1043
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -865,43 +990,32 @@ msgstr ""
 "\n"
 "キャンセル中...\n"
 
-#: gphoto2/main.c:1186
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "検出された USB デバイスを使用するために a:b=c:d という書式を使用して下さい。a, b, c, d は '0x' で始まる 16 進の数値にして下さい。\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"検出された USB デバイスを使用するために a:b=c:d という書式を使用して下さい。"
+"a, b, c, d は '0x' で始まる 16 進の数値にして下さい。\n"
 
-#: gphoto2/main.c:1343
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "この gphoto2 は CDK をサポートしていません。"
 
-#: gphoto2/main.c:1513
-#, c-format
-msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
-msgstr "カメラからのイベントを待っています。[Ctrl][C] を押すと中断します。\n"
-
-#: gphoto2/main.c:1517
-#, c-format
-msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "カメラからのイベントを %d 秒待っています。[Ctrl][C] を押すと中断します。\n"
-
-#: gphoto2/main.c:1520
-#, c-format
-msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
-msgstr "カメラから %d 回のイベントを待っています。[Ctrl][C] を押すと中断します。\n"
-
-#: gphoto2/main.c:1585
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "操作がキャンセルされました。\n"
 
-#: gphoto2/main.c:1589
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
 "\n"
 msgstr ""
 
-#: gphoto2/main.c:1591
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -910,7 +1024,7 @@ msgstr ""
 "*** エラー (%i: '%s') ***       \n"
 "\n"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -927,363 +1041,412 @@ msgstr ""
 "送信する場合、以下のように gphoto2 を起動してください:\n"
 "\n"
 
-#: gphoto2/main.c:1617
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
 "\n"
 msgstr ""
 
-#: gphoto2/main.c:1684
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "プログラムの使い方の完全なヘルプメッセージを表示する"
 
-#: gphoto2/main.c:1686
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "プログラムに使い方の短いメッセージを表示する"
 
-#: gphoto2/main.c:1688
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "デバッグを有効にする"
 
-#: gphoto2/main.c:1690
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
+
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "デバッグ情報を書き込むファイルの名前"
 
-#: gphoto2/main.c:1690 gphoto2/main.c:1695 gphoto2/main.c:1701
-#: gphoto2/main.c:1815
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: gphoto2/main.c:1692
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "簡易出力 (標準=詳細)"
 
-#: gphoto2/main.c:1694
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "ダウンロード、取り込みなどの跡に呼び出すフックスクリプトです。"
 
-#: gphoto2/main.c:1701
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "デバイス・ポートを指定する"
 
-#: gphoto2/main.c:1703
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "シリアル転送スピードを指定する"
 
-#: gphoto2/main.c:1703
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "SPEED"
 
-#: gphoto2/main.c:1705
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "カメラの型式を指定して下さい"
 
-#: gphoto2/main.c:1705
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODEL"
 
-#: gphoto2/main.c:1707
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "USB ID の上書き (エキスパート向け)"
 
-#: gphoto2/main.c:1707
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBID"
 
-#: gphoto2/main.c:1713
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "バージョン情報を表示して終了する"
 
-#: gphoto2/main.c:1715
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "サポートしているカメラ型式の一覧"
 
-#: gphoto2/main.c:1717
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "サポートしているポート・デバイスの一覧を表示する"
 
-#: gphoto2/main.c:1719
-msgid "Display camera/driver abilities"
+#: gphoto2/main.c:2015
+#, fuzzy
+msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "カメラ/ドライバーの性能を表示する"
 
-#: gphoto2/main.c:1726
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "設定"
 
-#: gphoto2/main.c:1729
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "設定ツリーの一覧"
 
-#: gphoto2/main.c:1731
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "全設定ツリーのダンプ出力"
 
-#: gphoto2/main.c:1733
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "設定値の取得"
 
-#: gphoto2/main.c:1735
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "設定値かインデックスを選択して設定する"
 
-#: gphoto2/main.c:1737
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "設定値インデックスを選択して設定する"
 
-#: gphoto2/main.c:1739
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "設定値の設定"
 
-#: gphoto2/main.c:1745
+#: gphoto2/main.c:2037
+#, fuzzy
+msgid "Reset device port"
+msgstr "デバイス・ポートを指定する"
+
+#: gphoto2/main.c:2043
+msgid "Keep images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2045
+msgid "Keep RAW images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2047
+msgid "Remove images from camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "カメラからのイベントを待つ"
 
-#: gphoto2/main.c:1745 gphoto2/main.c:1747 gphoto2/main.c:1754
-#: gphoto2/main.c:1768
-msgid "COUNT"
-msgstr "COUNT"
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
 
-#: gphoto2/main.c:1747
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "カメラのイベントと新規画像のダウンロードを待つ"
 
-#: gphoto2/main.c:1750
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "取り込みの簡易プレビュー"
 
-#: gphoto2/main.c:1752
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
+
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "白熱灯の露出時間設定 (単位:秒)"
 
-#: gphoto2/main.c:1752 gphoto2/main.c:1756
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SECONDS"
 
-#: gphoto2/main.c:1754
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "取り込むフレーム数の設定 (標準=infinite(無限))"
 
-#: gphoto2/main.c:1756
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr "COUNT"
+
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "取り込み間隔の設定 (単位:秒)"
 
-#: gphoto2/main.c:1758
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "シグナルで取り込み間隔をリセットする (標準=no)"
 
-#: gphoto2/main.c:1760
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "画像の取り込み"
 
-#: gphoto2/main.c:1762
+#: gphoto2/main.c:2069
+#, fuzzy
+msgid "Trigger capture of an image"
+msgstr "画像の取り込み"
+
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "画像の取り込みとダウンロード"
 
-#: gphoto2/main.c:1764
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "映像の取り込み"
 
-#: gphoto2/main.c:1764
+#: gphoto2/main.c:2073
 #, fuzzy
 msgid "COUNT or SECONDS"
 msgstr "SECONDS"
 
-#: gphoto2/main.c:1766
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "オーディオの取り込み"
 
-#: gphoto2/main.c:1768
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "カメラのシャッターリリースとダウンロードを待つ"
 
-#: gphoto2/main.c:1774
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "フォルダの一覧"
 
-#: gphoto2/main.c:1776
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "フォルダ内のファイル一覧"
 
-#: gphoto2/main.c:1778
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "ディレクトリの作成"
 
-#: gphoto2/main.c:1778 gphoto2/main.c:1780
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "DIRNAME"
 
-#: gphoto2/main.c:1780
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "ディレクトリの削除"
 
-#: gphoto2/main.c:1782
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "ファイル数の表示"
 
-#: gphoto2/main.c:1784
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "指定した範囲でファイルの取得"
 
-#: gphoto2/main.c:1784 gphoto2/main.c:1788 gphoto2/main.c:1793
-#: gphoto2/main.c:1800 gphoto2/main.c:1806 gphoto2/main.c:1811
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "RANGE"
 
-#: gphoto2/main.c:1786
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "フォルダからすべてのファイルの取得"
 
-#: gphoto2/main.c:1788
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "指定した範囲でサムネイルの取得"
 
-#: gphoto2/main.c:1791
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "フォルダからすべてのサムネイルの取得"
 
-#: gphoto2/main.c:1793
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "指定範囲のメタデータの取得"
 
-#: gphoto2/main.c:1795
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "フォルダからすべてのメタデータを取得する"
 
-#: gphoto2/main.c:1797
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "ファイルからメタデータをアップロードする"
 
-#: gphoto2/main.c:1800
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "指定した範囲で生データの取得"
 
-#: gphoto2/main.c:1803
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "フォルダからすべての生データの取得"
 
-#: gphoto2/main.c:1806
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "指定したオーディオデータの取得"
 
-#: gphoto2/main.c:1809
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "フォルダからオーディオデータの取得"
 
-#: gphoto2/main.c:1811
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "指定した範囲でファイルの削除"
 
-#: gphoto2/main.c:1813
+#: gphoto2/main.c:2122
 #, fuzzy
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "フォルダの中のファイルを削除"
 
-#: gphoto2/main.c:1815
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "ファイルをカメラにアップロード"
 
-#: gphoto2/main.c:1817
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "ファイル名もしくはファイル名のパターンの指定"
 
-#: gphoto2/main.c:1817
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "FILENAME_PATTERN"
 
-#: gphoto2/main.c:1819
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "カメラのフォルダを指定する (標準=\"/\")"
 
-#: gphoto2/main.c:1819
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "FOLDER"
 
-#: gphoto2/main.c:1821
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "再帰する (標準=ダウンロード)"
 
-#: gphoto2/main.c:1823
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "再帰しない (標準=削除)"
 
-#: gphoto2/main.c:1825
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "新しいファイルのみ処理する"
 
-#: gphoto2/main.c:1827
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "ファイルの上書きで問い合わせない"
 
-#: gphoto2/main.c:1833
+#: gphoto2/main.c:2140
+msgid "Skip existing files"
+msgstr ""
+
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "標準出力にファイルを送出する"
 
-#: gphoto2/main.c:1835
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "データの前にファイルサイズを出力する"
 
-#: gphoto2/main.c:1837
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "自動検出したカメラの一覧を表示する"
 
-#: gphoto2/main.c:1841 gphoto2/shell.c:138
-msgid "Show EXIF information"
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
 msgstr "EXIF 情報の表示"
 
-#: gphoto2/main.c:1844 gphoto2/shell.c:132
-msgid "Show info"
-msgstr "情報の表示"
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
 
-#: gphoto2/main.c:1846
-msgid "Show summary"
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "サマリの表示"
 
-#: gphoto2/main.c:1848
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "カメラのドライバのマニュアルを表示する"
 
-#: gphoto2/main.c:1850
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "カメラのドライバのマニュアルの情報"
 
-#: gphoto2/main.c:1852
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "ストレージ情報の表示"
 
-#: gphoto2/main.c:1854
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "gPhoto シェル"
 
-#: gphoto2/main.c:1860
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "共通オプション"
 
-#: gphoto2/main.c:1862
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "その他のオプション (順不同)"
 
-#: gphoto2/main.c:1864
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "ソフトウェアとホストシステムの情報の取得 (カメラからではありません)"
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "使用するカメラの指定"
 
-#: gphoto2/main.c:1868
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "カメラとソフトウェア設定"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "カメラ上で、カメラから画像の取り込み"
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "ダウンロード、アップロードとファイル操作"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1292,7 +1455,7 @@ msgstr ""
 "%s\n"
 "画像の ID は 0 以上にして下さい。"
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1301,7 +1464,7 @@ msgstr ""
 "%s\n"
 "画像 ID %i は大きすぎます。"
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1310,7 +1473,7 @@ msgstr ""
 "%s\n"
 "範囲は ',' で区切って下さい。"
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1319,7 +1482,7 @@ msgstr ""
 "%s\n"
 "範囲は数値で始めて下さい。"
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1328,7 +1491,7 @@ msgstr ""
 "%s\n"
 "予期しない文字 '%c' です。"
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -1337,218 +1500,235 @@ msgstr ""
 "%s\n"
 "範囲を小さくすることはできません。%i から %i の範囲で指定して下さい。"
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** エラー (%i: '%s') ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "カメラ上でディレクトリを変更します"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "ディレクトリ"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "ローカルディスク上でディレクトリを変更します"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "gPhoto シェルを終了します"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "ファイルのダウンロード"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[ディレクトリ/]ファイル名"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "ファイルのアップロード"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "サムネイルのダウンロード"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "生データのダウンロード"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "削除"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "ディレクトリの作成"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "ディレクトリの削除"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "コマンドの用法を表示する"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[コマンド]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "このディレクトリの一覧を表示します"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[ディレクトリ/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "設定値の一覧"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "設定値の取得"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "名前"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "設定値の設定"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "名前=値"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "設定値インデックスの設定"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "名前=値インデックス"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "単一画像の取り込み"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "単一画像の取り込み"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "単一画像の取り込みとダウンロード"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "プレビュー画像の取り込み"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "イベントを待つ"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "回数か秒数"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "取り込み、ダウンロードされた画像を待つ"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "取り込み、ダウンロードされた画像とイベントを待つ"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "コマンドが正しくありません。"
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "コマンド '%s' には引数が必要です。"
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "パス名が正しくありません。"
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "ホーム・ディレクトリが見つかりませんでした。"
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "ローカルのディレクトリ '%s' に移動できませんでした。"
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "現在のローカルディレクトリは '%s' です。"
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "現在のリモートのディレクトリは '%s' です。"
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config は第 2 引数を必要とします。\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "set-config-value は第 2 引数を必要とします。\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "set-config-index は第 2 引数を必要とします。\n"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "コマンド '%s' が見つかりませんでした。'help' で利用可能なコマンド一覧を表示します。"
+msgstr ""
+"コマンド '%s' が見つかりませんでした。'help' で利用可能なコマンド一覧を表示し"
+"ます。"
 
-#: gphoto2/shell.c:969
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "\"%s\" のヘルプ:"
 
-#: gphoto2/shell.c:971
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "使い方:"
 
-#: gphoto2/shell.c:974
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "説明:"
 
-#: gphoto2/shell.c:976
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* [] 内の引数はオプションです。"
 
-#: gphoto2/shell.c:997
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "利用可能なコマンド:"
 
-#: gphoto2/shell.c:1002
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "特定のコマンドに対するヘルプを表示する場合は 'help コマンド名' と入力して下さい。"
+msgstr ""
+"特定のコマンドに対するヘルプを表示する場合は 'help コマンド名' と入力して下さ"
+"い。"
+
+#, c-format
+#~ msgid "  Name:        '%s'\n"
+#~ msgstr "  名前:        '%s'\n"
+
+#~ msgid "Show info"
+#~ msgstr "情報の表示"
 
 #~ msgid "You cannot use '%%n' in combination with non-persistent files!"
-#~ msgstr "non-persistent ファイルと「%%n」の組み合わせを使用することはできません!"
+#~ msgstr ""
+#~ "non-persistent ファイルと「%%n」の組み合わせを使用することはできません!"
 
 #~ msgid "Could not get filename (bulb mode)."
 #~ msgstr "ファイル名を取得できませんでした (白熱灯モード)。"
@@ -1712,11 +1892,19 @@ msgstr "特定のコマンドに対するヘルプを表示する場合は 'help
 #~ msgid "folder"
 #~ msgstr "フォルダ名"
 
-#~ msgid "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
-#~ msgstr "OS/2 向けの gPhoto2 では環境変数 ${CAMLIBS} にカメラ・ライブラリへのパスを設定する必要があります。(例) SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the "
+#~ "location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgstr ""
+#~ "OS/2 向けの gPhoto2 では環境変数 ${CAMLIBS} にカメラ・ライブラリへのパスを"
+#~ "設定する必要があります。(例) SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
 
-#~ msgid "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
-#~ msgstr "OS/2 向けの gPhoto2 では環境変数 ${IOLIBS} にカメラの I/O ライブラリへのパスに設定する必要があります。(例) SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the "
+#~ "location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgstr ""
+#~ "OS/2 向けの gPhoto2 では環境変数 ${IOLIBS} にカメラの I/O ライブラリへのパ"
+#~ "スに設定する必要があります。(例) SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
 
 #~ msgid "Usage:\n"
 #~ msgstr "用法:\n"
@@ -1733,7 +1921,9 @@ msgstr "特定のコマンドに対するヘルプを表示する場合は 'help
 
 #~ msgid ""
 #~ "--------------------------------------------------------------------------------\n"
-#~ "[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
+#~ "[Use double-quotes around arguments]        [Picture numbers begin with "
+#~ "one (1)]\n"
 #~ msgstr ""
 #~ "--------------------------------------------------------------------------------\n"
-#~ "[引数にダブルクオーテーションを使用する]    [写真の番号を (1) から始める]\n"
+#~ "[引数にダブルクオーテーションを使用する]    [写真の番号を (1) から始め"
+#~ "る]\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -11,147 +11,147 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2-2.5.6\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2014-12-21 20:43+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2014-12-29 13:18+0100\n"
 "Last-Translator: Benno Schulenberg <benno@vertaalt.nl>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
 "Language: nl\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 1.0\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Aantal bestanden in map '%s': %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "Er is %d map in map '%s'.\n"
 msgstr[1] "Er zijn %d mappen in map '%s'.\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Er is geen bestand in map '%s'.\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "Er is %d bestand in map '%s'.\n"
 msgstr[1] "Er zijn %d bestanden in map '%s'.\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Informatie over bestand '%s' (map '%s'):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Bestand:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Geen beschikbaar.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  MIME-type:   '%s'\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Grootte:     %lu byte(s)\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Breedte:     %i pixel(s)\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Hoogte:      %i pixel(s)\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Gedownload:  %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:712
-#: gphoto2/actions.c:715 gphoto2/actions.c:718 gphoto2/actions.c:721
-#: gphoto2/actions.c:724 gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "ja"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:712
-#: gphoto2/actions.c:715 gphoto2/actions.c:718 gphoto2/actions.c:721
-#: gphoto2/actions.c:724 gphoto2/actions.c:1769 gphoto2/actions.c:2006
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "nee"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Toegangsrechten: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "lezen/verwijderen"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "lezen"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "verwijderen"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "geen"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Tijd:        %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Miniatuurvoorbeeld:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Audiogegevens:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  MIME-type:  '%s'\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Grootte:    %lu byte(s)\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Gedownload: %s\n"
@@ -173,46 +173,46 @@ msgstr "Label"
 msgid "Value"
 msgstr "Waarde"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "EXIF-gegevens bevatten een miniatuurvoorbeeld (%i bytes)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 is gecompileerd zonder EXIF-ondersteuning."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Aantal ondersteunde camera's: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Ondersteunde camera's:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (AAN HET TESTEN)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (EXPERIMENTEEL)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Aantal gevonden apparaten: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -221,150 +221,169 @@ msgstr ""
 "Pad                              Omschrijving\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Model"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Poort"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Mogelijkheden van de camera      : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Ondersteuning van seriële poort  : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB-ondersteuning                : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Ondersteunde overdrachtssnelheden:\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Opnamekeuzes                     :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Afbeelding\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Audio\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Voorbeeldweergave\n"
 
-#: gphoto2/actions.c:709
-#, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : Stuurprogramma ondersteunt opname niet\n"
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:711
+#: gphoto2/actions.c:700
+#, c-format
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : Stuurprogramma ondersteunt opname niet\n"
+
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Configuratie-ondersteuning       : %s\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Geselecteerde bestanden op camera wissen: %s\n"
 
-#: gphoto2/actions.c:716
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Alle bestanden op camera wissen  : %s\n"
 
-#: gphoto2/actions.c:719
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Ondersteuning voor voorbeeldweergave (miniaturen): %s\n"
 
-#: gphoto2/actions.c:722
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Ondersteuning van bestandsupload : %s\n"
 
-#: gphoto2/actions.c:739
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Poorten moeten eruit zien als 'serial:/dev/ttyS0' of 'usb:', maar '%s' mist een dubbele punt, dus er wordt gegist naar wat u bedoelt."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Poorten moeten eruit zien als 'serial:/dev/ttyS0' of 'usb:', maar '%s' mist "
+"een dubbele punt, dus er wordt gegist naar wat u bedoelt."
 
-#: gphoto2/actions.c:773
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "De opgegeven poort ('%s') kan niet worden gevonden.  Geef één van de poorten gevonden door 'gphoto2 --list-ports' op en zorg dat de schrijfwijze juist is (bijvoorbeeld met het voorvoegsel 'serial:' of 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"De opgegeven poort ('%s') kan niet worden gevonden.  Geef één van de poorten "
+"gevonden door 'gphoto2 --list-ports' op en zorg dat de schrijfwijze juist is "
+"(bijvoorbeeld met het voorvoegsel 'serial:' of 'usb:')."
 
-#: gphoto2/actions.c:806
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "Over het camerastuurprogramma:"
 
-#: gphoto2/actions.c:819
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Camerasamenvatting:"
 
-#: gphoto2/actions.c:832
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Handleiding van camera:"
 
-#: gphoto2/actions.c:849
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "U kunt alleen snelheden opgeven voor seriële poorten."
 
-#: gphoto2/actions.c:899
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "OS/2-port door Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:903
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
@@ -377,299 +396,343 @@ msgstr ""
 "\n"
 "Deze versie van gphoto2 gebruikt de volgende softwareversies en -opties:\n"
 
-#: gphoto2/actions.c:1003
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Kan 'movie.mjpg' niet openen."
 
-#: gphoto2/actions.c:1010
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Voorbeeldopnames worden als film opgeslagen in '%s'.  Druk op Ctrl+C om af te breken.\n"
+msgstr ""
+"Voorbeeldopnames worden als film opgeslagen in '%s'.  Druk op Ctrl+C om af "
+"te breken.\n"
 
-#: gphoto2/actions.c:1014
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
-msgstr "Voorbeeldopnames worden gedurende %2$d seconden als film opgeslagen in '%1$s'.\n"
+msgstr ""
+"Voorbeeldopnames worden gedurende %2$d seconden als film opgeslagen in "
+"'%1$s'.\n"
 
-#: gphoto2/actions.c:1019
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Er worden %d voorbeeldopnames als film opgeslagen in '%s'.\n"
 
-#: gphoto2/actions.c:1029
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Fout tijdens filmopname...  Afgesloten."
 
-#: gphoto2/actions.c:1034
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Fout tijdens filmopname...  Onbekend MIME-type '%s'."
 
-#: gphoto2/actions.c:1041
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ctrl+C is ingedrukt...  Afgesloten.\n"
 
-#: gphoto2/actions.c:1055
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Filmopname is afgesloten (%d frames)\n"
 
-#: gphoto2/actions.c:1085
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Er wordt gewacht op gebeurtenissen van de camera.  Druk op Ctrl+C om af te breken.\n"
+msgstr ""
+"Er wordt gewacht op gebeurtenissen van de camera.  Druk op Ctrl+C om af te "
+"breken.\n"
 
-#: gphoto2/actions.c:1091
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
-msgstr "Er wordt gewacht op %d opnames van de camera.  Druk op Ctrl+C om af te breken.\n"
+msgstr ""
+"Er wordt gewacht op %d opnames van de camera.  Druk op Ctrl+C om af te "
+"breken.\n"
 
-#: gphoto2/actions.c:1096
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Er wordt %d milliseconden gewacht op gebeurtenissen van de camera.  Druk op Ctrl+C om af te breken.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Er wordt %d milliseconden gewacht op gebeurtenissen van de camera.  Druk op "
+"Ctrl+C om af te breken.\n"
 
-#: gphoto2/actions.c:1101
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Er wordt %d seconden gewacht op gebeurtenissen van de camera.  Druk op Ctrl+C om af te breken.\n"
+msgstr ""
+"Er wordt %d seconden gewacht op gebeurtenissen van de camera.  Druk op Ctrl"
+"+C om af te breken.\n"
 
-#: gphoto2/actions.c:1104
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
-msgstr "Er wordt gewacht op %d gebeurtenissen van de camera.  Druk op Ctrl+C om af te breken.\n"
+msgstr ""
+"Er wordt gewacht op %d gebeurtenissen van de camera.  Druk op Ctrl+C om af "
+"te breken.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Er wordt gewacht op een %s-gebeurtenis van de camera.  Druk op Ctrl+C om af "
+"te breken.\n"
+
+#: gphoto2/actions.c:1144
 #, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
-msgstr "Er wordt gewacht op een %s-gebeurtenis van de camera.  Druk op Ctrl+C om af te breken.\n"
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
 
-#: gphoto2/actions.c:1152 gphoto2/actions.c:1166 gphoto2/actions.c:1178
-#: gphoto2/actions.c:1216 gphoto2/actions.c:1224
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "gebeurtenis is gevonden; het wachten wordt beëindigd\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "gebeurtenis is gevonden; het wachten wordt beëindigd\n"
 
-#: gphoto2/actions.c:1188 gphoto2/main.c:824
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Kan de map niet instellen."
 
-#: gphoto2/actions.c:1194 gphoto2/main.c:831
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Kan opname niet verkrijgen."
 
-#: gphoto2/actions.c:1201 gphoto2/main.c:838
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "Fouten in libcanon.so?"
 
-#: gphoto2/actions.c:1211 gphoto2/main.c:850
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Kan opname niet verwijderen."
 
-#: gphoto2/actions.c:1243
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
-msgstr "Het verkrijgen van opslaginformatie is bij deze camera niet mogelijk.\n"
+msgstr ""
+"Het verkrijgen van opslaginformatie is bij deze camera niet mogelijk.\n"
 
-#: gphoto2/actions.c:1258
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "lezen+schrijven"
 
-#: gphoto2/actions.c:1261
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "alleen-lezen"
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "alleen-lezen plus verwijderen"
 
-#: gphoto2/actions.c:1267 gphoto2/actions.c:1277
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "[onbekend]"
 
-#: gphoto2/actions.c:1280
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "vaste ROM"
 
-#: gphoto2/actions.c:1283
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "verwijderbare ROM"
 
-#: gphoto2/actions.c:1286
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "vaste RAM"
 
-#: gphoto2/actions.c:1289
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "verwijderbare RAM"
 
-#: gphoto2/actions.c:1299
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "[ongedefinieerd]"
 
-#: gphoto2/actions.c:1302
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "gewoon vlak"
 
-#: gphoto2/actions.c:1305
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "gewoon hiërarchisch"
 
-#: gphoto2/actions.c:1308
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "camera-layout (DCIM)"
 
-#: gphoto2/actions.c:1346
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Verkoper/product-ID 0x%x/0x%x is herschreven naar 0x%x/0x%x"
 
-#: gphoto2/actions.c:1414
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "NEEM ALTIJD DE VOLGENDE REGELS OP BIJ HET ZENDEN VAN DEBUG-MELDINGEN NAAR DE MAILINGLIJST:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"NEEM ALTIJD DE VOLGENDE REGELS OP BIJ HET ZENDEN VAN DEBUG-MELDINGEN NAAR DE "
+"MAILINGLIJST:"
 
-#: gphoto2/actions.c:1429
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s is gecompileerd met de volgende opties:"
 
-#: gphoto2/actions.c:1560
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s is niet gevonden in instellingenboom."
 
-#: gphoto2/actions.c:1609
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Verkrijgen van waarde van tekstonderdeel %s is mislukt."
 
-#: gphoto2/actions.c:1626
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Verkrijgen van waardes van bereikonderdeel %s is mislukt."
 
-#: gphoto2/actions.c:1638
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Verkrijgen van waardes van schakelonderdeel %s is mislukt."
 
-#: gphoto2/actions.c:1650
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Verkrijgen van waardes van datum-/tijd-onderdeel %s is mislukt."
 
 # FIXME: Cryptic sentence - don't know what is meant here.
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "Bij het instellen 'nu' gebruiken voor de huidige tijd.\n"
 
-#: gphoto2/actions.c:1681
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Verkrijgen van waardes van radio-onderdeel %s is mislukt."
 
-#: gphoto2/actions.c:1725
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "Eigenschap %s is alleen-lezen."
 
-#: gphoto2/actions.c:1739 gphoto2/actions.c:1976
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Instellen van waarde van tekstonderdeel %s als %s is mislukt."
 
-#: gphoto2/actions.c:1749 gphoto2/actions.c:1986
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "De gegeven waarde %s is geen drijvendekommagetal."
 
-#: gphoto2/actions.c:1754 gphoto2/actions.c:1991
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "De gegeven waarde %f ligt niet in het verwachte bereik %f - %f."
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Instellen van waarde van bereikonderdeel %s als %f is mislukt."
 
-#: gphoto2/actions.c:1769 gphoto2/actions.c:2006
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "uit"
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "onwaar"
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "aan"
 
-#: gphoto2/actions.c:1776 gphoto2/actions.c:2013
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "waar"
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "De gegeven waarde %s is geen geldige schakelwaarde."
 
-#: gphoto2/actions.c:1787 gphoto2/actions.c:2024
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Instellen van waardes %s van schakelonderdeel %s is mislukt."
 
-#: gphoto2/actions.c:1799
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "nu"
 
-#: gphoto2/actions.c:1811 gphoto2/actions.c:2037
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "De gegeven waarde %s is geen geldige tijd, noch een geheel getal."
 
-#: gphoto2/actions.c:1819 gphoto2/actions.c:2044
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Instellen van datum-/tijd-onderdeel %s als %s is mislukt."
 
-#: gphoto2/actions.c:1866 gphoto2/actions.c:1930 gphoto2/actions.c:2074
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Keuze %s is niet gevonden in lijst met keuzes."
 
-#: gphoto2/actions.c:1874 gphoto2/actions.c:2082
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Het %s-onderdeel is niet instelbaar."
 
-#: gphoto2/actions.c:1881 gphoto2/actions.c:1949 gphoto2/actions.c:2089
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
-msgstr "Instellen van nieuwe configuratiewaarde %s voor configuratie-item %s is mislukt."
+msgstr ""
+"Instellen van nieuwe configuratiewaarde %s voor configuratie-item %s is "
+"mislukt."
 
-#: gphoto2/actions.c:1942
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "Assistent %s heeft geen geïndexeerde keuzelijst. Gebruik in plaats daarvan --set-config-value."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"Assistent %s heeft geen geïndexeerde keuzelijst. Gebruik in plaats daarvan --"
+"set-config-value."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Ongeldig bestandsnummer.  U hebt %i opgegeven, maar er zijn maar %i bestanden beschikbaar in '%s' en zijn onderliggende mappen.  Bepaal een geldig bestandsnummer via een weergave van de bestanden."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Ongeldig bestandsnummer.  U hebt %i opgegeven, maar er zijn maar %i "
+"bestanden beschikbaar in '%s' en zijn onderliggende mappen.  Bepaal een "
+"geldig bestandsnummer via een weergave van de bestanden."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -678,25 +741,34 @@ msgstr "Er zijn geen bestanden in map '%s'."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Ongeldig bestandsnummer.  U hebt %i opgegeven, maar er is maar één bestand beschikbaar in '%s'."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Ongeldig bestandsnummer.  U hebt %i opgegeven, maar er is maar één bestand "
+"beschikbaar in '%s'."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Ongeldig bestandsnummer.  U hebt %i opgegeven, maar er zijn maar %i bestanden beschikbaar in '%s'.  Bepaal een geldig bestandsnummer via een weergave van de bestanden."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Ongeldig bestandsnummer.  U hebt %i opgegeven, maar er zijn maar %i "
+"bestanden beschikbaar in '%s'.  Bepaal een geldig bestandsnummer via een "
+"weergave van de bestanden."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Fout ***               \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Druk op een toets om verder te gaan.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Onvoldoende geheugen beschikbaar."
@@ -705,206 +777,215 @@ msgstr "Onvoldoende geheugen beschikbaar."
 msgid "Operation cancelled"
 msgstr "Actie is geannuleerd"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Verdergaan"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Annuleren"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Fout"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Kan de configuratie niet instellen:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Afsluiten"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Terug"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Tijd: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Waarde: "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Ja"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Nee"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
-msgstr "Getallen in bestandsnamen aanvullen met voornullen is alleen mogelijk met %%n."
+msgstr ""
+"Getallen in bestandsnamen aanvullen met voornullen is alleen mogelijk met "
+"%%n."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
-msgstr "U kunt een nullenaanvulling van %%n niet gebruiken zonder een precisiewaarde."
+msgstr ""
+"U kunt een nullenaanvulling van %%n niet gebruiken zonder een precisiewaarde."
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
-msgstr "De bestandsnaam aangeboden door de camera ('%s') bevat geen achtervoegsel."
+msgstr ""
+"De bestandsnaam aangeboden door de camera ('%s') bevat geen achtervoegsel."
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Ongeldige opmaak '%s' (fout op positie %i)."
 
-#: gphoto2/main.c:382 gphoto2/main.c:585
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Overslaan van bestaand bestand %s\n"
 
-#: gphoto2/main.c:394
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Bestand %s bestaat al.  Overschrijven?  [j|n] "
 
-#: gphoto2/main.c:406
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Nieuwe bestandsnaam opgeven?  [j|n] "
 
-#: gphoto2/main.c:418
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Geef nieuwe bestandsnaam: "
 
-#: gphoto2/main.c:424
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Opslaan van bestand als %s\n"
 
-#: gphoto2/main.c:623
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Toegang geweigerd"
 
-#: gphoto2/main.c:785
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Kan opname niet triggeren."
 
-#: gphoto2/main.c:815
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Nieuw bestand staat op locatie %s%s%s op de camera\n"
 
-#: gphoto2/main.c:845
-#, c-format
-msgid "Deleting file %s%s%s on the camera\n"
-msgstr "Verwijderen van bestand %s%s%s op de camera\n"
-
-#: gphoto2/main.c:855
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Bestand %s%s%s op de camera wordt behouden\n"
 
-#: gphoto2/main.c:888
+#: gphoto2/main.c:868
+#, c-format
+msgid "Deleting file %s%s%s on the camera\n"
+msgstr "Verwijderen van bestand %s%s%s op de camera\n"
+
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "Gebeurtenis MAP_TOEGEVOEGD %s/%s tijdens het wachten; genegeerd.\n"
 
-#: gphoto2/main.c:898
+#: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "Gebeurtenis MAP_TOEGEVOEGD %s/%s tijdens het wachten; genegeerd.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Onbekende gebeurtenis %s tijdens het wachten; genegeerd.\n"
 
-#: gphoto2/main.c:904
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr "Onbekend gebeurtenistype %d tijdens bulb-wachten; genegeerd.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Kan capabilities niet verkrijgen?"
 
-#: gphoto2/main.c:930
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Tijdverloopmodus is ingeschakeld (interval: %ds).\n"
 
-#: gphoto2/main.c:933
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Klaar voor opname, wachtend op SIGUSR1.\n"
 
-#: gphoto2/main.c:939
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Bulb-modus is ingeschakeld (belichtingstijd: %d s).\n"
 
-#: gphoto2/main.c:952
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Opnemen van beeldje %d...\n"
 
-#: gphoto2/main.c:954
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Opnemen van beeldje %d/%d...\n"
 
-#: gphoto2/main.c:964
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Kan bulb-opname niet inschakelen; afsluitwaarde is %d."
 
-#: gphoto2/main.c:978
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Kan bulb-opname niet beëindigen."
 
-#: gphoto2/main.c:991
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Kan beeldopname niet triggeren."
 
-#: gphoto2/main.c:998
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Kan geen opname maken."
 
-#: gphoto2/main.c:1005
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Opname is mislukt (autofocusprobleem?)...\n"
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Kan geen opname maken."
 
-#: gphoto2/main.c:1048
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Er wordt %ld seconden gewacht op het volgende opnamemoment...\n"
 
-#: gphoto2/main.c:1057 gphoto2/main.c:1098
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Gewekt door SIGUSR1...\n"
 
-#: gphoto2/main.c:1070
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "niet aan het slapen (%ld seconden achter op schema)\n"
 
-#: gphoto2/main.c:1213
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "FOUT: "
 
-#: gphoto2/main.c:1236
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -913,12 +994,12 @@ msgstr ""
 "\n"
 "Aan het afbreken...\n"
 
-#: gphoto2/main.c:1242
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Afgebroken.\n"
 
-#: gphoto2/main.c:1247
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -927,25 +1008,27 @@ msgstr ""
 "\n"
 "Aan het annuleren...\n"
 
-#: gphoto2/main.c:1397
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
 msgstr ""
 "Gebruik de syntax 'A:B=C:D' om een USB-apparaat dat gedetecteerd is als\n"
 "A:B te behandelen alsof het C:D was.  De getallen A, B, C en D moeten\n"
 "hexadecimaal zijn en dus beginnen met '0x'.\n"
 "\n"
 
-#: gphoto2/main.c:1570
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 is gecompileerd zonder ondersteuning voor CDK."
 
-#: gphoto2/main.c:1834
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Actie is geannuleerd.\n"
 
-#: gphoto2/main.c:1838
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -954,7 +1037,7 @@ msgstr ""
 "*** Fout: geen camera gevonden. ***\n"
 "\n"
 
-#: gphoto2/main.c:1840
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -963,7 +1046,7 @@ msgstr ""
 "*** Fout (%i: '%s') ***        \n"
 "\n"
 
-#: gphoto2/main.c:1845
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -980,393 +1063,417 @@ msgstr ""
 "dan gphoto uit als volgt:\n"
 "\n"
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
 "\n"
 msgstr ""
-"Verzeker u ervan dat er voldoende aanhalingstekens rond de argumenten staan.\n"
+"Verzeker u ervan dat er voldoende aanhalingstekens rond de argumenten "
+"staan.\n"
 "\n"
 
-#: gphoto2/main.c:1933
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Deze lange hulptekst tonen"
 
-#: gphoto2/main.c:1935
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Een korte gebruikssamenvatting tonen"
 
-#: gphoto2/main.c:1937
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Debuggen inschakelen"
 
-#: gphoto2/main.c:1939
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Het debug-niveau instellen [error|debug|data|all]"
 
-#: gphoto2/main.c:1941
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Debug-informatie in dit bestand opslaan"
 
-#: gphoto2/main.c:1941 gphoto2/main.c:1946 gphoto2/main.c:1952
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "BESTAND"
 
-#: gphoto2/main.c:1943
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Stille uitvoer (standaard wordt veel info geven)"
 
-#: gphoto2/main.c:1945
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Script dat uitgevoerd moet worden na downloads, opnames, enzovoort"
 
-#: gphoto2/main.c:1952
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Te gebruiken apparaatpoort"
 
-#: gphoto2/main.c:1954
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Te gebruiken seriële overdrachtssnelheid"
 
-#: gphoto2/main.c:1954
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "SNELHEID"
 
-#: gphoto2/main.c:1956
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Te gebruiken cameramodel"
 
-#: gphoto2/main.c:1956
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODEL"
 
-#: gphoto2/main.c:1958
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(voor experts) USB-ID-paren herschrijven"
 
-#: gphoto2/main.c:1958
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USB-ID's"
 
-#: gphoto2/main.c:1964
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Programmaversie tonen en stoppen"
 
-#: gphoto2/main.c:1966
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Lijst van ondersteunde cameramodellen"
 
-#: gphoto2/main.c:1968
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Lijst van ondersteunde poortapparaten"
 
-#: gphoto2/main.c:1970
-msgid "Display camera/driver abilities"
+#: gphoto2/main.c:2015
+#, fuzzy
+msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Cameramogelijkheden tonen"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Configureren"
 
-#: gphoto2/main.c:1980
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Instellingenboom weergeven"
 
-#: gphoto2/main.c:1982
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Volledige instellingenboom weergeven"
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Configuratiewaarde verkrijgen"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Configuratiewaarde of index instellen onder keuzes"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Index van configuratiewaarde instellen onder keuzes"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Configuratiewaarde instellen"
 
-#: gphoto2/main.c:1992
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Apparaatpoort resetten"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Beelden op camera behouden na opname"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2045
+#, fuzzy
+msgid "Keep RAW images on camera after capturing"
+msgstr "Beelden op camera behouden na opname"
+
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Beelden van camera verwijderen na opname"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Op gebeurtenis(sen) van camera wachten"
 
-#: gphoto2/main.c:2002 gphoto2/main.c:2004 gphoto2/main.c:2011
-#: gphoto2/main.c:2027
-msgid "COUNT"
-msgstr "AANTAL"
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
 
-#: gphoto2/main.c:2004
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
-msgstr "Op gebeurtenis(sen) van de camera wachten en vervolgens nieuw opnamen downloaden"
+msgstr ""
+"Op gebeurtenis(sen) van de camera wachten en vervolgens nieuw opnamen "
+"downloaden"
 
-#: gphoto2/main.c:2007
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Een snelle voorbeeldopname maken"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
+
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Bulb-belichtingstijd in seconden"
 
-#: gphoto2/main.c:2009 gphoto2/main.c:2013
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SECONDEN"
 
-#: gphoto2/main.c:2011
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Aantal te maken opnames (standaard=oneindig)"
 
-#: gphoto2/main.c:2013
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr "AANTAL"
+
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Opname-interval in seconden"
 
-#: gphoto2/main.c:2015
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Opname-interval resetten bij signaal (standaard=nee)"
 
-#: gphoto2/main.c:2017
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Een foto-opname maken"
 
-#: gphoto2/main.c:2019
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Een beeldopname triggeren"
 
-#: gphoto2/main.c:2021
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Een foto-opname maken en deze downloaden"
 
-#: gphoto2/main.c:2023
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Een film-opname maken"
 
-#: gphoto2/main.c:2023
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "AANTAL of SECONDEN"
 
-#: gphoto2/main.c:2025
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Een audio-opname maken"
 
-#: gphoto2/main.c:2027
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
-msgstr "Wachten op sluiterontspanning van de camera en dan opname direct downloaden"
+msgstr ""
+"Wachten op sluiterontspanning van de camera en dan opname direct downloaden"
 
-#: gphoto2/main.c:2029
-msgid "Trigger image capture"
-msgstr "Beeldopname triggeren"
-
-#: gphoto2/main.c:2035
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Mappen in map weergeven"
 
-#: gphoto2/main.c:2037
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Bestanden in map weergeven"
 
-#: gphoto2/main.c:2039
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Een map aanmaken"
 
-#: gphoto2/main.c:2039 gphoto2/main.c:2041
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "MAPNAAM"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Een map verwijderen"
 
-#: gphoto2/main.c:2043
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Het aantal bestanden weergeven"
 
-#: gphoto2/main.c:2045
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Bestanden in gegeven bereik ophalen"
 
-#: gphoto2/main.c:2045 gphoto2/main.c:2049 gphoto2/main.c:2054
-#: gphoto2/main.c:2061 gphoto2/main.c:2067 gphoto2/main.c:2072
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "BEREIK"
 
-#: gphoto2/main.c:2047
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Alle bestanden in map ophalen"
 
-#: gphoto2/main.c:2049
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Miniaturen in gegeven bereik ophalen"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Alle miniaturen in map ophalen"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Metagegevens in gegeven bereik ophalen"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Alle metagegevens in map ophalen"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Metagegevens voor bestand uploaden"
 
-#: gphoto2/main.c:2061
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Ruwe gegevens in gegeven bereik ophalen"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Alle ruwe gegevens in map ophalen"
 
-#: gphoto2/main.c:2067
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Audiogegevens in gegeven bereik ophalen"
 
-#: gphoto2/main.c:2070
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Alle audiogegevens in map ophalen"
 
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Bestanden in gegeven bereik verwijderen"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Alle bestanden in map verwijderen (standaard '--no-recurse')"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Dit bestand naar de camera uploaden"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Te gebruiken bestandsnaam of patroon"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "BESTANDSPATROON"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Te gebruiken cameramap (standaard='/')"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "MAP"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Recursie (standaard bij downloaden)"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Geen recursie (standaard bij verwijdering)"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Alleen nieuwe bestanden behandelen"
 
-#: gphoto2/main.c:2088
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Bestanden overschrijven zonder te vragen"
 
-#: gphoto2/main.c:2090
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Bestaande bestanden overslaan"
 
-#: gphoto2/main.c:2096
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Bestand naar standaarduitvoer sturen"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Bestandsgrootte voor gegevens afdrukken"
 
-#: gphoto2/main.c:2100
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Automatisch gedetecteerde camera's tonen"
 
-#: gphoto2/main.c:2104 gphoto2/shell.c:138
-msgid "Show EXIF information"
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
 msgstr "EXIF-informatie tonen"
 
-#: gphoto2/main.c:2107 gphoto2/shell.c:132
-msgid "Show info"
-msgstr "Informatie tonen"
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
 
-#: gphoto2/main.c:2109
-msgid "Show summary"
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "Samenvatting tonen"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Handleiding van camerastuurprogramma tonen"
 
 # De originele tekst is onjuist; zie man-pagina.
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Over het camerastuurprogramma"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Opslaginformatie tonen"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "Een gPhoto-shell starten"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Standaardopties"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Algemene opties (ongesorteerd)"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "Informatie over hostsysteem en -software (niet uit de camera)"
 
-#: gphoto2/main.c:2129
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Te gebruiken cameramodel"
 
-#: gphoto2/main.c:2131
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Instellingen van camera en software"
 
 # Dit is omschrijvend kopje boven een groepje opties.
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Het maken van een opname"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Downloaden, uploaden en bestanden manipuleren"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1375,7 +1482,7 @@ msgstr ""
 "%s\n"
 "Een afbeeldings-ID moet een getal groter dan nul zijn."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1384,7 +1491,7 @@ msgstr ""
 "%s\n"
 "Afbeeldings-ID %i is te groot."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1393,7 +1500,7 @@ msgstr ""
 "%s\n"
 "Bereiken moeten worden gescheiden door ','."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1402,7 +1509,7 @@ msgstr ""
 "%s\n"
 "Bereiken moeten beginnen met een getal."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1411,226 +1518,238 @@ msgstr ""
 "%s\n"
 "Onverwacht teken '%c'."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"Afnemende bereiken zijn niet toegestaan. U kunt een bereik opgeven van %i tot %i."
+"Afnemende bereiken zijn niet toegestaan. U kunt een bereik opgeven van %i "
+"tot %i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Fout (%i: '%s') ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Naar een map op de camera gaan"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "map"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Naar een map op de lokale schijf gaan"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Deze gPhoto-shell afsluiten"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Een bestand downloaden"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[map/]bestandsnaam"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Een bestand uploaden"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Een miniatuurvoorbeeld downloaden"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Ruwe gegevens downloaden"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Map aanmaken"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Map verwijderen"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Omschrijving van commando('s) tonen"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[commando]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "De inhoud van de huidige map tonen"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[map/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Configuratievariabelen tonen"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Een configuratievariabele verkrijgen"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "naam"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Een configuratievariabele instellen"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "naam=waarde"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Index van configuratievariabele instellen"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "naam=indexwaarde"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Een beeldopname triggeren"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Eén enkele opname maken"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Eén opname maken en deze downloaden"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Een voorbeeldopname maken"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Op een gebeurtenis wachten"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "aantal of seconden"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Op opnamen van de camera wachten en deze downloaden"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Op gebeurtenissen en opnamen wachten en deze downloaden"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Ongeldig commando."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Het commando '%s' vereist een argument."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Ongeldig pad."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Kan persoonlijke map niet vinden."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Kan niet naar lokale map '%s' gaan."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Lokale map is nu '%s'."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Map op andere computer is nu '%s'."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "Commando 'set-config' vereist een tweede argument.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "Commando 'set-config-value' vereist een tweede argument.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "Commando 'set-config-index' vereist een tweede argument.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
 msgstr ""
 "Commando '%s' is niet gevonden.\n"
 "Gebruik 'help' om een lijst van beschikbare commando's te krijgen."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Hulp over \"%s\":"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Gebruik: "
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Omschrijving:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Argumenten tussen vierkante haken [] zijn optioneel"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Beschikbare commando's:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr "Om hulp te krijgen voor een bepaald commando, typ 'help commandonaam'."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Beeldopname triggeren"
+
+#~ msgid "Show info"
+#~ msgstr "Informatie tonen"
 
 #~ msgid "  Name:        '%s'\n"
 #~ msgstr "  Naam:        '%s'\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,224 +7,209 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2-2.1.6rc1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-04-11 13:08-0400\n"
+"Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2007-06-23 08:36+0530\n"
 "Last-Translator: Amanpreet Singh Alam <amanpreetalam@yahoo.com>\n"
 "Language-Team: Punjabi <fedora-trans-pa@redhat.com>\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Language: pa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: KBabel 1.9.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: gphoto2/actions.c:124
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "ਫੋਲਡਰ '%s' ਵਿੱਚ ਫਾਇਲਾਂ ਦੀ ਗਿਣਤੀ: %i\n"
 
-#: gphoto2/actions.c:145
+#: gphoto2/actions.c:201
 #, fuzzy, c-format
-msgid "There are no folders in folder '%s'."
-msgstr "ਫੋਲਡਰ '%s' ਵਿੱਚ ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਹੈ।"
+msgid "There is %d folder in folder '%s'.\n"
+msgid_plural "There are %d folders in folder '%s'.\n"
+msgstr[0] "'%2$s' ਫੋਲਡਰ ਵਿੱਚ %1$d ਫਾਇਲ ਹੈ।\n"
+msgstr[1] "'%2$s' ਫੋਲਡਰ ਵਿੱਚ %1$d ਫਾਇਲਾਂ ਹਨ।\n"
 
-#: gphoto2/actions.c:149
+#: gphoto2/actions.c:250
 #, fuzzy, c-format
-msgid "There is one folder in folder '%s':"
-msgstr "'%2$s' ਫੋਲਡਰ ਵਿੱਚ %1$d ਫੋਲਡਰ ਹੈ।\n"
+msgid "There is no file in folder '%s'.\n"
+msgstr "'%2$s' ਫੋਲਡਰ ਵਿੱਚ %1$d ਫਾਇਲ ਹੈ।\n"
 
-#: gphoto2/actions.c:153
-#, fuzzy, c-format
-msgid "There are %i folders in folder '%s':"
-msgstr "ਫੋਲਡਰ '%s' ਵਿੱਚ ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਹੈ।"
-
-#: gphoto2/actions.c:196 gphoto2/foreach.c:277
+#: gphoto2/actions.c:253
 #, c-format
-msgid "There are no files in folder '%s'."
-msgstr "ਫੋਲਡਰ '%s' ਵਿੱਚ ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਹੈ।"
+msgid "There is %d file in folder '%s'.\n"
+msgid_plural "There are %d files in folder '%s'.\n"
+msgstr[0] "'%2$s' ਫੋਲਡਰ ਵਿੱਚ %1$d ਫਾਇਲ ਹੈ।\n"
+msgstr[1] "'%2$s' ਫੋਲਡਰ ਵਿੱਚ %1$d ਫਾਇਲਾਂ ਹਨ।\n"
 
-#: gphoto2/actions.c:200
-#, fuzzy, c-format
-msgid "There is one file in folder '%s':"
-msgstr "ਫੋਲਡਰ '%s' ਵਿੱਚ ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਹੈ।\n"
-
-#: gphoto2/actions.c:204
-#, fuzzy, c-format
-msgid "There are %i files in folder '%s':"
-msgstr "ਫੋਲਡਰ '%s' ਵਿੱਚ ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਹੈ।"
-
-#: gphoto2/actions.c:225
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "ਫਾਇਲ '%s' (ਫੋਲਡਰ '%s') ਉੱਤੇ ਜਾਣਕਾਰੀ:\n"
 
-#: gphoto2/actions.c:227
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "ਫਾਇਲ:\n"
 
-#: gphoto2/actions.c:229 gphoto2/actions.c:263 gphoto2/actions.c:279
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  ਉਪਲੱਬਧ ਨਹੀਂ।\n"
 
-#: gphoto2/actions.c:232
-#, c-format
-msgid "  Name:        '%s'\n"
-msgstr "  ਨਾਂ:           '%s'\n"
-
-#: gphoto2/actions.c:234 gphoto2/actions.c:266
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr " ਮਾਈਮ ਕਿਸਮ:   '%s'\n"
 
-#: gphoto2/actions.c:236 gphoto2/actions.c:268
-#, c-format
-msgid "  Size:        %li byte(s)\n"
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#, fuzzy, c-format
+msgid "  Size:        %lu byte(s)\n"
 msgstr "  ਅਕਾਰ:         %li ਬਾਈਟ\n"
 
-#: gphoto2/actions.c:238 gphoto2/actions.c:270
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  ਚੌੜਾਈ:       %i ਪਿਕਸਲ\n"
 
-#: gphoto2/actions.c:240 gphoto2/actions.c:272
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  ਉਚਾਈ:      %i ਪਿਕਸਲ\n"
 
-#: gphoto2/actions.c:242 gphoto2/actions.c:274
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  ਡਾਊਨਲੋਡ ਕੀਤੇ:  %s\n"
 
-#: gphoto2/actions.c:243 gphoto2/actions.c:275 gphoto2/actions.c:287
-#: gphoto2/actions.c:624 gphoto2/actions.c:626 gphoto2/actions.c:654
-#: gphoto2/actions.c:657 gphoto2/actions.c:660 gphoto2/actions.c:663
-#: gphoto2/actions.c:1286
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "ਹਾਂ"
 
-#: gphoto2/actions.c:243 gphoto2/actions.c:275 gphoto2/actions.c:287
-#: gphoto2/actions.c:624 gphoto2/actions.c:626 gphoto2/actions.c:654
-#: gphoto2/actions.c:657 gphoto2/actions.c:660 gphoto2/actions.c:663
-#: gphoto2/actions.c:1280
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "ਨਹੀਂ"
 
-#: gphoto2/actions.c:245
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  ਅਧਿਕਾਰ: "
 
-#: gphoto2/actions.c:248
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "ਪੜੋ/ਹਟਾਓ"
 
-#: gphoto2/actions.c:250
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "ਪੜੋ"
 
-#: gphoto2/actions.c:252
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "ਹਟਾਓ"
 
-#: gphoto2/actions.c:254
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "ਕੋਈ ਨਹੀਂ"
 
-#: gphoto2/actions.c:258
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  ਸਮਾਂ:        %s"
 
-#: gphoto2/actions.c:261
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "ਥੰਮਨੇਲ:\n"
 
-#: gphoto2/actions.c:277
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "ਆਡੀਓ ਡਾਟਾ:\n"
 
-#: gphoto2/actions.c:282
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Mime ਕਿਸਮ:  '%s'\n"
 
-#: gphoto2/actions.c:284
-#, c-format
-msgid "  Size:       %li byte(s)\n"
+#: gphoto2/actions.c:332
+#, fuzzy, c-format
+msgid "  Size:       %lu byte(s)\n"
 msgstr "  ਅਕਾਰ:       %li ਬਾਇਟ\n"
 
-#: gphoto2/actions.c:286
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  ਡਾਊਨਲੋਡ: %s\n"
 
-#: gphoto2/actions.c:455
+#: gphoto2/actions.c:504
 msgid "Could not parse EXIF data."
 msgstr "EXIF ਡਾਟਾ ਪਾਰਸ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।"
 
-#: gphoto2/actions.c:459
+#: gphoto2/actions.c:508
 #, c-format
 msgid "EXIF tags:"
 msgstr "EXIF ਟੈਗ:"
 
-#: gphoto2/actions.c:462
+#: gphoto2/actions.c:511
 msgid "Tag"
 msgstr "ਟੈਗ"
 
-#: gphoto2/actions.c:464
+#: gphoto2/actions.c:513
 msgid "Value"
 msgstr "ਮੁੱਲ"
 
-#: gphoto2/actions.c:485
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr ""
 
-#: gphoto2/actions.c:494
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr ""
 
-#: gphoto2/actions.c:512
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "ਸਹਾਇਕ ਕੈਮਰਿਆਂ ਦੀ ਗਿਣਤੀ: %i\n"
 
-#: gphoto2/actions.c:513
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "ਸਹਾਇਕ ਕੈਮਰੇ:\n"
 
-#: gphoto2/actions.c:526
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (ਜਾਂਚ ਜਾਰੀ)\n"
 
-#: gphoto2/actions.c:529
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (ਤਜਰਬੇ ਅਧੀਨ)\n"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:564
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "ਜੰਤਰ ਮਿਲਿਆ: %i\n"
 
-#: gphoto2/actions.c:565
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -233,658 +218,736 @@ msgstr ""
 "ਮਾਰਗ                             ਵੇਰਵਾ\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:603 gphoto2/actions.c:608
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:603
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "ਮਾਡਲ"
 
-#: gphoto2/actions.c:603
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "ਪੋਰਟ"
 
-#: gphoto2/actions.c:604
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:622
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "ਕੈਮਰੇ ਲਈ ਯੋਗਤਾ             : %s\n"
 
-#: gphoto2/actions.c:623
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "ਸੀਰੀਅਲ ਪੋਰਟ ਸਹਿਯੋਗ               : %s\n"
 
-#: gphoto2/actions.c:625
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB ਸਹਾਇਕ                      : %s\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "ਸਹਾਇਕ ਸੰਚਾਰ ਗਤੀ        :\n"
 
-#: gphoto2/actions.c:630
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:633
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "ਕੈਪਚਰ ਚੋਣ                  :\n"
 
-#: gphoto2/actions.c:635
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : ਤਸਵੀਰ\n"
 
-#: gphoto2/actions.c:639
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : ਵੀਡਿਓ\n"
 
-#: gphoto2/actions.c:643
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : ਆਡੀਓ\n"
 
-#: gphoto2/actions.c:647
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                  : ਝਲਕ\n"
 
-#: gphoto2/actions.c:651
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
+
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
 msgstr ""
 
-#: gphoto2/actions.c:653
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "ਸੰਰਚਨਾ ਸਹਾਇਕ                  : %s\n"
 
-#: gphoto2/actions.c:655
+#: gphoto2/actions.c:704
+#, c-format
+msgid "Delete selected files on camera  : %s\n"
+msgstr "ਕੈਮਰੇ ਤੋਂ ਚੁਣੀਆਂ ਫਾਇਲਾਂ ਹਟਾਓ  : %s\n"
+
+#: gphoto2/actions.c:707
 #, fuzzy, c-format
-msgid "Delete files on camera support   : %s\n"
+msgid "Delete all files on camera       : %s\n"
 msgstr "ਕੈਮਰੇ ਤੋਂ ਸਭ ਫਾਇਲਾਂ ਹਟਾਓ             : %s\n"
 
-#: gphoto2/actions.c:658
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "ਫਾਇਲ ਝਲਕ (ਥੰਮਨੇਲ) ਸਹਿਯੋਗ: %s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "ਫਾਇਲ ਅੱਪਲੋਡ ਸਹਿਯੋਗ              : %s\n"
 
-#: gphoto2/actions.c:678
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "ਪੋਰਟ 'serial:/dev/ttyS0' ਜਾਂ 'usb:' ਵਾਂਗ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ, ਪਰ '%s' ਵਿੱਚ ਕਾਲਨ ਨਹੀਂ ਹੈ, ਇਸਕਰਕੇ ਮੈਂ ਤੁਹਾਡੇ ਲਈ ਅੰਦਾਜ਼ਾ ਲਗਾਉਦਾ ਹਾਂ।"
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"ਪੋਰਟ 'serial:/dev/ttyS0' ਜਾਂ 'usb:' ਵਾਂਗ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ, ਪਰ '%s' ਵਿੱਚ ਕਾਲਨ ਨਹੀਂ ਹੈ, "
+"ਇਸਕਰਕੇ ਮੈਂ ਤੁਹਾਡੇ ਲਈ ਅੰਦਾਜ਼ਾ ਲਗਾਉਦਾ ਹਾਂ।"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "ਪੋਰਟ, ਜੋ ਤੁਸੀਂ ਦਿੱਤੀ ਹੈ ('%s'), ਨਹੀਂ ਲੱਭੀ ਜਾ ਸਕੀ। ਉਹ ਪੋਰਟ ਦਿਓ ਜੀ, ਜੋ ਕਿ 'gphoto2 --list-ports' ਰਾਹੀਂ ਲੱਭੀ ਗਈ ਹੈ ਅਤੇ ਇਹ ਜਾਂਚ ਲਵੋ ਕਿ ਸ਼ਬਦ ਠੀਕ ਤਰ੍ਹਾਂ ਲਿਖੇ ਗਏ ਹਨ (ਭਾਵ ਕਿ 'serial:' ਜਾਂ 'usb:' ਅੱਗੇ ਲਿਖਿਆ ਗਿਆ ਹੈ)।"
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"ਪੋਰਟ, ਜੋ ਤੁਸੀਂ ਦਿੱਤੀ ਹੈ ('%s'), ਨਹੀਂ ਲੱਭੀ ਜਾ ਸਕੀ। ਉਹ ਪੋਰਟ ਦਿਓ ਜੀ, ਜੋ ਕਿ 'gphoto2 --"
+"list-ports' ਰਾਹੀਂ ਲੱਭੀ ਗਈ ਹੈ ਅਤੇ ਇਹ ਜਾਂਚ ਲਵੋ ਕਿ ਸ਼ਬਦ ਠੀਕ ਤਰ੍ਹਾਂ ਲਿਖੇ ਗਏ ਹਨ (ਭਾਵ ਕਿ "
+"'serial:' ਜਾਂ 'usb:' ਅੱਗੇ ਲਿਖਿਆ ਗਿਆ ਹੈ)।"
 
-#: gphoto2/actions.c:755
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "ਕੈਮਰਾ ਮਾਡਲ ਬਾਰੇ:"
 
-#: gphoto2/actions.c:768
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "ਕੈਮਰਾ ਸੰਖੇਪ:"
 
-#: gphoto2/actions.c:781
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "ਕੈਮਰਾ ਦਸਤਾਵੇਜ਼:"
 
-#: gphoto2/actions.c:796
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "ਤੁਸੀਂ ਸੀਰੀਅਲ ਪੋਰਟ ਦੀ ਸਪੀਡ ਹੀ ਦੇ ਸਕਦੇ ਹੋ।"
 
-#: gphoto2/actions.c:847
+#: gphoto2/actions.c:890
+msgid "OS/2 port by Bart van Leeuwen\n"
+msgstr "OS/2 ਲਈ Bart van Leeuwen ਨੇ ਤਿਆਰ ਕੀਤਾ\n"
+
+#: gphoto2/actions.c:894
 #, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-2004 Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 
-#: gphoto2/actions.c:860
-msgid "OS/2 port by Bart van Leeuwen\n"
-msgstr "OS/2 ਲਈ Bart van Leeuwen ਨੇ ਤਿਆਰ ਕੀਤਾ\n"
+#: gphoto2/actions.c:1015
+#, fuzzy
+msgid "Could not open 'movie.mjpg'."
+msgstr "ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਹੋ ਨਹੀਂ ਸਕੀ ਹੈ।"
 
-#: gphoto2/actions.c:933
+#: gphoto2/actions.c:1022
 #, c-format
-msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
-msgstr "USB ਵਿਕਰੇਤਾ/ਉਤਪਾਦ id 0x%x/0x%x with 0x%x/0x%x ਨੂੰ ਅਣਡਿੱਠੀ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
+msgstr ""
 
-#: gphoto2/actions.c:984
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-
-#: gphoto2/actions.c:999
+#: gphoto2/actions.c:1026
 #, c-format
-msgid "%s has been compiled with the following options:"
-msgstr "%s ਨੂੰ ਅੱਗੇ ਦਿੱਤੇ ਚੋਣਾਂ ਨਾਲ ਤਿਆਰ ਕੀਤਾ ਗਿਆ ਹੈ:"
+msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
+msgstr ""
 
-#: gphoto2/actions.c:1096
+#: gphoto2/actions.c:1031
 #, c-format
-msgid "%s not found in configuration tree."
-msgstr "%s ਸੰਰਚਨਾ ਲੜੀ ਵਿੱਚ ਨਹੀਂ ਲੱਭਿਆ ਜਾ ਸਕਿਆ।"
+msgid "Capturing %d preview frames as movie to '%s'.\n"
+msgstr ""
 
-#: gphoto2/actions.c:1138
+#: gphoto2/actions.c:1047
+msgid "Movie capture error... Exiting."
+msgstr ""
+
+#: gphoto2/actions.c:1053
 #, c-format
-msgid "Failed to retrieve value of text widget %s."
-msgstr "ਪਾਠ ਸਹਾਇਕ %s ਦਾ ਮੁੱਲ ਲੈਣ ਲਈ ਫੇਲ੍ਹ ਹੋਇਆ।"
+msgid "Movie capture error... Unhandled MIME type '%s'."
+msgstr ""
+
+#: gphoto2/actions.c:1060
+#, c-format
+msgid "Ctrl-C pressed ... Exiting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1074
+#, c-format
+msgid "Movie capture finished (%d frames)\n"
+msgstr ""
+
+#: gphoto2/actions.c:1106
+#, fuzzy, c-format
+msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
+msgstr "ਕੈਮਰੇ ਵਲੋਂ ਜਵਾਬ ਦੀ ਉਡੀਕ"
+
+#: gphoto2/actions.c:1112
+#, c-format
+msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1117
+#, c-format
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1122
+#, c-format
+msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1125
+#, fuzzy, c-format
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr "ਕੈਮਰੇ ਵਲੋਂ ਜਵਾਬ ਦੀ ਉਡੀਕ"
+
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr "ਕੈਮਰੇ ਵਲੋਂ ਜਵਾਬ ਦੀ ਉਡੀਕ"
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
 
 #: gphoto2/actions.c:1155
 #, c-format
-msgid "Failed to retrieve values of range widget %s."
-msgstr "%s ਰੇਜ਼ ਸਹਾਇਕ ਦਾ ਮੁੱਲ ਲੈਣ ਲਈ ਫੇਲ੍ਹ"
-
-#: gphoto2/actions.c:1167
-#, c-format
-msgid "Failed to retrieve values of toggle widget %s."
-msgstr "%s ਟਾਗਲ ਸਹਾਇਕ ਦਾ ਮੁੱਲ ਲੈਣ ਲਈ ਫੇਲ੍ਹ"
-
-#: gphoto2/actions.c:1179
-#, c-format
-msgid "Failed to retrieve values of date/time widget %s."
-msgstr "%s ਮਿਤੀ/ਸਮਾਂ ਸਹਾਇਕ ਦਾ ਮੁੱਲ ਲੈਣ ਲਈ ਫੇਲ੍ਹ"
-
-#: gphoto2/actions.c:1209
-#, c-format
-msgid "Failed to retrieve values of radio widget %s."
-msgstr "%s ਰੇਡੀਓ ਸਹਾਇਕ ਦਾ ਮੁੱਲ ਲੈਣ ਲਈ ਫੇਲ੍ਹ"
-
-#: gphoto2/actions.c:1250
-#, c-format
-msgid "Failed to set the value of text widget %s to %s."
+msgid "SIGUSR2 signal received, stopping wait!\n"
 msgstr ""
 
-#: gphoto2/actions.c:1260
-#, c-format
-msgid "The passed value %s is not a floating point value."
-msgstr ""
-
-#: gphoto2/actions.c:1265
-#, c-format
-msgid "The passed value %f is not within the expected range %f - %f."
-msgstr ""
-
-#: gphoto2/actions.c:1271
-#, c-format
-msgid "Failed to set the value of range widget %s to %f."
-msgstr ""
-
-#: gphoto2/actions.c:1280
-msgid "off"
-msgstr "ਬੰਦ"
-
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
 #: gphoto2/actions.c:1281
-msgid "false"
-msgstr "ਗਲਤ"
-
-#: gphoto2/actions.c:1286
-msgid "on"
-msgstr "ਚਾਲੂ"
-
-#: gphoto2/actions.c:1287
-msgid "true"
-msgstr "ਠੀਕ"
-
-#: gphoto2/actions.c:1291
 #, c-format
-msgid "The passed value %s is not a valid toggle value."
+msgid "event found, stopping wait!\n"
 msgstr ""
 
-#: gphoto2/actions.c:1297
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
+msgid "Could not set folder."
+msgstr "ਫੋਲਡਰ ਦਿੱਤਾ ਨਹੀਂ ਜਾ ਸਕਿਆ ਹੈ।"
+
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
+msgid "Could not get image."
+msgstr "ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਹੋ ਨਹੀਂ ਸਕੀ ਹੈ।"
+
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
+msgid "Buggy libcanon.so?"
+msgstr "ਬੱਗੀ libcanon.so ਹੈ?"
+
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
+msgid "Could not delete image."
+msgstr "ਤਸਵੀਰ ਹਟਾਇਆ ਨਹੀਂ ਜਾ ਸਕਿਆ ਹੈ।"
+
+#: gphoto2/actions.c:1300
 #, c-format
-msgid "Failed to set values %s of toggle widget %s."
+msgid "Getting storage information not supported for this camera.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1315
 #, c-format
-msgid "The passed value %s is neither a valid time nor an integer."
+msgid "Read-Write"
 msgstr ""
 
-#: gphoto2/actions.c:1317
+#: gphoto2/actions.c:1318
 #, c-format
-msgid "Failed to set new time of date/time widget %s to %s."
+msgid "Read-Only"
 msgstr ""
 
-#: gphoto2/actions.c:1354
+#: gphoto2/actions.c:1321
 #, c-format
-msgid "Choice %s not found within list of choices."
+msgid "Read-only with delete"
+msgstr ""
+
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
+#, c-format
+msgid "Unknown"
+msgstr ""
+
+#: gphoto2/actions.c:1337
+#, c-format
+msgid "Fixed ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1340
+#, c-format
+msgid "Removable ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1343
+#, c-format
+msgid "Fixed RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1346
+#, c-format
+msgid "Removable RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1356
+#, c-format
+msgid "Undefined"
+msgstr ""
+
+#: gphoto2/actions.c:1359
+#, c-format
+msgid "Generic Flat"
 msgstr ""
 
 #: gphoto2/actions.c:1362
 #, c-format
+msgid "Generic Hierarchical"
+msgstr ""
+
+#: gphoto2/actions.c:1365
+#, c-format
+msgid "Camera layout (DCIM)"
+msgstr ""
+
+#: gphoto2/actions.c:1406
+#, c-format
+msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
+msgstr "USB ਵਿਕਰੇਤਾ/ਉਤਪਾਦ id 0x%x/0x%x with 0x%x/0x%x ਨੂੰ ਅਣਡਿੱਠੀ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+
+#: gphoto2/actions.c:1489
+#, c-format
+msgid "%s has been compiled with the following options:"
+msgstr "%s ਨੂੰ ਅੱਗੇ ਦਿੱਤੇ ਚੋਣਾਂ ਨਾਲ ਤਿਆਰ ਕੀਤਾ ਗਿਆ ਹੈ:"
+
+#: gphoto2/actions.c:1629
+#, c-format
+msgid "%s not found in configuration tree."
+msgstr "%s ਸੰਰਚਨਾ ਲੜੀ ਵਿੱਚ ਨਹੀਂ ਲੱਭਿਆ ਜਾ ਸਕਿਆ।"
+
+#: gphoto2/actions.c:1681
+#, c-format
+msgid "Failed to retrieve value of text widget %s."
+msgstr "ਪਾਠ ਸਹਾਇਕ %s ਦਾ ਮੁੱਲ ਲੈਣ ਲਈ ਫੇਲ੍ਹ ਹੋਇਆ।"
+
+#: gphoto2/actions.c:1698
+#, c-format
+msgid "Failed to retrieve values of range widget %s."
+msgstr "%s ਰੇਜ਼ ਸਹਾਇਕ ਦਾ ਮੁੱਲ ਲੈਣ ਲਈ ਫੇਲ੍ਹ"
+
+#: gphoto2/actions.c:1710
+#, c-format
+msgid "Failed to retrieve values of toggle widget %s."
+msgstr "%s ਟਾਗਲ ਸਹਾਇਕ ਦਾ ਮੁੱਲ ਲੈਣ ਲਈ ਫੇਲ੍ਹ"
+
+#: gphoto2/actions.c:1722
+#, c-format
+msgid "Failed to retrieve values of date/time widget %s."
+msgstr "%s ਮਿਤੀ/ਸਮਾਂ ਸਹਾਇਕ ਦਾ ਮੁੱਲ ਲੈਣ ਲਈ ਫੇਲ੍ਹ"
+
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1753
+#, c-format
+msgid "Failed to retrieve values of radio widget %s."
+msgstr "%s ਰੇਡੀਓ ਸਹਾਇਕ ਦਾ ਮੁੱਲ ਲੈਣ ਲਈ ਫੇਲ੍ਹ"
+
+#: gphoto2/actions.c:1799
+#, c-format
+msgid "Property %s is read only."
+msgstr ""
+
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
+#, c-format
+msgid "Failed to set the value of text widget %s to %s."
+msgstr ""
+
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
+#, c-format
+msgid "The passed value %s is not a floating point value."
+msgstr ""
+
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
+#, c-format
+msgid "The passed value %f is not within the expected range %f - %f."
+msgstr ""
+
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
+#, c-format
+msgid "Failed to set the value of range widget %s to %f."
+msgstr ""
+
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
+msgid "off"
+msgstr "ਬੰਦ"
+
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
+msgid "false"
+msgstr "ਗਲਤ"
+
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
+msgid "on"
+msgstr "ਚਾਲੂ"
+
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
+msgid "true"
+msgstr "ਠੀਕ"
+
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
+#, c-format
+msgid "The passed value %s is not a valid toggle value."
+msgstr ""
+
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
+#, c-format
+msgid "Failed to set values %s of toggle widget %s."
+msgstr ""
+
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
+#, fuzzy
+msgid "now"
+msgstr "ਨਹੀਂ"
+
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
+#, c-format
+msgid "The passed value %s is neither a valid time nor an integer."
+msgstr ""
+
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
+#, c-format
+msgid "Failed to set new time of date/time widget %s to %s."
+msgstr ""
+
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
+#, c-format
+msgid "Choice %s not found within list of choices."
+msgstr ""
+
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
+#, c-format
 msgid "The %s widget is not configurable."
 msgstr ""
 
-#: gphoto2/actions.c:1369
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr ""
 
-#: gphoto2/foreach.c:254
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
 msgstr ""
 
-#: gphoto2/foreach.c:283
+#: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "ਗਲਤ ਫਾਇਲ ਨੰਬਰ ਹੈ। ਤੁਸੀਂ %i ਦਿੱਤਾ ਹੈ, ਪਰ '%s' ਵਿੱਚ ਸਿਰਫ਼ ਇੱਕ ਹੀ ਫਾਇਲ ਹੈ।"
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+
+#: gphoto2/foreach.c:285
+#, c-format
+msgid "There are no files in folder '%s'."
+msgstr "ਫੋਲਡਰ '%s' ਵਿੱਚ ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਹੈ।"
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "ਗਲਤ ਫਾਇਲ ਨੰਬਰ ਹੈ। ਤੁਸੀਂ %1$i ਦਿੱਤਾ ਹੈ, ਪਰ '%3$s' ਵਿੱਚ ਸਿਰਫ਼ %2$i ਹੀ ਫਾਇਲਾਂ ਹਨ। ਫਾਇਲ ਲਿਸਟ ਤੋਂ ਪਹਿਲਾਂ ਠੀਕ ਫਾਇਲਾਂ ਦੀ ਗਿਣਤੀ ਲਵੋ ਜੀ।"
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr "ਗਲਤ ਫਾਇਲ ਨੰਬਰ ਹੈ। ਤੁਸੀਂ %i ਦਿੱਤਾ ਹੈ, ਪਰ '%s' ਵਿੱਚ ਸਿਰਫ਼ ਇੱਕ ਹੀ ਫਾਇਲ ਹੈ।"
 
-#: gphoto2/gp-params.c:59
+#: gphoto2/foreach.c:299
+#, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"ਗਲਤ ਫਾਇਲ ਨੰਬਰ ਹੈ। ਤੁਸੀਂ %1$i ਦਿੱਤਾ ਹੈ, ਪਰ '%3$s' ਵਿੱਚ ਸਿਰਫ਼ %2$i ਹੀ ਫਾਇਲਾਂ ਹਨ। ਫਾਇਲ "
+"ਲਿਸਟ ਤੋਂ ਪਹਿਲਾਂ ਠੀਕ ਫਾਇਲਾਂ ਦੀ ਗਿਣਤੀ ਲਵੋ ਜੀ।"
+
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** ਗਲਤੀ ***              \n"
 
-#: gphoto2/gp-params.c:232
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "ਜਾਰੀ ਰੱਖਣ ਲਈ ਕੋਈ ਵੀ ਸਵਿੱਚ ਦਬਾਉ।\n"
 
-#: gphoto2/gp-params.c:249
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "ਲੋੜੀਦੀ ਮੈਮੋਰੀ ਨਹੀਂ ਹੈ।"
 
-#: gphoto2/gphoto2-cmd-capture.c:201
+#: gphoto2/gphoto2-cmd-capture.c:211
 msgid "Operation cancelled"
 msgstr "ਕਾਰਵਾਈ ਰੱਦ ਕੀਤੀ ਗਈ"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>ਜਾਰੀ ਰੱਖੋ"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>ਰੱਦ ਕਰੋ"
 
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>ਗਲਤੀ"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "ਸੰਰਚਨਾ ਸੈੱਟ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ:"
 
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "ਬੰਦ ਕਰੋ"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "ਪਿੱਛੇ"
 
-#: gphoto2/gphoto2-cmd-config.c:254
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "ਸਮਾਂ: "
 
-#: gphoto2/gphoto2-cmd-config.c:313 gphoto2/gphoto2-cmd-config.c:341
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "ਮੁੱਲ: "
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "ਹਾਂ"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "ਨਹੀਂ"
 
-#: gphoto2/main.c:167 gphoto2/main.c:1638
-msgid "Turn on debugging"
-msgstr ""
-
-#: gphoto2/main.c:168 gphoto2/main.c:1640
-msgid "Quiet output (default=verbose)"
-msgstr ""
-
-#: gphoto2/main.c:172 gphoto2/main.c:1644
-msgid "Display version and exit"
-msgstr "ਵਰਜਨ ਵੇਖਾਓ ਅਤੇ ਬੰਦ ਕਰੋ"
-
-#: gphoto2/main.c:173
-msgid "Displays this help screen"
-msgstr ""
-
-#: gphoto2/main.c:174 gphoto2/main.c:1646
-msgid "List supported camera models"
-msgstr "ਸਹਾਇਕ ਕੈਮਰਾ ਮਾਡਲ ਵੇਖਾਓ"
-
-#: gphoto2/main.c:175 gphoto2/main.c:1648
-msgid "List supported port devices"
-msgstr "ਸਹਾਇਕ ਪੋਰਟ ਜੰਤਰ ਵੇਖਾਓ"
-
-#: gphoto2/main.c:176 gphoto2/main.c:1650
-msgid "Send file to stdout"
-msgstr ""
-
-#: gphoto2/main.c:177 gphoto2/main.c:1652
-msgid "Print filesize before data"
-msgstr "ਡਾਟੇ ਤੋਂ ਪਹਿਲਾਂ ਫਾਇਲ-ਆਕਾਰ ਛਾਪੋ"
-
-#: gphoto2/main.c:178 gphoto2/main.c:1654
-msgid "List auto-detected cameras"
-msgstr "ਆਟੋ-ਖੋਜੇ ਕੈਮਰੇ ਦਿਓ"
-
-#: gphoto2/main.c:181 gphoto2/main.c:1656
-msgid "Specify port device"
-msgstr "ਪੋਰਟ ਜੰਤਰ ਦਿਓ"
-
-#: gphoto2/main.c:182 gphoto2/main.c:1658
-msgid "Specify serial transfer speed"
-msgstr "ਲੜੀ ਸੰਚਾਰ ਗਤੀ ਦਿਓ"
-
-#: gphoto2/main.c:183 gphoto2/main.c:1660
-msgid "Specify camera model"
-msgstr "ਕੈਮਰਾ ਮਾਡਲ ਵੇਖਾਓ"
-
-#: gphoto2/main.c:184 gphoto2/main.c:1662
-#, fuzzy
-msgid "Specify a filename"
-msgstr "ਕੀ ਨਵਾਂ ਫਾਇਲ ਨਾਂ ਦੇਣਾ ਹੈ? [y|n] "
-
-#: gphoto2/main.c:185 gphoto2/main.c:1664
-msgid "(expert only) Override USB IDs"
-msgstr ""
-
-#: gphoto2/main.c:188 gphoto2/main.c:1666
-#, fuzzy
-msgid "Display camera abilities"
-msgstr "ਕੈਮਰਾ/ਡਰਾਇਵਰ ਯੋਗਤਾ ਵੇਖਾਓ"
-
-#: gphoto2/main.c:189 gphoto2/main.c:1668
-msgid "Specify camera folder (default=\"/\")"
-msgstr "ਕੈਮਰਾ ਫੋਲਡਰ ਦਿਓ (ਮੂਲ=\"/\")"
-
-#: gphoto2/main.c:190 gphoto2/main.c:1670
-msgid "Recursion (default for download)"
-msgstr ""
-
-#: gphoto2/main.c:191 gphoto2/main.c:1672
-msgid "No recursion (default for deletion)"
-msgstr ""
-
-#: gphoto2/main.c:192 gphoto2/main.c:1674
-msgid "Process new files only"
-msgstr "ਨਵੀਆਂ ਫਾਇਲਾਂ ਉੱਤੇ ਕਾਰਵਾਈ"
-
-#: gphoto2/main.c:193 gphoto2/main.c:1676
-msgid "List folders in folder"
-msgstr "ਫੋਲਡਰ ਵਿੱਚ ਫੋਲਡਰ ਵੇਖਾਓ"
-
-#: gphoto2/main.c:194 gphoto2/main.c:1678
-msgid "List files in folder"
-msgstr "ਫੋਲਡਰ ਵਿੱਚ ਫਾਇਲਾਂ ਵੇਖਾਓ"
-
-#: gphoto2/main.c:195 gphoto2/main.c:196
-msgid "name"
-msgstr "ਨਾਂ"
-
-#: gphoto2/main.c:195 gphoto2/main.c:1680
-msgid "Create a directory"
-msgstr "ਇੱਕ ਡਾਇਰੈਕਟਰੀ ਬਣਾਓ"
-
-#: gphoto2/main.c:196 gphoto2/main.c:1682
-msgid "Remove a directory"
-msgstr "ਇੱਕ ਡਾਇਰੈਕਟਰੀ ਹਟਾਓ"
-
-#: gphoto2/main.c:197 gphoto2/main.c:1684
-msgid "Display number of files"
-msgstr "ਫਾਇਲਾਂ ਦੀ ਗਿਣਤੀ ਵੇਖਾਓ"
-
-#: gphoto2/main.c:198 gphoto2/main.c:1686
-msgid "Get files given in range"
-msgstr ""
-
-#: gphoto2/main.c:199 gphoto2/main.c:1688
-msgid "Get all files from folder"
-msgstr "ਫੋਲਡਰ ਤੋਂ ਸਭ ਫਾਇਲਾਂ ਲਵੋ"
-
-#: gphoto2/main.c:200 gphoto2/main.c:1690
-msgid "Get thumbnails given in range"
-msgstr "ਰੇਜ਼ ਵਿੱਚ ਦਿੱਤੇ ਥੰਮਨੇਲ ਲਵੋ"
-
-#: gphoto2/main.c:201 gphoto2/main.c:1693
-msgid "Get all thumbnails from folder"
-msgstr "ਫੋਲਡਰ ਤੋਂ ਸਭ ਥੰਮਨੇਲ ਲਵੋ"
-
-#: gphoto2/main.c:202 gphoto2/main.c:1696
-msgid "Get raw data given in range"
-msgstr ""
-
-#: gphoto2/main.c:203 gphoto2/main.c:1699
-msgid "Get all raw data from folder"
-msgstr ""
-
-#: gphoto2/main.c:204 gphoto2/main.c:1702
-msgid "Get audio data given in range"
-msgstr ""
-
-#: gphoto2/main.c:205 gphoto2/main.c:1705
-msgid "Get all audio data from folder"
-msgstr "ਫੋਲਡਰ ਤੋਂ ਸਭ ਆਡੀਓ ਡਾਟਾ ਲਵੋ"
-
-#: gphoto2/main.c:206 gphoto2/main.c:1707
-msgid "Delete files given in range"
-msgstr ""
-
-#: gphoto2/main.c:207 gphoto2/main.c:1709
-msgid "Delete all files in folder"
-msgstr "ਫੋਲਡਰ ਵਿੱਚ ਸਭ ਫਾਇਲ ਹਟਾਓ"
-
-#: gphoto2/main.c:208 gphoto2/main.c:1711
-msgid "Upload a file to camera"
-msgstr "ਇੱਕ ਫਾਇਲ ਕੈਮਰੇ ਉੱਤੇ ਅੱਪਲੋਡ ਕਰੋ"
-
-#: gphoto2/main.c:210 gphoto2/main.c:1714
-msgid "Configure"
-msgstr "ਸੰਰਚਨਾ"
-
-#: gphoto2/main.c:212
-#, fuzzy
-msgid "List the configuration tree"
-msgstr "ਸੰਰਚਨਾ ਲੜੀ ਵੇਖਾਓ"
-
-#: gphoto2/main.c:213
-#, fuzzy
-msgid "Get a configuration variable"
-msgstr "ਸੰਰਚਨਾ ਮੁੱਲ ਲਵੋ"
-
-#: gphoto2/main.c:214
-#, fuzzy
-msgid "Set a configuration variable"
-msgstr "ਸੰਰਚਨਾ ਮੁੱਲ ਦਿਓ"
-
-#: gphoto2/main.c:215 gphoto2/main.c:1726
-msgid "Set number of frames to capture (default=infinite)"
-msgstr ""
-
-#: gphoto2/main.c:216 gphoto2/main.c:1728
-msgid "Set capture interval in seconds"
-msgstr ""
-
-#: gphoto2/main.c:217 gphoto2/main.c:1724
-msgid "Capture a quick preview"
-msgstr "ਇੱਕ ਤੁਰੰਤ ਝਲਕ ਕੈਪਚਰ ਕਰੋ"
-
-#: gphoto2/main.c:218 gphoto2/main.c:1730
-msgid "Capture an image"
-msgstr "ਇੱਕ ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਕਰੋ"
-
-#: gphoto2/main.c:219
-#, fuzzy
-msgid "Capture a movie "
-msgstr "ਇੱਕ ਫਿਲਮ ਲਵੋ"
-
-#: gphoto2/main.c:220 gphoto2/main.c:1734
-msgid "Capture an audio clip"
-msgstr "ਇੱਕ ਆਡੀਓ ਕਲਿੱਪ ਪ੍ਰਾਪਤ ਕਰੋ"
-
-#: gphoto2/main.c:222 gphoto2/main.c:1737 gphoto2/shell.c:113
-msgid "Show EXIF information"
-msgstr "EXIF ਜਾਣਕਾਰੀ ਵੇਖਾਓ"
-
-#: gphoto2/main.c:224 gphoto2/main.c:1740 gphoto2/shell.c:109
-msgid "Show info"
-msgstr "ਜਾਣਕਾਰੀ ਵੇਖਾਓ"
-
-#: gphoto2/main.c:225
-msgid "Summary of camera status"
-msgstr ""
-
-#: gphoto2/main.c:226
-#, fuzzy
-msgid "Camera driver manual"
-msgstr "ਕੈਮਰਾ ਡਰਾਇਵਰ ਦਸਤਾਵੇਜ਼ ਵੇਖਾਓ"
-
-#: gphoto2/main.c:227
-#, fuzzy
-msgid "About the camera driver"
-msgstr "ਕੈਮਰਾ ਮਾਡਲ ਬਾਰੇ:"
-
-#: gphoto2/main.c:228 gphoto2/main.c:1748
-msgid "gPhoto shell"
-msgstr "gPhoto ਸ਼ੈੱਲ"
-
-#: gphoto2/main.c:382 gphoto2/main.c:1343
+#: gphoto2/main.c:220
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr ""
 
-#: gphoto2/main.c:581
+#: gphoto2/main.c:229
 #, c-format
-msgid "You cannot use '%%n' in combination with non-persistent files!"
+msgid "You cannot use %%n zero padding without a precision value!"
 msgstr ""
 
-#: gphoto2/main.c:604
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr ""
 
-#: gphoto2/main.c:654
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "ਗਲਤ ਫਾਰਮੈਟ '%s' (%i ਸਥਿਤੀ ਉੱਤੇ ਗਲਤੀ)।"
 
-#: gphoto2/main.c:702
+#: gphoto2/main.c:386 gphoto2/main.c:592
+#, fuzzy, c-format
+msgid "Skip existing file %s\n"
+msgstr "ਫਾਇਲ %s ਦੇ ਤੌਰ ਉੱਤੇ ਸੰਭਾਲੀ ਜਾ ਰਹੀ ਹੈ\n"
+
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "ਫਾਇਲ %s ਪਹਿਲਾਂ ਹੀ ਮੌਜੂਦ ਹੈ। ਕੀ ਉੱਤੇ ਲਿਖਣਾ ਹੈ? [y|n] "
 
-#: gphoto2/main.c:713
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "ਕੀ ਨਵਾਂ ਫਾਇਲ ਨਾਂ ਦੇਣਾ ਹੈ? [y|n] "
 
-#: gphoto2/main.c:722
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "ਨਵਾਂ ਫਾਇਲ ਨਾਂ ਦਿਓ: "
 
-#: gphoto2/main.c:727
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "ਫਾਇਲ %s ਦੇ ਤੌਰ ਉੱਤੇ ਸੰਭਾਲੀ ਜਾ ਰਹੀ ਹੈ\n"
 
-#: gphoto2/main.c:957
-#, c-format
-msgid "Time-lapse mode enabled (interval: %ds).\n"
-msgstr ""
+#: gphoto2/main.c:630
+#, fuzzy
+msgid "Permission denied"
+msgstr "  ਅਧਿਕਾਰ: "
 
-#: gphoto2/main.c:964
-#, c-format
-msgid "Capturing frame #%d...\n"
-msgstr "ਫਰੇਮ #%d ਕੈਪਚਰ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ...\n"
-
-#: gphoto2/main.c:966
-#, c-format
-msgid "Capturing frame #%d/%d...\n"
-msgstr "ਫਰੇਮ #%d/%d ਕੈਪਚਰ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ...\n"
-
-#: gphoto2/main.c:973
-msgid "Could not capture."
+#: gphoto2/main.c:800
+#, fuzzy
+msgid "Could not trigger capture."
 msgstr "ਕੈਪਚਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।"
 
-#: gphoto2/main.c:982
-#, c-format
-msgid "Capture failed (auto-focus problem?)...\n"
-msgstr "ਕੈਪਚਰ ਫੇਲ੍ਹ ਹੋਇਆ (ਆਟੋ-ਫੋਕਸ ਸਮੱਸਿਆ ਹੈ?)...\n"
-
-#: gphoto2/main.c:996
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "ਕੈਮਰੇ ਉੱਤੇ ਨਵੀਂ ਫਾਇਲ %s%s%s ਟਿਕਾਣੇ ਉੱਤੇ ਹੈ\n"
 
-#: gphoto2/main.c:1006
-msgid "Could not set folder."
-msgstr "ਫੋਲਡਰ ਦਿੱਤਾ ਨਹੀਂ ਜਾ ਸਕਿਆ ਹੈ।"
+#: gphoto2/main.c:847 gphoto2/main.c:878
+#, fuzzy, c-format
+msgid "Keeping file %s%s%s on the camera\n"
+msgstr "ਕੈਮਰੇ ਉੱਤੇ ਫਾਇਲ %s%s%s ਨੂੰ ਹਟਾਇਆ ਜਾ ਰਿਹਾ ਹੈ\n"
 
-#: gphoto2/main.c:1024
-msgid "Could not get image."
-msgstr "ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਹੋ ਨਹੀਂ ਸਕੀ ਹੈ।"
-
-#: gphoto2/main.c:1031
-msgid "Buggy libcanon.so?"
-msgstr "ਬੱਗੀ libcanon.so ਹੈ?"
-
-#: gphoto2/main.c:1037
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "ਕੈਮਰੇ ਉੱਤੇ ਫਾਇਲ %s%s%s ਨੂੰ ਹਟਾਇਆ ਜਾ ਰਿਹਾ ਹੈ\n"
 
-#: gphoto2/main.c:1042
-msgid "Could not delete image."
-msgstr "ਤਸਵੀਰ ਹਟਾਇਆ ਨਹੀਂ ਜਾ ਸਕਿਆ ਹੈ।"
-
-#: gphoto2/main.c:1056
-msgid "Could not close camera connection."
-msgstr "ਕੈਮਰਾ ਕੁਨੈਕਸ਼ਨ ਬੰਦ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ ਹੈ।"
-
-#: gphoto2/main.c:1060
+#: gphoto2/main.c:911
 #, c-format
-msgid "Sleeping for %d second(s)...\n"
-msgstr "%d ਸਕਿੰਟ ਲਈ ਸਲੀਪ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ...\n"
+msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
+msgstr ""
 
-#: gphoto2/main.c:1194
+#: gphoto2/main.c:916
+#, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:926
+#, c-format
+msgid "Event UNKNOWN %s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:932
+#, c-format
+msgid "Unknown event type %d during bulb wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:950
+#, fuzzy
+msgid "Could not get capabilities?"
+msgstr "ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਹੋ ਨਹੀਂ ਸਕੀ ਹੈ।"
+
+#: gphoto2/main.c:958
+#, c-format
+msgid "Time-lapse mode enabled (interval: %ds).\n"
+msgstr ""
+
+#: gphoto2/main.c:961
+#, c-format
+msgid "Standing by waiting for SIGUSR1 to capture.\n"
+msgstr ""
+
+#: gphoto2/main.c:967
+#, c-format
+msgid "Bulb mode enabled (exposure time: %ds).\n"
+msgstr ""
+
+#: gphoto2/main.c:975
+#, c-format
+msgid "Capturing frame #%d...\n"
+msgstr "ਫਰੇਮ #%d ਕੈਪਚਰ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ...\n"
+
+#: gphoto2/main.c:977
+#, c-format
+msgid "Capturing frame #%d/%d...\n"
+msgstr "ਫਰੇਮ #%d/%d ਕੈਪਚਰ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ...\n"
+
+#: gphoto2/main.c:987
+#, fuzzy, c-format
+msgid "Could not set bulb capture, result %d."
+msgstr "ਕੈਪਚਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।"
+
+#: gphoto2/main.c:1001
+#, fuzzy
+msgid "Could not end capture (bulb mode)."
+msgstr "ਕੈਪਚਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।"
+
+#: gphoto2/main.c:1014
+#, fuzzy
+msgid "Could not trigger image capture."
+msgstr "ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਹੋ ਨਹੀਂ ਸਕੀ ਹੈ।"
+
+#: gphoto2/main.c:1021
+#, fuzzy
+msgid "Could not capture image."
+msgstr "ਕੈਪਚਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।"
+
+#: gphoto2/main.c:1028
+#, c-format
+msgid "Capture failed (auto-focus problem?)...\n"
+msgstr "ਕੈਪਚਰ ਫੇਲ੍ਹ ਹੋਇਆ (ਆਟੋ-ਫੋਕਸ ਸਮੱਸਿਆ ਹੈ?)...\n"
+
+#: gphoto2/main.c:1039
+msgid "Could not capture."
+msgstr "ਕੈਪਚਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ।"
+
+#: gphoto2/main.c:1074
+#, c-format
+msgid "Waiting for next capture slot %ld seconds...\n"
+msgstr ""
+
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
+#, c-format
+msgid "Awakened by SIGUSR1...\n"
+msgstr ""
+
+#: gphoto2/main.c:1096
+#, c-format
+msgid "not sleeping (%ld seconds behind schedule)\n"
+msgstr ""
+
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "ਗਲਤੀ: "
 
-#: gphoto2/main.c:1217
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -893,12 +956,12 @@ msgstr ""
 "\n"
 "ਅਧੂਰਾ ਛੱਡਿਆ ਜਾ ਰਿਹਾ ਹੈ...\n"
 
-#: gphoto2/main.c:1223
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "ਅਧੂਰਾ ਛੱਡਿਆ।\n"
 
-#: gphoto2/main.c:1228
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -907,16 +970,30 @@ msgstr ""
 "\n"
 "ਰੱਦ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ...\n"
 
-#: gphoto2/main.c:1446
+#: gphoto2/main.c:1426
+#, c-format
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr ""
 
-#: gphoto2/main.c:1581
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "ਕਾਰਵਾਈ ਰੱਦ ਕੀਤੀ ਗਈ।\n"
 
-#: gphoto2/main.c:1585
+#: gphoto2/main.c:1883
+#, c-format
+msgid ""
+"*** Error: No camera found. ***\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -925,7 +1002,7 @@ msgstr ""
 "*** ਗਤੀ (%i: '%s') ***       \n"
 "\n"
 
-#: gphoto2/main.c:1589
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -936,134 +1013,446 @@ msgid ""
 "\n"
 msgstr ""
 
-#: gphoto2/main.c:1642
-msgid "Overwrite files without asking"
-msgstr "ਬਿਨਾਂ ਪੁੱਛੇ ਫਾਇਲ ਉੱਪਰ ਲਿਖੋ"
-
-#: gphoto2/main.c:1656
-msgid "path"
+#: gphoto2/main.c:1911
+#, c-format
+msgid ""
+"Please make sure there is sufficient quoting around the arguments.\n"
+"\n"
 msgstr ""
 
-#: gphoto2/main.c:1658
-msgid "speed"
+#: gphoto2/main.c:1978
+msgid "Print complete help message on program usage"
 msgstr ""
 
-#: gphoto2/main.c:1660
+#: gphoto2/main.c:1980
+msgid "Print short message on program usage"
+msgstr ""
+
+#: gphoto2/main.c:1982
+msgid "Turn on debugging"
+msgstr ""
+
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
+
+#: gphoto2/main.c:1986
+msgid "Name of file to write debug info to"
+msgstr ""
+
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
+msgid "FILENAME"
+msgstr "FILENAME"
+
+#: gphoto2/main.c:1988
+msgid "Quiet output (default=verbose)"
+msgstr ""
+
+#: gphoto2/main.c:1990
+msgid "Hook script to call after downloads, captures, etc."
+msgstr ""
+
+#: gphoto2/main.c:1997
 #, fuzzy
-msgid "model"
-msgstr "ਮਾਡਲ"
+msgid "Specify device port"
+msgstr "ਪੋਰਟ ਜੰਤਰ ਦਿਓ"
 
-#: gphoto2/main.c:1662
-msgid "filename"
-msgstr "ਫਾਇਲ ਨਾਂ"
+#: gphoto2/main.c:1999
+msgid "Specify serial transfer speed"
+msgstr "ਲੜੀ ਸੰਚਾਰ ਗਤੀ ਦਿਓ"
 
-#: gphoto2/main.c:1664
-msgid "usbid"
+#: gphoto2/main.c:1999
+msgid "SPEED"
+msgstr "SPEED"
+
+#: gphoto2/main.c:2001
+msgid "Specify camera model"
+msgstr "ਕੈਮਰਾ ਮਾਡਲ ਵੇਖਾਓ"
+
+#: gphoto2/main.c:2001
+msgid "MODEL"
+msgstr "MODEL"
+
+#: gphoto2/main.c:2003
+msgid "(expert only) Override USB IDs"
 msgstr ""
 
-#: gphoto2/main.c:1668
-msgid "folder"
+#: gphoto2/main.c:2003
+msgid "USBIDs"
+msgstr "USBIDs"
+
+#: gphoto2/main.c:2009
+msgid "Display version and exit"
+msgstr "ਵਰਜਨ ਵੇਖਾਓ ਅਤੇ ਬੰਦ ਕਰੋ"
+
+#: gphoto2/main.c:2011
+msgid "List supported camera models"
+msgstr "ਸਹਾਇਕ ਕੈਮਰਾ ਮਾਡਲ ਵੇਖਾਓ"
+
+#: gphoto2/main.c:2013
+msgid "List supported port devices"
+msgstr "ਸਹਾਇਕ ਪੋਰਟ ਜੰਤਰ ਵੇਖਾਓ"
+
+#: gphoto2/main.c:2015
+msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr ""
 
-#: gphoto2/main.c:1717
+#: gphoto2/main.c:2022
+msgid "Configure"
+msgstr "ਸੰਰਚਨਾ"
+
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "ਸੰਰਚਨਾ ਲੜੀ ਵੇਖਾਓ"
 
-#: gphoto2/main.c:1719
+#: gphoto2/main.c:2027
+#, fuzzy
+msgid "Dump full configuration tree"
+msgstr "ਸੰਰਚਨਾ ਲੜੀ ਵੇਖਾਓ"
+
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "ਸੰਰਚਨਾ ਮੁੱਲ ਲਵੋ"
 
-#: gphoto2/main.c:1721
+#: gphoto2/main.c:2031
+#, fuzzy
+msgid "Set configuration value or index in choices"
+msgstr "ਸੰਰਚਨਾ ਮੁੱਲ ਦਿਓ"
+
+#: gphoto2/main.c:2033
+#, fuzzy
+msgid "Set configuration value index in choices"
+msgstr "ਸੰਰਚਨਾ ਮੁੱਲ ਦਿਓ"
+
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "ਸੰਰਚਨਾ ਮੁੱਲ ਦਿਓ"
 
-#: gphoto2/main.c:1726
-msgid "count"
+#: gphoto2/main.c:2037
+msgid "Reset device port"
 msgstr ""
 
-#: gphoto2/main.c:1728
-msgid "seconds"
+#: gphoto2/main.c:2043
+msgid "Keep images on camera after capturing"
 msgstr ""
 
-#: gphoto2/main.c:1732
+#: gphoto2/main.c:2045
+msgid "Keep RAW images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2047
+msgid "Remove images from camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2049
+#, fuzzy
+msgid "Wait for event(s) from camera"
+msgstr "ਕੈਮਰੇ ਵਲੋਂ ਜਵਾਬ ਦੀ ਉਡੀਕ"
+
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
+
+#: gphoto2/main.c:2051
+#, fuzzy
+msgid "Wait for event(s) from the camera and download new images"
+msgstr "ਕੈਮਰੇ ਵਲੋਂ ਜਵਾਬ ਦੀ ਉਡੀਕ"
+
+#: gphoto2/main.c:2054
+msgid "Capture a quick preview"
+msgstr "ਇੱਕ ਤੁਰੰਤ ਝਲਕ ਕੈਪਚਰ ਕਰੋ"
+
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
+
+#: gphoto2/main.c:2059
+msgid "Set bulb exposure time in seconds"
+msgstr ""
+
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
+msgid "SECONDS"
+msgstr "SECONDS"
+
+#: gphoto2/main.c:2061
+msgid "Set number of frames to capture (default=infinite)"
+msgstr ""
+
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr "COUNT"
+
+#: gphoto2/main.c:2063
+msgid "Set capture interval in seconds"
+msgstr ""
+
+#: gphoto2/main.c:2065
+msgid "Reset capture interval on signal (default=no)"
+msgstr ""
+
+#: gphoto2/main.c:2067
+msgid "Capture an image"
+msgstr "ਇੱਕ ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਕਰੋ"
+
+#: gphoto2/main.c:2069
+#, fuzzy
+msgid "Trigger capture of an image"
+msgstr "ਇੱਕ ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਕਰੋ"
+
+#: gphoto2/main.c:2071
+#, fuzzy
+msgid "Capture an image and download it"
+msgstr "ਇੱਕ ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਕਰੋ"
+
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "ਇੱਕ ਫਿਲਮ ਲਵੋ"
 
-#: gphoto2/main.c:1742
-msgid "Show summary"
+#: gphoto2/main.c:2073
+#, fuzzy
+msgid "COUNT or SECONDS"
+msgstr "SECONDS"
+
+#: gphoto2/main.c:2075
+msgid "Capture an audio clip"
+msgstr "ਇੱਕ ਆਡੀਓ ਕਲਿੱਪ ਪ੍ਰਾਪਤ ਕਰੋ"
+
+#: gphoto2/main.c:2077
+msgid "Wait for shutter release on the camera and download"
+msgstr ""
+
+#: gphoto2/main.c:2083
+msgid "List folders in folder"
+msgstr "ਫੋਲਡਰ ਵਿੱਚ ਫੋਲਡਰ ਵੇਖਾਓ"
+
+#: gphoto2/main.c:2085
+msgid "List files in folder"
+msgstr "ਫੋਲਡਰ ਵਿੱਚ ਫਾਇਲਾਂ ਵੇਖਾਓ"
+
+#: gphoto2/main.c:2087
+msgid "Create a directory"
+msgstr "ਇੱਕ ਡਾਇਰੈਕਟਰੀ ਬਣਾਓ"
+
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
+msgid "DIRNAME"
+msgstr "DIRNAME"
+
+#: gphoto2/main.c:2089
+msgid "Remove a directory"
+msgstr "ਇੱਕ ਡਾਇਰੈਕਟਰੀ ਹਟਾਓ"
+
+#: gphoto2/main.c:2091
+msgid "Display number of files"
+msgstr "ਫਾਇਲਾਂ ਦੀ ਗਿਣਤੀ ਵੇਖਾਓ"
+
+#: gphoto2/main.c:2093
+msgid "Get files given in range"
+msgstr ""
+
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
+msgid "RANGE"
+msgstr "RANGE"
+
+#: gphoto2/main.c:2095
+msgid "Get all files from folder"
+msgstr "ਫੋਲਡਰ ਤੋਂ ਸਭ ਫਾਇਲਾਂ ਲਵੋ"
+
+#: gphoto2/main.c:2097
+msgid "Get thumbnails given in range"
+msgstr "ਰੇਜ਼ ਵਿੱਚ ਦਿੱਤੇ ਥੰਮਨੇਲ ਲਵੋ"
+
+#: gphoto2/main.c:2100
+msgid "Get all thumbnails from folder"
+msgstr "ਫੋਲਡਰ ਤੋਂ ਸਭ ਥੰਮਨੇਲ ਲਵੋ"
+
+#: gphoto2/main.c:2102
+msgid "Get metadata given in range"
+msgstr "ਰੇਜ਼ ਵਿੱਚ ਮੇਟਾਡਾਟਾ ਲਵੋ"
+
+#: gphoto2/main.c:2104
+msgid "Get all metadata from folder"
+msgstr "ਫੋਲਡਰ ਤੋਂ ਸਭ ਮੇਟਾ-ਡਾਟਾ ਲਵੋ"
+
+#: gphoto2/main.c:2106
+msgid "Upload metadata for file"
+msgstr "ਫਾਇਲ ਤੋਂ ਮੇਟਾਡਾਟਾ ਅੱਪਲੋਡ ਕਰੋ"
+
+#: gphoto2/main.c:2109
+msgid "Get raw data given in range"
+msgstr ""
+
+#: gphoto2/main.c:2112
+msgid "Get all raw data from folder"
+msgstr ""
+
+#: gphoto2/main.c:2115
+msgid "Get audio data given in range"
+msgstr ""
+
+#: gphoto2/main.c:2118
+msgid "Get all audio data from folder"
+msgstr "ਫੋਲਡਰ ਤੋਂ ਸਭ ਆਡੀਓ ਡਾਟਾ ਲਵੋ"
+
+#: gphoto2/main.c:2120
+msgid "Delete files given in range"
+msgstr ""
+
+#: gphoto2/main.c:2122
+#, fuzzy
+msgid "Delete all files in folder (--no-recurse by default)"
+msgstr "ਫੋਲਡਰ ਵਿੱਚ ਸਭ ਫਾਇਲ ਹਟਾਓ"
+
+#: gphoto2/main.c:2124
+msgid "Upload a file to camera"
+msgstr "ਇੱਕ ਫਾਇਲ ਕੈਮਰੇ ਉੱਤੇ ਅੱਪਲੋਡ ਕਰੋ"
+
+#: gphoto2/main.c:2126
+msgid "Specify a filename or filename pattern"
+msgstr "ਇੱਕ ਫਾਇਲ ਨਾਂ ਜਾਂ ਫਾਇਲ-ਨਾਂ ਪੈਟਰਨ ਦਿਓ"
+
+#: gphoto2/main.c:2126
+msgid "FILENAME_PATTERN"
+msgstr "FILENAME_PATTERN"
+
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
+msgid "Specify camera folder (default=\"/\")"
+msgstr "ਕੈਮਰਾ ਫੋਲਡਰ ਦਿਓ (ਮੂਲ=\"/\")"
+
+#: gphoto2/main.c:2130
+msgid "FOLDER"
+msgstr "FOLDER"
+
+#: gphoto2/main.c:2132
+msgid "Recursion (default for download)"
+msgstr ""
+
+#: gphoto2/main.c:2134
+msgid "No recursion (default for deletion)"
+msgstr ""
+
+#: gphoto2/main.c:2136
+msgid "Process new files only"
+msgstr "ਨਵੀਆਂ ਫਾਇਲਾਂ ਉੱਤੇ ਕਾਰਵਾਈ"
+
+#: gphoto2/main.c:2138
+msgid "Overwrite files without asking"
+msgstr "ਬਿਨਾਂ ਪੁੱਛੇ ਫਾਇਲ ਉੱਪਰ ਲਿਖੋ"
+
+#: gphoto2/main.c:2140
+msgid "Skip existing files"
+msgstr ""
+
+#: gphoto2/main.c:2146
+msgid "Send file to stdout"
+msgstr ""
+
+#: gphoto2/main.c:2148
+msgid "Print filesize before data"
+msgstr "ਡਾਟੇ ਤੋਂ ਪਹਿਲਾਂ ਫਾਇਲ-ਆਕਾਰ ਛਾਪੋ"
+
+#: gphoto2/main.c:2150
+msgid "List auto-detected cameras"
+msgstr "ਆਟੋ-ਖੋਜੇ ਕੈਮਰੇ ਦਿਓ"
+
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
+msgstr "EXIF ਜਾਣਕਾਰੀ ਵੇਖਾਓ"
+
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
+
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "ਸੰਖੇਪ ਵੇਖਾਓ"
 
-#: gphoto2/main.c:1744
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "ਕੈਮਰਾ ਡਰਾਇਵਰ ਦਸਤਾਵੇਜ਼ ਵੇਖਾਓ"
 
-#: gphoto2/main.c:1746
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "ਕੈਮਰਾ ਡਰਾਇਵਰ ਦਸਤਾਵੇਜ਼ ਬਾਰੇ"
 
-#: gphoto2/main.c:1973
-#, c-format
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
+#, fuzzy
+msgid "Show storage information"
+msgstr "EXIF ਜਾਣਕਾਰੀ ਵੇਖਾਓ"
+
+#: gphoto2/main.c:2167
+msgid "gPhoto shell"
+msgstr "gPhoto ਸ਼ੈੱਲ"
+
+#: gphoto2/main.c:2173
+msgid "Common options"
+msgstr "ਆਮ ਚੋਣਾਂ"
+
+#: gphoto2/main.c:2175
+msgid "Miscellaneous options (unsorted)"
+msgstr "ਫੁਟਕਲ ਚੋਣਾਂ (ਨਾ-ਲੜੀਬੱਧ)"
+
+#: gphoto2/main.c:2177
+msgid "Get information on software and host system (not from the camera)"
+msgstr "ਸਾਫਵੇਅਰ ਅਤੇ ਹੋਸਟ ਸਿਸਟਮ ਤੋਂ ਜਾਣਕਾਰੀ ਲਵੋ (ਕੈਮਰੇ ਤੋਂ ਨਹੀਂ)"
+
+#: gphoto2/main.c:2179
+msgid "Specify the camera to use"
+msgstr "ਵਰਤਣ ਲਈ ਕੈਮਰਾ ਦਿਓ"
+
+#: gphoto2/main.c:2181
+msgid "Camera and software configuration"
+msgstr "ਕੈਮਰਾ ਅਤੇ ਸਾਫਟਵੇਅਰ ਸੰਰਚਨਾ"
+
+#: gphoto2/main.c:2183
+msgid "Capture an image from or on the camera"
+msgstr "ਕੈਮਰੇ ਤੋਂ ਇੱਕ ਚਿੱਤਰ ਲਵੋ"
+
+#: gphoto2/main.c:2185
+msgid "Downloading, uploading and manipulating files"
 msgstr ""
 
-#: gphoto2/main.c:1983
-#, c-format
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
-msgstr ""
-
-#: gphoto2/options.c:181
-#, c-format
-msgid "Usage:\n"
-msgstr "ਵਰਤੋਂ:\n"
-
-#: gphoto2/options.c:184
-#, c-format
-msgid ""
-"Short/long options (& argument)        Description\n"
-"--------------------------------------------------------------------------------\n"
-msgstr ""
-
-#: gphoto2/options.c:209
-#, c-format
-msgid "%-38s %s\n"
-msgstr "%-38s %s\n"
-
-#: gphoto2/options.c:214
-#, c-format
-msgid ""
-"--------------------------------------------------------------------------------\n"
-"[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
-msgstr ""
-
-#: gphoto2/range.c:103 gphoto2/range.c:157
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
 "Image IDs must be a number greater than zero."
 msgstr ""
 
-#: gphoto2/range.c:109 gphoto2/range.c:163
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
 "Image ID %i too high."
 msgstr ""
 
-#: gphoto2/range.c:125
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
 "Ranges must be separated by ','."
 msgstr ""
 
-#: gphoto2/range.c:139
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
 "Ranges need to start with a number."
 msgstr ""
 
-#: gphoto2/range.c:179
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1072,226 +1461,307 @@ msgstr ""
 "%s\n"
 "ਵਿਲੱਖਣ ਅੱਖਰ '%c' ਹੈ।"
 
-#: gphoto2/range.c:202
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 
-#: gphoto2/shell.c:55
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** ਗਲਤੀ (%i: '%s') ***"
 
-#: gphoto2/shell.c:98
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "ਕੈਮਰੇ ਉੱਤੇ ਇੱਕ ਡਾਇਰੈਕਟਰੀ ਤਬਦੀਲ"
 
-#: gphoto2/shell.c:99 gphoto2/shell.c:101
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "ਡਾਇਰੈਕਟਰੀ"
 
-#: gphoto2/shell.c:100
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "ਸਥਾਨਕ ਡਰਾਇਵ ਉੱਤੇ ਇੱਕ ਡਾਇਰੈਕਟਰੀ ਤਬਦੀਲ"
 
-#: gphoto2/shell.c:102 gphoto2/shell.c:120 gphoto2/shell.c:121
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr ""
 
-#: gphoto2/shell.c:103
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "ਇੱਕ ਫਾਇਲ ਡਾਊਨਲੋਡ"
 
-#: gphoto2/shell.c:103 gphoto2/shell.c:106 gphoto2/shell.c:108
-#: gphoto2/shell.c:110 gphoto2/shell.c:111 gphoto2/shell.c:114
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[ਡਾਇਰੈਕਟਰੀ/]ਫਾਇਲ ਨਾਂ"
 
-#: gphoto2/shell.c:105
+#: gphoto2/shell.c:132
+msgid "Upload a file"
+msgstr "ਇੱਕ ਫਾਇਲ ਅੱਪਲੋਡ ਕਰੋ"
+
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "ਇੱਕ ਥੰਮਨੇਲ ਡਾਊਨਲੋਡ ਕਰੋ"
 
-#: gphoto2/shell.c:107
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "ਕੱਚਾ ਡਾਟਾ ਡਾਊਨਲੋਡ"
 
-#: gphoto2/shell.c:111
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "ਹਟਾਓ"
 
-#: gphoto2/shell.c:116 gphoto2/shell.c:122
+#: gphoto2/shell.c:140
+msgid "Create Directory"
+msgstr "ਡਾਇਰੈਕਟਰੀ ਬਣਾਓ"
+
+#: gphoto2/shell.c:141
+msgid "Remove Directory"
+msgstr "ਡਾਇਰੈਕਟਰੀ ਹਟਾਓ"
+
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "ਕਮਾਂਡ ਵੇਖਾਓ"
 
-#: gphoto2/shell.c:117 gphoto2/shell.c:122
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[ਕਮਾਂਡ]"
 
-#: gphoto2/shell.c:118
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "ਮੌਜੂਦਾ ਡਾਇਰੈਕਟਰੀ ਦੇ ਭਾਗ ਵੇਖਾਓ"
 
-#: gphoto2/shell.c:119
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[ਡਾਇਰੈਕਟਰੀ/]"
 
-#: gphoto2/shell.c:425
+#: gphoto2/shell.c:152
+msgid "List configuration variables"
+msgstr "ਸੰਰਚਨਾਯੋਗ ਮੁੱਲ ਲਿਸਟ ਕਰੋ"
+
+#: gphoto2/shell.c:153
+#, fuzzy
+msgid "Get configuration variable"
+msgstr "ਸੰਰਚਨਾ ਮੁੱਲ ਲਵੋ"
+
+#: gphoto2/shell.c:153
+msgid "name"
+msgstr "ਨਾਂ"
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+#, fuzzy
+msgid "Set configuration variable"
+msgstr "ਸੰਰਚਨਾ ਮੁੱਲ ਦਿਓ"
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+msgid "name=value"
+msgstr "name=value"
+
+#: gphoto2/shell.c:155
+#, fuzzy
+msgid "Set configuration variable index"
+msgstr "ਸੰਰਚਨਾ ਮੁੱਲ ਦਿਓ"
+
+#: gphoto2/shell.c:155
+#, fuzzy
+msgid "name=valueindex"
+msgstr "name=value"
+
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "ਇੱਕ ਇੱਕਲੀ ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਕਰੋ"
+
+#: gphoto2/shell.c:158
+msgid "Capture a single image"
+msgstr "ਇੱਕ ਇੱਕਲੀ ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਕਰੋ"
+
+#: gphoto2/shell.c:159
+#, fuzzy
+msgid "Capture a single image and download it"
+msgstr "ਇੱਕ ਇੱਕਲੀ ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਕਰੋ"
+
+#: gphoto2/shell.c:160
+#, fuzzy
+msgid "Capture a preview image"
+msgstr "ਇੱਕ ਇੱਕਲੀ ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਕਰੋ"
+
+#: gphoto2/shell.c:161
+#, fuzzy
+msgid "Wait for an event"
+msgstr "ਕੈਮਰੇ ਵਲੋਂ ਜਵਾਬ ਦੀ ਉਡੀਕ"
+
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
+msgid "count or seconds"
+msgstr ""
+
+#: gphoto2/shell.c:162
+msgid "Wait for images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:163
+msgid "Wait for events and images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "ਗਲਤ ਕਮਾਂਡ ਹੈ।"
 
-#: gphoto2/shell.c:434
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "ਕਮਾਂਡ '%s' ਲਈ ਇੱਕ ਮੁੱਲ ਦੀ ਲੋੜ ਹੈ।"
 
-#: gphoto2/shell.c:487
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "ਗਲਤ ਮਾਰਗ ਹੈ।"
 
-#: gphoto2/shell.c:533
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "ਘਰ ਡਾਇਰੈਕਟਰੀ ਨਹੀਂ ਮਿਲੀ ਸਕੀ ਹੈ।"
 
-#: gphoto2/shell.c:541
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "ਸਥਾਨਕ ਡਾਇਰੈਕਟਰੀ '%s' ਨੂੰ ਬਦਲਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ ਹੈ।"
 
-#: gphoto2/shell.c:544
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "ਸਥਾਨਕ ਡਾਇਰੈਕਟਰੀ ਹੁਣ '%s' ਹੈ।"
 
-#: gphoto2/shell.c:582
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "ਰਿਮੋਟ ਡਾਇਰੈਕਟਰੀ ਹੁਣ '%s' ਹੈ।"
 
-#: gphoto2/shell.c:738
+#: gphoto2/shell.c:874
+#, c-format
+msgid "set-config needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:895
+#, c-format
+msgid "set-config-value needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:916
+#, c-format
+msgid "set-config-index needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
 msgstr ""
 
-#: gphoto2/shell.c:745
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "\"%s\" ਲਈ ਸਹਾਇਤਾ:"
 
-#: gphoto2/shell.c:747
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "ਵਰਤੋਂ:"
 
-#: gphoto2/shell.c:750
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "ਵੇਰਵਾ:"
 
-#: gphoto2/shell.c:752
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* ਬਰੈਕਟਾਂ [] ਵਿੱਚ ਦਿੱਤੇ ਮੁੱਲ ਚੋਣਵੇਂ ਹਨ"
 
-#: gphoto2/shell.c:773
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "ਉਪਲੱਬਧ ਕਮਾਂਡਾਂ:"
 
-#: gphoto2/shell.c:778
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr "ਇੱਕ ਖਾਸ ਕਮਾਂਡ ਤੋਂ ਸਹਾਇਤਾ ਪ੍ਰਾਪਤ ਕਰਨ ਲਈ, ਲਿਖੋ 'help command-name'।"
 
-#~ msgid "There is %d file in folder '%s'.\n"
-#~ msgid_plural "There are %d files in folder '%s'.\n"
-#~ msgstr[0] "'%2$s' ਫੋਲਡਰ ਵਿੱਚ %1$d ਫਾਇਲ ਹੈ।\n"
-#~ msgstr[1] "'%2$s' ਫੋਲਡਰ ਵਿੱਚ %1$d ਫਾਇਲਾਂ ਹਨ।\n"
+#, fuzzy, c-format
+#~ msgid "There are no folders in folder '%s'."
+#~ msgstr "ਫੋਲਡਰ '%s' ਵਿੱਚ ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਹੈ।"
 
-#~ msgid "Delete selected files on camera  : %s\n"
-#~ msgstr "ਕੈਮਰੇ ਤੋਂ ਚੁਣੀਆਂ ਫਾਇਲਾਂ ਹਟਾਓ  : %s\n"
+#, fuzzy, c-format
+#~ msgid "There is one folder in folder '%s':"
+#~ msgstr "'%2$s' ਫੋਲਡਰ ਵਿੱਚ %1$d ਫੋਲਡਰ ਹੈ।\n"
 
-#~ msgid "FILENAME"
-#~ msgstr "FILENAME"
+#, fuzzy, c-format
+#~ msgid "There are %i folders in folder '%s':"
+#~ msgstr "ਫੋਲਡਰ '%s' ਵਿੱਚ ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਹੈ।"
 
-#~ msgid "SPEED"
-#~ msgstr "SPEED"
+#, fuzzy, c-format
+#~ msgid "There is one file in folder '%s':"
+#~ msgstr "ਫੋਲਡਰ '%s' ਵਿੱਚ ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਹੈ।\n"
 
-#~ msgid "MODEL"
-#~ msgstr "MODEL"
+#, fuzzy, c-format
+#~ msgid "There are %i files in folder '%s':"
+#~ msgstr "ਫੋਲਡਰ '%s' ਵਿੱਚ ਕੋਈ ਫਾਇਲ ਨਹੀਂ ਹੈ।"
 
-#~ msgid "USBIDs"
-#~ msgstr "USBIDs"
+#, c-format
+#~ msgid "  Name:        '%s'\n"
+#~ msgstr "  ਨਾਂ:           '%s'\n"
 
-#~ msgid "Wait for event from camera"
-#~ msgstr "ਕੈਮਰੇ ਵਲੋਂ ਜਵਾਬ ਦੀ ਉਡੀਕ"
+#, fuzzy
+#~ msgid "Specify a filename"
+#~ msgstr "ਕੀ ਨਵਾਂ ਫਾਇਲ ਨਾਂ ਦੇਣਾ ਹੈ? [y|n] "
 
-#~ msgid "COUNT"
-#~ msgstr "COUNT"
+#, fuzzy
+#~ msgid "Display camera abilities"
+#~ msgstr "ਕੈਮਰਾ/ਡਰਾਇਵਰ ਯੋਗਤਾ ਵੇਖਾਓ"
 
-#~ msgid "SECONDS"
-#~ msgstr "SECONDS"
+#, fuzzy
+#~ msgid "List the configuration tree"
+#~ msgstr "ਸੰਰਚਨਾ ਲੜੀ ਵੇਖਾਓ"
 
-#~ msgid "DIRNAME"
-#~ msgstr "DIRNAME"
+#, fuzzy
+#~ msgid "Capture a movie "
+#~ msgstr "ਇੱਕ ਫਿਲਮ ਲਵੋ"
 
-#~ msgid "RANGE"
-#~ msgstr "RANGE"
+#~ msgid "Show info"
+#~ msgstr "ਜਾਣਕਾਰੀ ਵੇਖਾਓ"
 
-#~ msgid "Get metadata given in range"
-#~ msgstr "ਰੇਜ਼ ਵਿੱਚ ਮੇਟਾਡਾਟਾ ਲਵੋ"
+#, fuzzy
+#~ msgid "Camera driver manual"
+#~ msgstr "ਕੈਮਰਾ ਡਰਾਇਵਰ ਦਸਤਾਵੇਜ਼ ਵੇਖਾਓ"
 
-#~ msgid "Get all metadata from folder"
-#~ msgstr "ਫੋਲਡਰ ਤੋਂ ਸਭ ਮੇਟਾ-ਡਾਟਾ ਲਵੋ"
+#, fuzzy
+#~ msgid "About the camera driver"
+#~ msgstr "ਕੈਮਰਾ ਮਾਡਲ ਬਾਰੇ:"
 
-#~ msgid "Upload metadata for file"
-#~ msgstr "ਫਾਇਲ ਤੋਂ ਮੇਟਾਡਾਟਾ ਅੱਪਲੋਡ ਕਰੋ"
+#~ msgid "Could not close camera connection."
+#~ msgstr "ਕੈਮਰਾ ਕੁਨੈਕਸ਼ਨ ਬੰਦ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ ਹੈ।"
 
-#~ msgid "Specify a filename or filename pattern"
-#~ msgstr "ਇੱਕ ਫਾਇਲ ਨਾਂ ਜਾਂ ਫਾਇਲ-ਨਾਂ ਪੈਟਰਨ ਦਿਓ"
+#, c-format
+#~ msgid "Sleeping for %d second(s)...\n"
+#~ msgstr "%d ਸਕਿੰਟ ਲਈ ਸਲੀਪ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ...\n"
 
-#~ msgid "FILENAME_PATTERN"
-#~ msgstr "FILENAME_PATTERN"
+#, fuzzy
+#~ msgid "model"
+#~ msgstr "ਮਾਡਲ"
 
-#~ msgid "FOLDER"
-#~ msgstr "FOLDER"
+#~ msgid "filename"
+#~ msgstr "ਫਾਇਲ ਨਾਂ"
 
-#~ msgid "Common options"
-#~ msgstr "ਆਮ ਚੋਣਾਂ"
+#, c-format
+#~ msgid "Usage:\n"
+#~ msgstr "ਵਰਤੋਂ:\n"
 
-#~ msgid "Miscellaneous options (unsorted)"
-#~ msgstr "ਫੁਟਕਲ ਚੋਣਾਂ (ਨਾ-ਲੜੀਬੱਧ)"
-
-#~ msgid "Get information on software and host system (not from the camera)"
-#~ msgstr "ਸਾਫਵੇਅਰ ਅਤੇ ਹੋਸਟ ਸਿਸਟਮ ਤੋਂ ਜਾਣਕਾਰੀ ਲਵੋ (ਕੈਮਰੇ ਤੋਂ ਨਹੀਂ)"
-
-#~ msgid "Specify the camera to use"
-#~ msgstr "ਵਰਤਣ ਲਈ ਕੈਮਰਾ ਦਿਓ"
-
-#~ msgid "Camera and software configuration"
-#~ msgstr "ਕੈਮਰਾ ਅਤੇ ਸਾਫਟਵੇਅਰ ਸੰਰਚਨਾ"
-
-#~ msgid "Capture an image from or on the camera"
-#~ msgstr "ਕੈਮਰੇ ਤੋਂ ਇੱਕ ਚਿੱਤਰ ਲਵੋ"
-
-#~ msgid "Upload a file"
-#~ msgstr "ਇੱਕ ਫਾਇਲ ਅੱਪਲੋਡ ਕਰੋ"
-
-#~ msgid "Create Directory"
-#~ msgstr "ਡਾਇਰੈਕਟਰੀ ਬਣਾਓ"
-
-#~ msgid "Remove Directory"
-#~ msgstr "ਡਾਇਰੈਕਟਰੀ ਹਟਾਓ"
-
-#~ msgid "List configuration variables"
-#~ msgstr "ਸੰਰਚਨਾਯੋਗ ਮੁੱਲ ਲਿਸਟ ਕਰੋ"
-
-#~ msgid "name=value"
-#~ msgstr "name=value"
-
-#~ msgid "Capture a single image"
-#~ msgstr "ਇੱਕ ਇੱਕਲੀ ਤਸਵੀਰ ਪ੍ਰਾਪਤ ਕਰੋ"
+#, c-format
+#~ msgid "%-38s %s\n"
+#~ msgstr "%-38s %s\n"
 
 #~ msgid "[name]"
 #~ msgstr "[ਨਾਂ]"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,23 +7,24 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.9\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-11-18 22:19+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2015-11-19 18:00+0100\n"
 "Last-Translator: Jakub Bogusz <qboosh@pld-linux.org>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
 "Language: pl\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Liczba plików w folderze '%s': %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
@@ -31,12 +32,12 @@ msgstr[0] "Jest %d folder w folderze '%s'.\n"
 msgstr[1] "Są %d foldery w folderze '%s'.\n"
 msgstr[2] "Jest %d folderów w folderze '%s'.\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Nie ma plików w folderze '%s'.\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
@@ -44,111 +45,111 @@ msgstr[0] "Jest %d plik w folderze '%s'.\n"
 msgstr[1] "Są %d pliki w folderze '%s'.\n"
 msgstr[2] "Jest %d plików w folderze '%s'.\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Informacje o pliku '%s' (folder '%s'):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Plik:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Brak dostępnych.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Typ MIME:    '%s'\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Rozmiar:     %lu bajt(ów)\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Szerokość:   %i piksel(i)\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Wysokość:    %i piksel(i)\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Ściągnięto:  %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "tak"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "nie"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Uprawnienia: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "odczyt/usuwanie"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "odczyt"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "usuwanie"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "brak"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Czas:        %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Miniaturka:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Dane dźwiękowe:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Typ MIME:   '%s'\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Rozmiar:    %lu bajt(ów)\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Ściągnięto: %s\n"
@@ -170,46 +171,46 @@ msgstr "Znacznik"
 msgid "Value"
 msgstr "Wartość"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Dane EXIF zawierają miniaturkę (%i bajtów)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 zostało skompilowane bez obsługi EXIF."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Liczba obsługiwanych aparatów: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Obsługiwane aparaty:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (TESTOWO)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (EKSPERYMENTALNIE)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Znalezione urządzenia: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -218,155 +219,169 @@ msgstr ""
 "Ścieżka                          Opis\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Model"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Port"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Możliwości aparatu               : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Obsługa portu szeregowego        : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Obsługa USB                      : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Obsługiwane prędkości przesyłania:\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Możliwość nagrywania             :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Zdjęcia\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Filmy\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Dźwięk\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Podgląd\n"
 
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr "                                 : Wyzwolenie zdjęcia\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : Ten sterownik nie obsługuje nagrywania\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : Ten sterownik nie obsługuje nagrywania\n"
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Obsługa konfiguracji             : %s\n"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Usuwanie wybranych plików        : %s\n"
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Usuwanie wszystkich plików       : %s\n"
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Podgląd plików (miniaturek)      : %s\n"
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Przesyłanie plików do aparatu    : %s\n"
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Porty muszą być w postaci 'serial:/dev/ttyS0' lub 'usb:', ale '%s' nie zawiera dwukropka, więc spróbuję zgadnąć, co to miało znaczyć."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Porty muszą być w postaci 'serial:/dev/ttyS0' lub 'usb:', ale '%s' nie "
+"zawiera dwukropka, więc spróbuję zgadnąć, co to miało znaczyć."
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Podany port ('%s') nie został odnaleziony. Proszę podać jeden z portów znajdywanych przez 'gphoto2 --list-ports' i upewnić się, że pisownia jest poprawna (tzn. z przedrostkiem 'serial:' lub 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Podany port ('%s') nie został odnaleziony. Proszę podać jeden z portów "
+"znajdywanych przez 'gphoto2 --list-ports' i upewnić się, że pisownia jest "
+"poprawna (tzn. z przedrostkiem 'serial:' lub 'usb:')."
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "O sterowniku aparatu:"
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Opis aparatu:"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Podręcznik do aparatu:"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Można podać prędkości tylko dla portów szeregowych."
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "Port OS/2 wykonał Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:907
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
@@ -379,298 +394,337 @@ msgstr ""
 "\n"
 "Ta wersja gphoto2 używa następujących wersji oprogramowania i opcji:\n"
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Nie udało się otworzyć 'movie.mjpg'."
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Pobieranie ramek podglądu jako filmu do '%s'. Aby przerwać, proszę nacisnąć Ctrl-C.\n"
+msgstr ""
+"Pobieranie ramek podglądu jako filmu do '%s'. Aby przerwać, proszę nacisnąć "
+"Ctrl-C.\n"
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr "Pobieranie ramek podglądu jako filmu do '%s' przez sekund: %d.\n"
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Pobieranie ramek podglądu (ramek: %d) jako filmu do '%s'.\n"
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Błąd pobierania filmu... zakończenie."
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Błąd pobierania filmu... nieobsługiwany typ MIME '%s'."
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Naciśnięto Ctrl-C... zakończenie.\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Nagrywanie filmu zakończone (klatek: %d)\n"
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Oczekiwanie na zdarzenie z aparatu. Aby przerwać, proszę nacisnąć Ctrl-C.\n"
+msgstr ""
+"Oczekiwanie na zdarzenie z aparatu. Aby przerwać, proszę nacisnąć Ctrl-C.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
-msgstr "Oczekiwanie na otrzymanie %d klatek z aparatu. Aby przerwać, proszę nacisnąć Ctrl-C.\n"
+msgstr ""
+"Oczekiwanie na otrzymanie %d klatek z aparatu. Aby przerwać, proszę nacisnąć "
+"Ctrl-C.\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Oczekiwanie przez %d milisekund na zdarzenia z aparatu. Aby przerwać, proszę nacisnąć Ctrl-C.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Oczekiwanie przez %d milisekund na zdarzenia z aparatu. Aby przerwać, proszę "
+"nacisnąć Ctrl-C.\n"
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Oczekiwanie przez %d sekund na zdarzenia z aparatu. Aby przerwać, proszę nacisnąć Ctrl-C.\n"
-
-#: gphoto2/actions.c:1121
-#, c-format
-msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
-msgstr "Oczekiwanie na %d zdarzeń z aparatu. Aby przerwać, proszę nacisnąć Ctrl-C.\n"
+msgstr ""
+"Oczekiwanie przez %d sekund na zdarzenia z aparatu. Aby przerwać, proszę "
+"nacisnąć Ctrl-C.\n"
 
 #: gphoto2/actions.c:1125
 #, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
-msgstr "Oczekiwanie na zdarzenie %s z aparatu. Aby przerwać, proszę nacisnąć Ctrl-C.\n"
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Oczekiwanie na %d zdarzeń z aparatu. Aby przerwać, proszę nacisnąć Ctrl-C.\n"
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Oczekiwanie na zdarzenie %s z aparatu. Aby przerwać, proszę nacisnąć Ctrl-"
+"C.\n"
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "napotkano zdarzenie, kończenie oczekiwania!\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "napotkano zdarzenie, kończenie oczekiwania!\n"
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Nie udało się ustawić folderu."
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Nie udało się pobrać obrazu."
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "libcanon.so z błędami?"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Nie udało się usunąć obrazu."
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
-msgstr "Pobieranie informacji o nośniku nie jest obsługiwane przez ten aparat.\n"
+msgstr ""
+"Pobieranie informacji o nośniku nie jest obsługiwane przez ten aparat.\n"
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Odczyt i zapis"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Tylko odczyt"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Tylko odczyt z usuwaniem"
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "Stały ROM"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "Wymienialny ROM"
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "Stały RAM"
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "Wymienialny RAM"
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Nieokreślony"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Ogólny płaski"
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Ogólny hierarchiczny"
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Rozkład aparatu (DCIM)"
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Nadpisywanie id producenta/produktu USB 0x%x/0x%x przez 0x%x/0x%x"
 
-#: gphoto2/actions.c:1435
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "ZAWSZE NALEŻY DOŁĄCZYĆ NASTĘPUJĄCE LINIE PRZY WYSYŁANIU KOMUNIKATÓW DIAGNOSTYCZNYCH NA LISTĘ DYSKUSYJNĄ:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"ZAWSZE NALEŻY DOŁĄCZYĆ NASTĘPUJĄCE LINIE PRZY WYSYŁANIU KOMUNIKATÓW "
+"DIAGNOSTYCZNYCH NA LISTĘ DYSKUSYJNĄ:"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s zostało skompilowane z następującymi opcjami:"
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s nie występuje w drzewie konfiguracji."
 
-#: gphoto2/actions.c:1630
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Nie udało się odtworzyć wartości widgetu tekstowego %s."
 
-#: gphoto2/actions.c:1647
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Nie udało się odtworzyć wartości widgetu przedziału %s."
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Nie udało się odtworzyć wartości widgetu przełącznika %s."
 
-#: gphoto2/actions.c:1671
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Nie udało się odtworzyć wartości widgetu daty/czasu %s."
 
-#: gphoto2/actions.c:1680
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "Przy ustawianiu 'now' oznacza czas bieżący.\n"
 
-#: gphoto2/actions.c:1702
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Nie udało się odtworzyć wartości widgetu pojedynczego wyboru %s."
 
-#: gphoto2/actions.c:1746
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "Właściwość %s jest tylko do odczytu."
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Nie udało się ustawić wartości widgetu tekstowego %s na %s."
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Przekazana wartość %s nie jest wartością zmiennoprzecinkową."
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "Przekazana wartość %f nie leży w oczekiwanym przedziale %f - %f."
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Nie udało się ustawić wartości widgetu przedziału %s na %f."
 
-#: gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "wyłączone"
 
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "fałsz"
 
-#: gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "włączone"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "prawda"
 
-#: gphoto2/actions.c:1802 gphoto2/actions.c:2039
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Przekazana wartość %s nie jest poprawną wartością przełącznika."
 
-#: gphoto2/actions.c:1808 gphoto2/actions.c:2045
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Nie udało się ustawić wartości %s widgetu przełącznika %s."
 
-#: gphoto2/actions.c:1820
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "teraz"
 
-#: gphoto2/actions.c:1832 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
-msgstr "Przekazana wartość %s nie jest prawidłowym czasem ani liczbą całkowitą."
+msgstr ""
+"Przekazana wartość %s nie jest prawidłowym czasem ani liczbą całkowitą."
 
-#: gphoto2/actions.c:1840 gphoto2/actions.c:2065
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Nie udało się ustawić nowego czasu widgetu daty/czasu %s na %s."
 
-#: gphoto2/actions.c:1887 gphoto2/actions.c:1951 gphoto2/actions.c:2095
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Opcji %s nie znaleziono na liście wyboru."
 
-#: gphoto2/actions.c:1895 gphoto2/actions.c:2103
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Widget %s nie jest konfigurowalny."
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:1970 gphoto2/actions.c:2110
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
-msgstr "Nie udało się ustawić nowej wartości konfiguracji %s dla wpisu konfiguracji %s."
+msgstr ""
+"Nie udało się ustawić nowej wartości konfiguracji %s dla wpisu konfiguracji "
+"%s."
 
-#: gphoto2/actions.c:1963
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "Kontrolka %s nie ma listy numerowanych opcji. Należy użyć --set-config-value."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"Kontrolka %s nie ma listy numerowanych opcji. Należy użyć --set-config-value."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Zły numer pliku. Podano %i, a jest tylko %i plików dostępnych w '%s' i podkatalogach. Proszę uzyskać prawidłowy numer pliku z listy plików."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Zły numer pliku. Podano %i, a jest tylko %i plików dostępnych w '%s' i "
+"podkatalogach. Proszę uzyskać prawidłowy numer pliku z listy plików."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -679,25 +733,31 @@ msgstr "Nie ma plików w folderze '%s'."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
 msgstr "Zły numer pliku. Podano %i, ale jest tylko 1 plik dostępny w '%s'."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Zły numer pliku. Podano %i, a jest tylko %i plików dostępnych w '%s'. Proszę uzyskać prawidłowy numer pliku z listy plików."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Zły numer pliku. Podano %i, a jest tylko %i plików dostępnych w '%s'. Proszę "
+"uzyskać prawidłowy numer pliku z listy plików."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Błąd ***               \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Proszę nacisnąć dowolny klawisz w celu kontynuacji.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Zbyt mało pamięci."
@@ -706,206 +766,213 @@ msgstr "Zbyt mało pamięci."
 msgid "Operation cancelled"
 msgstr "Operacja anulowana"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Kontynuuj"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Anuluj"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Błąd"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Nie udało się ustawić konfiguracji:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Wyjście"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Powrót"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Czas: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Wartość "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Tak"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Nie"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
-msgstr "Dopełnianie zerami liczb w nazwach plików jest możliwe tylko przy użyciu %%n."
+msgstr ""
+"Dopełnianie zerami liczb w nazwach plików jest możliwe tylko przy użyciu %%n."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "Nie można użyć dopełniania zerami %%n bez wartości precyzji!"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Nazwa pliku dostarczona przez aparat ('%s') nie zawiera przyrostka!"
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Nieprawidłowy format '%s' (błąd na pozycji %i)."
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Pomijanie istniejącego pliku %s\n"
 
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Plik %s istnieje. Nadpisać? [y|n] "
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Określić nową nazwę pliku? [y|n] "
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Nowa nazwa pliku: "
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Zapisywanie pliku jako %s\n"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Brak uprawnień"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Nie udało się wyzwolić zrobienia zdjęcia."
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Nowy plik jest w miejscu %s%s%s w aparacie\n"
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Zachowywanie pliku %s%s%s na aparacie\n"
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Usuwanie pliku %s%s%s z aparatu\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "Zdarzenie FOLDER_ADDED %s/%s w trakcie oczekiwania, zignorowano.\n"
 
 #: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "Zdarzenie FOLDER_ADDED %s/%s w trakcie oczekiwania, zignorowano.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Zdarzenie UNKNOWN %s w trakcie oczekiwania, zignorowano.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
-msgstr "Nieznany rodzaj zdarzenia %d w trakcie oczekiwania na lampę, zignorowano.\n"
+msgstr ""
+"Nieznany rodzaj zdarzenia %d w trakcie oczekiwania na lampę, zignorowano.\n"
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Nie udało się pobrać możliwości?"
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Tryb zdjęć okresowych włączony (odstęp: %ds).\n"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Oczekiwanie na SIGUSR1 w celu zrobienia zdjęcia.\n"
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Tryb bulb włączony (czas ekspozycji: %ds).\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Robienie klatki #%d...\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Robienie klatki #%d/%d...\n"
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Nie udało się ustawić zdjęcia z lampą, wynik %d."
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Nie udało się zakończyć zdjęcia (tryb bulb)."
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Nie udało się wyzwolić zrobienia zdjęcia."
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Nie udało się zrobić zdjęcia."
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Zdjęcie nie udało się (problem z auto-focusem?)...\n"
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Nie udało się zrobić zdjęcia."
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Oczekiwanie %ld sekund na następne zdjęcie...\n"
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Obudzony przez SIGUSR1...\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "niezasypianie (%ld sekund poza terminem)\n"
 
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "BŁĄD: "
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -914,12 +981,12 @@ msgstr ""
 "\n"
 "Przerywanie...\n"
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Przerwano.\n"
 
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -928,21 +995,26 @@ msgstr ""
 "\n"
 "Anulowanie...\n"
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Należy użyć składni a:b=c:d, aby potraktować dowolne urządzenie USB wykryte jako a:b jako c:d. a b c d powinny być liczbami szesnastkowymi zaczynającymi się od '0x'.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Należy użyć składni a:b=c:d, aby potraktować dowolne urządzenie USB wykryte "
+"jako a:b jako c:d. a b c d powinny być liczbami szesnastkowymi zaczynającymi "
+"się od '0x'.\n"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 zostało skompilowane bez obsługi CDK."
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operacja anulowana.\n"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -951,7 +1023,7 @@ msgstr ""
 "*** Błąd: nie znaleziono aparatu. ***\n"
 "\n"
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -960,7 +1032,7 @@ msgstr ""
 "*** Błąd (%i: '%s') ***        \n"
 "\n"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -977,402 +1049,409 @@ msgstr ""
 "uruchomić gphoto2 w sposób następujący:\n"
 "\n"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
 "\n"
 msgstr ""
-"Proszę upewnić się, że argumenty są wystarczająco zabezpieczone cudzysłowami.\n"
+"Proszę upewnić się, że argumenty są wystarczająco zabezpieczone "
+"cudzysłowami.\n"
 "\n"
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Wypisanie pełnego opisu używania programu"
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Wypisanie krótkiego opisu używania programu"
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Włączenie diagnostyki"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Ustawienie poziomu diagnostyki [error|debug|data|all]"
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Nazwa pliku do zapisu informacji diagnostycznych"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "PLIK"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Ciche wyjście (domyślnie=szczegółowe)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Skrypt do wywoływania po ściągnięciu danych, zdjęciach itp."
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Określenie portu urządzenia"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Określenie prędkości transmisji szeregowej"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "PRĘDKOŚĆ"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Określenie modelu aparatu"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODEL"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(tylko tryb expert) Nadpisanie ID USB"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBID"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Wyświetlenie wersji i zakończenie"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Wypisanie listy obsługiwanych modeli aparatów"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Wypisanie listy obsługiwanych urządzeń portów"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Wyświetlenie możliwości aparatu/sterownika wg bazy danych libgphoto2"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Konfiguracja"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Wypisanie drzewa konfiguracji"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Zrzut pełnego drzewa konfiguracji"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Pobranie wartości z konfiguracji"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Ustawienie wartości lub pozycji wyboru w konfiguracji"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Ustawienie numeru wartości wyboru w konfiguracji"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Ustawienie wartości w konfiguracji"
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Reset portu urządzenia"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Zachowanie zdjęć na aparacie po wykonaniu"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr "Zachowanie zdjęć RAW w aparacie po wykonaniu"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Usunięcie zdjęć z aparatu po wykonaniu"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Oczekiwanie na zdarzenia z aparatu"
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr "COUNT, SECONDS, MILLISECONDS lub MATCHSTRING"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Oczekiwanie na zdarzenia z aparatu i ściągnięcie nowych zdjęć"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Zrobienie szybkiego podglądu"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr "Pokazanie szybkiego podglądu jako ASCII Art"
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Ustawienie czasu ekspozycji w trybie bulb w sekundach"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SEKUNDY"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Ustawienie liczby klatek do zrobienia (domyślnie=nieskończoność)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "LICZBA"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Ustawienie odstępu między zdjęciami w sekundach"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Przywracanie odstępu między zdjęciami po sygnale (domyślnie=nie)"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Zrobienie zdjęcia"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Wyzwolenie zrobienia zdjęcia"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Zrobienie zdjęcia i ściągnięcie go"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Nagranie filmu"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "LICZBA lub SEKUNDY"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Nagranie dźwięku"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Oczekiwanie na zwolnienie migawki aparatu i ściągnięcie"
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr "Wyzwolenie zrobienia zdjęcia"
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Wypisanie listy folderów w folderze"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Wypisanie listy plików w folderze"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Utworzenie katalogu"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "KATALOG"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Usunięcie katalogu"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Wyświetlenie liczby plików"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Pobranie plików z podanego przedziału"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "PRZEDZIAŁ"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Pobranie wszystkich plików z folderu"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Pobranie miniaturek z podanego przedziału"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Pobranie wszystkich miniaturek z folderu"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Pobranie metadanych z podanego przedziału"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Pobranie wszystkich metadanych z folderu"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Przesłanie do aparatu metadanych dla pliku"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Pobranie surowych danych z podanego przedziału"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Pobranie wszystkich surowych danych z folderu"
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Pobranie danych dźwiękowych z podanego przedziału"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Pobranie wszystkich danych dźwiękowych z folderu"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Usunięcie plików z podanego przedziału"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Usunięcie wszystkich plików z folderu (domyślnie --no-recurse)"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Przesłanie pliku do aparatu"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Określenie nazwy pliku lub wzorca nazwy pliku"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "WZORZEC_PLIKU"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Określenie folderu aparatu (domyślny=\"/\")"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "FOLDER"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Rekurencja (domyślne przy ściąganiu)"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Bez rekurencji (domyślne przy usuwaniu)"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Przetwarzanie tylko nowych plików"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Nadpisywanie plików bez pytania"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Pomijanie istniejących plików"
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Wysłanie pliku na standardowe wyjście"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Wypisanie rozmiaru pliku przed danymi"
 
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Wypisanie listy wykrytych aparatów"
 
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "Pokazywanie informacji EXIF obrazów JPEG"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
 msgstr "Pokazywanie informacji takich jak szerokość, wysokość i czas migawki"
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr "Pokazanie opisu aparatu"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Pokazanie podręcznika do sterownika aparatu"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "O podręczniku do sterownika aparatu"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Pokazanie informacji o nośniku"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "Powłoka gPhoto"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Opcje wspólne"
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Różnie opcje (kolejność dowolna)"
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
-msgstr "Pobranie informacji o oprogramowaniu i systemie komputera (nie z aparatu)"
+msgstr ""
+"Pobranie informacji o oprogramowaniu i systemie komputera (nie z aparatu)"
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Określenie, którego aparatu używać"
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Konfiguracja aparatu i oprogramowania"
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Zrobienie zdjęcia z lub na aparacie"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Ściąganie, wysyłanie i obróbka plików"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1381,7 +1460,7 @@ msgstr ""
 "%s\n"
 "Identyfikator zdjęcia musi być liczbą większą od zera."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1390,7 +1469,7 @@ msgstr ""
 "%s\n"
 "Identyfikator zdjęcia %i jest zbyt duży."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1399,7 +1478,7 @@ msgstr ""
 "%s\n"
 "Zakresy muszą być oddzielone znakiem ','."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1408,7 +1487,7 @@ msgstr ""
 "%s\n"
 "Zakresy muszą zaczynać się od liczby."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1417,221 +1496,232 @@ msgstr ""
 "%s\n"
 "Oczekiwano znaku '%c'."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"Przedziały zmniejszające się nie są dopuszczalne. Podano przedział od %i do %i."
+"Przedziały zmniejszające się nie są dopuszczalne. Podano przedział od %i do "
+"%i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Błąd (%i: '%s') ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Przejście do katalogu w aparacie"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "katalog"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Przejście do katalogu na dysku lokalnym"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Wyjście z powłoki gPhoto"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Ściągnięcie pliku"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[katalog/]plik"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Przesłanie pliku do aparatu"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Ściągnięcie miniaturki"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Ściągnięcie surowych danych"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Usunięcie"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Utworzenie katalogu"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Usunięcie katalogu"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Wyświetlenie składni polecenia"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[polecenie]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Wypisanie listy zawartości bieżącego katalogu"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[katalog/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Wypisanie zmiennych w konfiguracji"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Pobranie zmiennej z konfiguracji"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "nazwa"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Ustawienie zmiennej w konfiguracji"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "nazwa=wartość"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Ustawienie numeru zmiennej w konfiguracji"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "nazwa=numer_wartości"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Wyzwolenie zrobienia zdjęcia"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Zrobienie pojedynczego zdjęcia"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Zrobienie pojedynczego zdjęcia i ściągnięcie go"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Zrobienie podglądu zdjęcia"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Oczekiwanie na zdarzenie"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "liczba zdarzeń lub sekund"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Oczekiwanie na wykonanie i ściągnięcie zdjęć"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Oczekiwanie na zdarzenia oraz wykonanie i ściągnięcie zdjęć"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Nieprawidłowe polecenie."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Polecenie '%s' wymaga argumentu."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Nieprawidłowa ścieżka."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Nie udało się odnaleźć katalogu domowego."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Nie udało się zmienić katalogu domowego na '%s'."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Lokalny katalog zmieniony na '%s'."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Zdalny katalog zmieniony na '%s'."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config wymaga drugiego argumentu.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "set-config-value wymaga drugiego argumentu.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "set-config-index wymaga drugiego argumentu.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
 msgstr "Nie znaleziono polecenia '%s'. 'help' pokaże listę dostępnych poleceń."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Pomoc dla \"%s\":"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Składnia:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Opis:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Argumenty w nawiasach [] są opcjonalne"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Dostępne polecenia:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Aby uzyskać pomoc dla danego polecenia, należy napisać 'help nazwa-polecenia'."
+msgstr ""
+"Aby uzyskać pomoc dla danego polecenia, należy napisać 'help nazwa-"
+"polecenia'."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Wyzwolenie zrobienia zdjęcia"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,146 +8,147 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.9\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-11-18 22:19+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2015-12-28 16:17-0200\n"
 "Last-Translator: Fabrício Godoy <skarllot@gmail.com>\n"
-"Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge.net>\n"
+"Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
+"net>\n"
 "Language: pt_BR\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Número de arquivos na pasta \"%s\": %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "Há %d pasta na pasta \"%s\".\n"
 msgstr[1] "Há %d pastas na pasta \"%s\".\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Não há nenhum arquivo na pasta \"%s\".\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "Há %d arquivo na pasta \"%s\".\n"
 msgstr[1] "Há %d arquivos na pasta \"%s\".\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Informações sobre o arquivo \"%s\" (pasta \"%s\"):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Arquivo:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Nenhum disponível.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Tipo MIME:   \"%s\"\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Tamanho:     %lu byte(s)\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Largura:     %i pixel(s)\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Altura:      %i pixel(s)\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Baixados:    %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "sim"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "não"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Permissões: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "ler/excluir"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "ler"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "excluir"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "nenhum"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Hora:        %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Miniatura:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Dados de áudio:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Tipo MIME:  \"%s\"\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Tamanho:    %lu byte(s)\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Baixados:   %s\n"
@@ -169,46 +170,46 @@ msgstr "Etiqueta"
 msgid "Value"
 msgstr "Valor"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Dados EXIF contém uma miniatura (%i bytes)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 foi compilado sem suporte a EXIF."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Quantidade de câmeras que há suporte: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Câmeras que há suporte:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (EM TESTE)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (EXPERIMENTAL)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Disp. encontrados: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -217,155 +218,168 @@ msgstr ""
 "Caminho                          Descrição\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Modelo"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Porta"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Habilidades para a câmera        : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Suporte a porta serial           : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Suporte a USB                    : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Vel. de transf. permitidas       :\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Escolhas de captura              :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Imagem\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Vídeo\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Áudio\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Visualização\n"
 
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr "                                 : Disparo de captura\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
 msgstr "                                 : Driver sem suporte a captura\n"
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Suporte a configuração           : %s\n"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Excluir arquivos sel. na câmera  : %s\n"
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Excluir todos arquivos na câmera : %s\n"
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Suporte a miniaturas             : %s\n"
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Suporte a envio de arquivos      : %s\n"
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Portas deve parecer-se com \"serial:/dev/ttyS0\" ou \"usb:\", mas \"%s\" está com um dois-pontos faltando, então eu adivinharei o quê você quer dizer."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Portas deve parecer-se com \"serial:/dev/ttyS0\" ou \"usb:\", mas \"%s\" "
+"está com um dois-pontos faltando, então eu adivinharei o quê você quer dizer."
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "A porta especificada (\"%s\") não foi localizada. Por favor, especifique uma das portas localizadas pelo \"gphoto2 --list-ports\" e tenha certeza que está escrevendo corretamente (com prefixo \"serial:\" ou \"usb:\")."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"A porta especificada (\"%s\") não foi localizada. Por favor, especifique uma "
+"das portas localizadas pelo \"gphoto2 --list-ports\" e tenha certeza que "
+"está escrevendo corretamente (com prefixo \"serial:\" ou \"usb:\")."
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "Sobre o driver da câmera:"
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Resumo da câmera:"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Manual da câmera:"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Você só pode especificar velocidades para portas seriais."
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "portado para OS/2 por Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:907
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
@@ -376,300 +390,340 @@ msgstr ""
 "Geral GNU (GNU General Public License). Para mais informações sobre estas\n"
 "questões, veja os arquivos chamados COPYING.\n"
 "\n"
-"Esta versão do gphoto2 está usando as seguintes versões de software e opções:\n"
+"Esta versão do gphoto2 está usando as seguintes versões de software e "
+"opções:\n"
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Não foi possível abrir \"movie.mjpg\"."
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Capturando quadros de pré-visualização como vídeo em \"%s\". Pressione Ctrl+C para interromper.\n"
+msgstr ""
+"Capturando quadros de pré-visualização como vídeo em \"%s\". Pressione Ctrl"
+"+C para interromper.\n"
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
-msgstr "Capturando quadros de pré-visualização como vídeo em \"%s\" por %d segundos.\n"
+msgstr ""
+"Capturando quadros de pré-visualização como vídeo em \"%s\" por %d "
+"segundos.\n"
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Capturando %d quadros de pré-visualização como vídeo em \"%s\".\n"
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Erro na captura de vídeo... Saindo."
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Erro na captura de vídeo... Tipo MIME \"%s\" não manipulável."
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ctrl+C foi pressionado... Saindo.\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "A captura do filme terminou (%d quadros)\n"
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "Esperando por eventos da câmera. Pressione Ctrl+C para interromper.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
-msgstr "Esperando por %d quadros da câmera. Pressione Ctrl+C para interromper.\n"
+msgstr ""
+"Esperando por %d quadros da câmera. Pressione Ctrl+C para interromper.\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Esperando %d milissegundos por eventos da câmera. Pressione Ctrl+C para interromper.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Esperando %d milissegundos por eventos da câmera. Pressione Ctrl+C para "
+"interromper.\n"
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Esperando %d segundos por eventos da câmera. Pressione Ctrl+C para interromper.\n"
-
-#: gphoto2/actions.c:1121
-#, c-format
-msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
-msgstr "Esperando por %d eventos da câmera. Pressione Ctrl+C para interromper.\n"
+msgstr ""
+"Esperando %d segundos por eventos da câmera. Pressione Ctrl+C para "
+"interromper.\n"
 
 #: gphoto2/actions.c:1125
 #, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
-msgstr "Esperando pelo evento %s da câmera. Pressione Ctrl+C para interromper.\n"
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Esperando por %d eventos da câmera. Pressione Ctrl+C para interromper.\n"
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Esperando pelo evento %s da câmera. Pressione Ctrl+C para interromper.\n"
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "evento encontrado, finalizando espera!\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "evento encontrado, finalizando espera!\n"
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Não foi possível definir a pasta."
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Não foi possível obter a imagem."
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "libcanon.so defeituoso?"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Não foi possível excluir imagem."
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
-msgstr "Não há suporte a obtenção de informações de armazenamento para esta câmera.\n"
+msgstr ""
+"Não há suporte a obtenção de informações de armazenamento para esta câmera.\n"
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Leitura e escrita"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Somente leitura"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Somente leitura com exclusão"
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "ROM fixa"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "ROM removível"
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "RAM fixa"
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "RAM removível"
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Não definido"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Flat genérico"
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Hierárquico genérico"
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Layout da câmera (DCIM)"
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
-msgstr "Sobrescrevendo o ID USB do fornecedor/produto de 0x%x/0x%x para 0x%x/0x%x"
+msgstr ""
+"Sobrescrevendo o ID USB do fornecedor/produto de 0x%x/0x%x para 0x%x/0x%x"
 
-#: gphoto2/actions.c:1435
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "SEMPRE INCLUA AS SEGUINTES LINHAS AO ENVIAR MENSAGENS DE DEPURAÇÃO PARA A LISTA DE DISCUSSÃO:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"SEMPRE INCLUA AS SEGUINTES LINHAS AO ENVIAR MENSAGENS DE DEPURAÇÃO PARA A "
+"LISTA DE DISCUSSÃO:"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s foi compilado com as seguintes opções:"
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s não localizado na árvore de configurações."
 
-#: gphoto2/actions.c:1630
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Falha ao obter o valor do widget de texto %s."
 
-#: gphoto2/actions.c:1647
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Falha ao obter os valores do widget de alcance %s."
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Falha ao obter os valores do widget de faixa %s."
 
-#: gphoto2/actions.c:1671
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Falha ao obter os valores do widget de data e hora %s."
 
-#: gphoto2/actions.c:1680
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "Usar \"agora\" como a data atual ao configurar.\n"
 
-#: gphoto2/actions.c:1702
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Falha ao obter os valores do widget de opção %s."
 
-#: gphoto2/actions.c:1746
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "A propriedade %s é somente leitura."
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Falha ao definir o valor do widget de texto %s para %s."
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "O valor passado %s não é um valor de ponto flutuante."
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "O valor passado %f não está dentro do limite esperado, de %f até %f."
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Falha ao definir o valor do widget de alcance %s para %f."
 
-#: gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "desligado"
 
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "falso"
 
-#: gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "ligado"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "verdadeiro"
 
-#: gphoto2/actions.c:1802 gphoto2/actions.c:2039
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "O valor passado %s não é um valor de alternância válido."
 
-#: gphoto2/actions.c:1808 gphoto2/actions.c:2045
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Falha ao definir os valores %s do widget de alternância %s."
 
-#: gphoto2/actions.c:1820
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "agora"
 
-#: gphoto2/actions.c:1832 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "O valor passado %s não uma hora e nem um inteiro válido."
 
-#: gphoto2/actions.c:1840 gphoto2/actions.c:2065
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Falha ao definir nova hora do widget de data e hora de %s para %s."
 
-#: gphoto2/actions.c:1887 gphoto2/actions.c:1951 gphoto2/actions.c:2095
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "A escolha %s não foi localizada na lista de escolhas."
 
-#: gphoto2/actions.c:1895 gphoto2/actions.c:2103
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "O widget %s não é configurável."
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:1970 gphoto2/actions.c:2110
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
-msgstr "Falha ao definir novo valor de configuração %s para a entrada de configuração %s."
+msgstr ""
+"Falha ao definir novo valor de configuração %s para a entrada de "
+"configuração %s."
 
-#: gphoto2/actions.c:1963
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "O widget %s não tem um índice da lista de escolhas. Use --set-config-value."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"O widget %s não tem um índice da lista de escolhas. Use --set-config-value."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Número de arquivo errado. Você especificou %i, mas há somente %i arquivos disponíveis em \"%s\" ou em suas subpastas. Por favor, primeiro obtenha um número de arquivo válido da lista de arquivos."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Número de arquivo errado. Você especificou %i, mas há somente %i arquivos "
+"disponíveis em \"%s\" ou em suas subpastas. Por favor, primeiro obtenha um "
+"número de arquivo válido da lista de arquivos."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -678,25 +732,34 @@ msgstr "Não há arquivos na pasta \"%s\"."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Número de arquivo errado. Você especificou %i, mas há somente 1 arquivo disponível em \"%s\"."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Número de arquivo errado. Você especificou %i, mas há somente 1 arquivo "
+"disponível em \"%s\"."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Número de arquivo errado. Você especificou %i, mas há somente %i arquivos disponíveis em \"%s\". Por favor, primeiro obtenha um número de arquivo válido da lista de arquivos."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Número de arquivo errado. Você especificou %i, mas há somente %i arquivos "
+"disponíveis em \"%s\". Por favor, primeiro obtenha um número de arquivo "
+"válido da lista de arquivos."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Erro ***               \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Pressione qualquer tecla para continuar.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Memória insuficiente."
@@ -705,206 +768,214 @@ msgstr "Memória insuficiente."
 msgid "Operation cancelled"
 msgstr "Operação cancelada"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Continuar"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Cancelar"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Erro"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Não foi possível definir configuração:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Sair"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Voltar"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Hora: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Valor: "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Sim"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Não"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
-msgstr "Preenchimento de números zero nos nomes dos arquivos é possível apenas com %%n."
+msgstr ""
+"Preenchimento de números zero nos nomes dos arquivos é possível apenas com "
+"%%n."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
-msgstr "Você não pode usar o preenchimento de zeros %%n sem um valor de precisão!"
+msgstr ""
+"Você não pode usar o preenchimento de zeros %%n sem um valor de precisão!"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "O nome do arquivo fornecido pela câmera (\"%s\") não contêm um sufixo!"
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Formato inválido \"%s\" (erro na posição %i)."
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Arquivo existente ignorado %s\n"
 
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "O arquivo %s já existe. Sobrescrever? [y|n] "
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Especificar novo nome de arquivo? [y|n] "
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Digite um novo nome de arquivo: "
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Salvando arquivo como %s\n"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Permissão negada"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Não foi possível disparar a captura."
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Novo arquivo está localizado em %s%s%s na câmera\n"
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Mantendo o arquivo %s%s%s na câmera\n"
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Excluindo o arquivo %s%s%s na câmera\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "Evento de pasta adicionada %s/%s durante a espera, ignorando.\n"
 
 #: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "Evento de pasta adicionada %s/%s durante a espera, ignorando.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Evento desconhecido %s durante a espera, ignorando.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr "Tipo de evento desconhecido %d durante a espera bulb, ignorando.\n"
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Não foi possível obter as características?"
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Modo de captura por intervalos de tempo (intervalo: %ds).\n"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Permanecendo em espera por SIGUSR1 para capturar.\n"
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Modo bulb habilitado (tempo de exposição: %ds).\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Capturando quadro #%d...\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Capturando quadro #%d/%d...\n"
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Não foi possível definir captura bulb, resultado %d."
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Não foi possível finalizar captura (modo bulb)."
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Não foi possível disparar a captura da imagem."
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Não foi possível capturar a imagem."
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Falha ao capturar (problema de foco automático?)...\n"
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Não foi possível capturar."
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Esperando pela próxima captura em %ld segundos...\n"
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Alertado por SIGUSR1...\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "não esperando (%ld segundos atrasado)\n"
 
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "ERRO: "
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -913,12 +984,12 @@ msgstr ""
 "\n"
 "Interrompendo...\n"
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Interrompido.\n"
 
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -927,21 +998,26 @@ msgstr ""
 "\n"
 "Cancelando...\n"
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Use a sintaxe a:b=c:d para tratar qualquer dispositivo USB detectado como a:b em vez de c:d. a b c d devem ser números hexadecimais começando com \"0x\".\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Use a sintaxe a:b=c:d para tratar qualquer dispositivo USB detectado como a:"
+"b em vez de c:d. a b c d devem ser números hexadecimais começando com \"0x"
+"\".\n"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 foi compilado sem suporte a CDK."
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operação cancelada.\n"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -950,7 +1026,7 @@ msgstr ""
 "*** Erro: Nenhuma câmera localizada. ***\n"
 "\n"
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -959,7 +1035,7 @@ msgstr ""
 "*** Erro (%i: \"%s\") ***         \n"
 "\n"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -970,13 +1046,15 @@ msgid ""
 "\n"
 msgstr ""
 "Para mensagens de depuração, por favor use a opção --debug.\n"
-"Mensagens de depuração podem ajudar a encontrar uma solução para o seu problema.\n"
+"Mensagens de depuração podem ajudar a encontrar uma solução para o seu "
+"problema.\n"
 "Se você pretende enviar qualquer erro ou mensagem de depuração para a lista\n"
-"de discussão de desenvolvedores do gphoto gphoto-devel@lists.sourceforge.net,\n"
+"de discussão de desenvolvedores do gphoto gphoto-devel@lists.sourceforge."
+"net,\n"
 "por favor execute o gphoto como segue:\n"
 "\n"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
@@ -985,393 +1063,399 @@ msgstr ""
 "Favor verifique se há aspas suficientes em torno dos argumentos.\n"
 "\n"
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Exibir mensagem de ajuda completa sobre o uso do programa"
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Exibir uma mensagem curta sobre o uso do programa"
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Ativar depuração"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Definir o nível de depuração [error|debug|data|all]"
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Nome do arquivo para gravação de informações de depuração"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "NOME_ARQUIVO"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Saída limpa (padrão=detalhado)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Script de gancho para chamar após downloads, capturas e etc."
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Especifica a porta do dispositivo"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Especifica a velocidade de transferência serial"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "VELOCIDADE"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Especifica o modelo da câmera"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODELO"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "Sobrescrever ID do USB (especialistas)"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBIDs"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Exibe a versão e sai"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Lista os modelos de câmera que há suporte"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Lista os dispositivos de porta que há suporte"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
-msgstr "Exibe as especificações da câmera/driver no banco de dados do libgphoto2"
+msgstr ""
+"Exibe as especificações da câmera/driver no banco de dados do libgphoto2"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Configurar"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Lista a árvore de configurações"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Depeja toda a árvore de configurações"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Obtém o valor de configuração"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Define o valor de configuração ou um índice nas escolhas"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Define o índice do valor de configuração nas escolhas"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Define o valor de configuração"
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Redefinir a porta do dispositivo"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Manter as imagens na câmera após a captura"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr "Manter as imagens originais na câmera após a captura"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Remover as imagens da câmera após a captura"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Espera por evento(s) da câmera"
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr "QTDE, SEGUNDOS, MILISSEGUNDOS ou TEXTO_CORRESPONDENTE"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Esperar por evento(s) da câmera e baixar as novas imagens"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Capturar uma visualização rápida"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr "Exibir uma visualização rápida com ASCII Art"
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Define o tempo de exposição bulb em segundos"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SEGUNDOS"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Definir a quantidade de quadros para capturar (padrão=infinito)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "QTDE"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Define o intervalo de captura em segundos"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Redefinir intervalo de captura em ação do sinal (padrão=não)"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Capturar uma imagem"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Disparar a captura de uma imagem"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Capturar uma imagem e baixa-la"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Capturar um vídeo"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "QTDE ou SEGUNDOS"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Capturar um clipe de áudio"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Esperar pela liberação do obturador da câmera e baixar"
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr "Disparar a captura de imagem"
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Lista as pastas da pasta"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Lista os arquivos da pasta"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Criar um diretório"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "NOME_DIRETORIO"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Remover um diretório"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Exibir quantidade de arquivos"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Obter arquivos de um intervalo"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "INTERVALO"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Obter todos os arquivos da pasta"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Obter as miniaturas de um intervalo"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Obter todas as miniaturas da pasta"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Obter os metadados de um intervalo"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Obter todos os metadados da pasta"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Enviar metadados para arquivo"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Obter os dados não tratados de um intervalo"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Obter todos os dados não tratados da pasta"
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Obter os dados de áudio de um intervalo"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Obter todos os dados de áudio da pasta"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Excluir os arquivos de um intervalo"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Excluir todos os arquivos da pasta (predefinido como --no-recurse)"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Enviar um arquivo à câmera"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Especifica um nome de arquivo ou um padrão de nome de arquivo"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "PADRAO_NOME_ARQUIVO"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Especifica a pasta da câmera (padrão=\"/\")"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "PASTA"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Recursivo (padrão para download)"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Não recursivo (padrão para exclusão)"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Processa apenas novos arquivos"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Sobrescrever arquivos sem perguntar"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Ignorar arquivos existentes"
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Envia arquivo para a saída padrão"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Exibe o tamanho do arquivo antes dos dados"
 
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Lista as câmeras detectadas automaticamente"
 
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "Exibir informação EXIF das imagens JPEG"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
 msgstr "Exibir informações da imagem como largura, altura e data de captura"
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr "Mostrar resumo da câmera"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Exibir manual do driver da câmera"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Sobre o manual do driver da câmera"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Mostrar informações de armazenamento"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "Shell do gPhoto"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Opções comuns"
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Opções diversas (não ordenadas)"
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "Obter informações no software e no sistema hospedeiro, não da câmera"
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Especifica qual câmera usar"
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Configurações de câmera e software"
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Capturar uma imagem da ou na câmera"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Baixando, enviando e manipulando arquivos"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1380,7 +1464,7 @@ msgstr ""
 "%s\n"
 "ID de imagens devem ser um número maior do que zero."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1389,7 +1473,7 @@ msgstr ""
 "%s\n"
 "O ID de imagem %i é muito grande."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1398,7 +1482,7 @@ msgstr ""
 "%s\n"
 "Intervalos devem ser separados por \",\"."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1407,7 +1491,7 @@ msgstr ""
 "%s\n"
 "Intervalos precisam começar com um número."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1416,224 +1500,236 @@ msgstr ""
 "%s\n"
 "Caractere inesperado \"%c\"."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"Intervalos decrescentes não são permitidos. Você especificou um intervalo de %i até %i."
+"Intervalos decrescentes não são permitidos. Você especificou um intervalo de "
+"%i até %i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Erro (%i: \"%s\") ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Mudar para um diretório na câmera"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "diretório"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Mudar para um diretório no drive local"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Sair do shell do gPhoto"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Baixar um arquivo"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[diretório/]nome_arquivo"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Enviar um arquivo"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Baixar uma miniatura"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Baixar um dado não tratado"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Excluir"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Criar diretório"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Remover diretório"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Exibe o uso do comando"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[comando]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Lista o conteúdo do diretório atual"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[diretório/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Lista as variáveis de configuração"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Obter variável de configuração"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "nome"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Definir variável de configuração"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "nome=valor"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Definir o índice da variável de configuração"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "nome=indice_valor"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Disparar a captura de uma imagem"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Capturar uma única imagem"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Capturar uma única imagem e baixá-la"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Capturar uma imagem prévia"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Espera por um evento"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "quantidade ou segundos"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Esperar que as imagens sejam capturadas e baixá-las"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Esperar que eventos e imagens sejam capturados e baixá-los"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Comando inválido."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "O comando \"%s\" requer um argumento."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Caminho inválido."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Não foi possível encontrar o diretório home."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Não foi possível mudar para o diretório local \"%s\"."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Diretório local atual \"%s\"."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Diretório remoto atual \"%s\"."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config necessita de um segundo argumento.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "set-config-value necessita de um segundo argumento.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "set-config-index necessita de um segundo argumento.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "O comando \"%s\" não foi localizado. Use \"help\" para obter uma lista de comandos disponíveis."
+msgstr ""
+"O comando \"%s\" não foi localizado. Use \"help\" para obter uma lista de "
+"comandos disponíveis."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Ajuda em \"%s\":"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Uso:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Descrição:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Os argumentos entre colchetes [] são opcionais"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Comandos disponíveis:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Para obter ajuda em um comando particular digite \"help nome_do_comando\"."
+msgstr ""
+"Para obter ajuda em um comando particular digite \"help nome_do_comando\"."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Disparar a captura de imagem"
 
 #~ msgid "Show info"
 #~ msgstr "Exibir informação"
@@ -1642,4 +1738,5 @@ msgstr "Para obter ajuda em um comando particular digite \"help nome_do_comando\
 #~ msgstr "  Nome:        \"%s\"\n"
 
 #~ msgid "You cannot use '%%n' in combination with non-persistent files!"
-#~ msgstr "Você não pode usar \"%%n\" em combinação a arquivos não persistentes!"
+#~ msgstr ""
+#~ "Você não pode usar \"%%n\" em combinação a arquivos não persistentes!"

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,22 +7,24 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2-2.3.0\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2006-12-01 12:05-0500\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2006-12-11 12:00-0500\n"
 "Last-Translator: Laurentiu Buzdugan <lbuz@rolix.org>\n"
 "Language-Team: Romanian <translation-team-ro@lists.sourceforge.net>\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || ((n%100) > 0 && (n%100) < 20)) ? 1 : 2);\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || ((n%100) > 0 && (n"
+"%100) < 20)) ? 1 : 2);\n"
 
-#: gphoto2/actions.c:166
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Numărul de fişiere în director '%s': %i\n"
 
-#: gphoto2/actions.c:186
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
@@ -30,12 +32,12 @@ msgstr[0] "Există %d director în directorul '%s'.\n"
 msgstr[1] "Există %d directoare în directorul '%s'.\n"
 msgstr[2] "Există %d de directoare în directorul '%s'.\n"
 
-#: gphoto2/actions.c:226
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Nu există nici un fişier în directorul '%s'.\n"
 
-#: gphoto2/actions.c:229
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
@@ -43,177 +45,172 @@ msgstr[0] "Există %d fişier în directorul '%s'.\n"
 msgstr[1] "Există %d fişiere în directorul '%s'.\n"
 msgstr[2] "Există %d de fişiere în directorul '%s'.\n"
 
-#: gphoto2/actions.c:250
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Informaţii despre fişierul '%s' (directorul '%s'):\n"
 
-#: gphoto2/actions.c:252
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Fişier:\n"
 
-#: gphoto2/actions.c:254 gphoto2/actions.c:288 gphoto2/actions.c:304
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "Nici unul disponibil.\n"
 
-#: gphoto2/actions.c:257
-#, c-format
-msgid "  Name:        '%s'\n"
-msgstr "  Nume:        '%s'\n"
-
-#: gphoto2/actions.c:259 gphoto2/actions.c:291
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "   Tip Mime:   '%s'\n"
 
-#: gphoto2/actions.c:261 gphoto2/actions.c:293
-#, c-format
-msgid "  Size:        %li byte(s)\n"
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#, fuzzy, c-format
+msgid "  Size:        %lu byte(s)\n"
 msgstr "Dimens:        %li octet(i)\n"
 
-#: gphoto2/actions.c:263 gphoto2/actions.c:295
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr " Lăţime:       %i pixel(i)\n"
 
-#: gphoto2/actions.c:265 gphoto2/actions.c:297
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "Înălţime:      %i pixel(i)\n"
 
-#: gphoto2/actions.c:267 gphoto2/actions.c:299
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "   Descărcat:  %s\n"
 
-#: gphoto2/actions.c:268 gphoto2/actions.c:300 gphoto2/actions.c:312
-#: gphoto2/actions.c:662 gphoto2/actions.c:664 gphoto2/actions.c:692
-#: gphoto2/actions.c:695 gphoto2/actions.c:698 gphoto2/actions.c:701
-#: gphoto2/actions.c:704 gphoto2/actions.c:1404
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "da"
 
-#: gphoto2/actions.c:268 gphoto2/actions.c:300 gphoto2/actions.c:312
-#: gphoto2/actions.c:662 gphoto2/actions.c:664 gphoto2/actions.c:692
-#: gphoto2/actions.c:695 gphoto2/actions.c:698 gphoto2/actions.c:701
-#: gphoto2/actions.c:704 gphoto2/actions.c:1398
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "nu"
 
-#: gphoto2/actions.c:270
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "   Permisiuni: "
 
-#: gphoto2/actions.c:273
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "citeşte/şterge"
 
-#: gphoto2/actions.c:275
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "citeşte"
 
-#: gphoto2/actions.c:277
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "şterge"
 
-#: gphoto2/actions.c:279
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "nimic"
 
-#: gphoto2/actions.c:283
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Timp:        %s"
 
-#: gphoto2/actions.c:286
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Thumbnail:\n"
 
-#: gphoto2/actions.c:302
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Data audio:\n"
 
-#: gphoto2/actions.c:307
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr " Cadru Mime:  '%s'\n"
 
-#: gphoto2/actions.c:309
-#, c-format
-msgid "  Size:       %li byte(s)\n"
+#: gphoto2/actions.c:332
+#, fuzzy, c-format
+msgid "  Size:       %lu byte(s)\n"
 msgstr "Dimens:       %li octet(i)\n"
 
-#: gphoto2/actions.c:311
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "   Descărcat: %s\n"
 
-#: gphoto2/actions.c:487
+#: gphoto2/actions.c:504
 msgid "Could not parse EXIF data."
 msgstr "Nu am putut parsa data EXIF."
 
-#: gphoto2/actions.c:491
+#: gphoto2/actions.c:508
 #, c-format
 msgid "EXIF tags:"
 msgstr "Marcaje EXIF:"
 
-#: gphoto2/actions.c:494
+#: gphoto2/actions.c:511
 msgid "Tag"
 msgstr "Marcaj"
 
-#: gphoto2/actions.c:496
+#: gphoto2/actions.c:513
 msgid "Value"
 msgstr "Valoare"
 
-#: gphoto2/actions.c:517
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Data EXIF conţine un thumbnail (%i octeţi)."
 
-#: gphoto2/actions.c:526
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 a fost compilat fără suport pentru EXIF."
 
-#: gphoto2/actions.c:544
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Numărul aparatelor foto suportate: %i\n"
 
-#: gphoto2/actions.c:545
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Aparate foto suportate:\n"
 
-#: gphoto2/actions.c:558
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (ÎN TESTARE)\n"
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (EXPERIMENTAL)\n"
 
-#: gphoto2/actions.c:566
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:610
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Unităţi găsite: %i\n"
 
-#: gphoto2/actions.c:611
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -222,150 +219,171 @@ msgstr ""
 "Cale                                            Descriere\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:641 gphoto2/actions.c:646
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:641
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Model"
 
-#: gphoto2/actions.c:641
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Port"
 
-#: gphoto2/actions.c:642
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:660
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Capabilităţi aparat foto         : %s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Suport pentru portul serial      : %s\n"
 
-#: gphoto2/actions.c:663
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Suport USB                       : %s\n"
 
-#: gphoto2/actions.c:666
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Viteze de transport suportate    :\n"
 
-#: gphoto2/actions.c:668
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:671
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Alegeri captură                  :\n"
 
-#: gphoto2/actions.c:673
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Imagine\n"
 
-#: gphoto2/actions.c:677
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Audio\n"
 
-#: gphoto2/actions.c:685
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Previzualizare\n"
 
-#: gphoto2/actions.c:689
-#, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : Captura nu este suportată de driver\n"
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:700
+#, c-format
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : Captura nu este suportată de driver\n"
+
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Suport configuraţie              : %s\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Şterge fişierele selectate din aparatul foto : %s\n"
 
-#: gphoto2/actions.c:696
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Şterge toate fişierele din aparatul foto     : %s\n"
 
-#: gphoto2/actions.c:699
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Suport previzualizare (thumbnail) fişier     : %s\n"
 
-#: gphoto2/actions.c:702
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Suport pentru încărcarea fişierelor          : %s\n"
 
-#: gphoto2/actions.c:718
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Porturile trebuie să arate ceva de genul 'serial:/dev/ttyS0' sau 'usb:', dar lui '%s' îl lipseşte un ':' aşa că vom încerca să ghicim ce aţi intenţionat să scrieţi."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Porturile trebuie să arate ceva de genul 'serial:/dev/ttyS0' sau 'usb:', dar "
+"lui '%s' îl lipseşte un ':' aşa că vom încerca să ghicim ce aţi intenţionat "
+"să scrieţi."
 
-#: gphoto2/actions.c:752
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Portul pe care l-aţi specificat ('%s') nu poate fi ghichit. Vă rugăm specificaţi unul dintre porturile găsite folosind comanda 'gphoto2 --list-ports' şi asiguraţi-vă că îl specificaţi corect (adică folosind prefixurile 'serial:' sau 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Portul pe care l-aţi specificat ('%s') nu poate fi ghichit. Vă rugăm "
+"specificaţi unul dintre porturile găsite folosind comanda 'gphoto2 --list-"
+"ports' şi asiguraţi-vă că îl specificaţi corect (adică folosind prefixurile "
+"'serial:' sau 'usb:')."
 
-#: gphoto2/actions.c:784
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "Despre driver-ul pentru aparatul foto:"
 
-#: gphoto2/actions.c:797
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Rezumat despre aparatul foto:"
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Manualul aparatului foto:"
 
-#: gphoto2/actions.c:825
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Puteţi specifica viteze numai pentru porturile seriale."
 
-#: gphoto2/actions.c:878
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "Portul OS/2 de Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:882
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
@@ -376,154 +394,362 @@ msgstr ""
 "GNU (GNU General Public License). Pentru informaţii suplimentare despre\n"
 "aceste chestiuni consultaţi fişierele numite COPYING.\n"
 "\n"
-"Această versiune de gphoto2 foloseşte următoarele versiuni software şi opţiuni:\n"
+"Această versiune de gphoto2 foloseşte următoarele versiuni software şi "
+"opţiuni:\n"
 
-#: gphoto2/actions.c:1002
+#: gphoto2/actions.c:1015
+#, fuzzy
+msgid "Could not open 'movie.mjpg'."
+msgstr "Nu am putut obţine imaginea."
+
+#: gphoto2/actions.c:1022
+#, c-format
+msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1026
+#, c-format
+msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1031
+#, c-format
+msgid "Capturing %d preview frames as movie to '%s'.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1047
+msgid "Movie capture error... Exiting."
+msgstr ""
+
+#: gphoto2/actions.c:1053
+#, c-format
+msgid "Movie capture error... Unhandled MIME type '%s'."
+msgstr ""
+
+#: gphoto2/actions.c:1060
+#, c-format
+msgid "Ctrl-C pressed ... Exiting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1074
+#, c-format
+msgid "Movie capture finished (%d frames)\n"
+msgstr ""
+
+#: gphoto2/actions.c:1106
+#, fuzzy, c-format
+msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
+msgstr "Aştept eveniment de la aparatul foto"
+
+#: gphoto2/actions.c:1112
+#, c-format
+msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1117
+#, c-format
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1122
+#, c-format
+msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1125
+#, fuzzy, c-format
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr "Aştept eveniment de la aparatul foto"
+
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr "Aştept eveniment de la aparatul foto"
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
+#, c-format
+msgid "event found, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
+msgid "Could not set folder."
+msgstr "Nu am putut seta director."
+
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
+msgid "Could not get image."
+msgstr "Nu am putut obţine imaginea."
+
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
+msgid "Buggy libcanon.so?"
+msgstr "libcanon.so cu bug-uri?"
+
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
+msgid "Could not delete image."
+msgstr "Nu am putut şterge imaginea."
+
+#: gphoto2/actions.c:1300
+#, c-format
+msgid "Getting storage information not supported for this camera.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1315
+#, c-format
+msgid "Read-Write"
+msgstr ""
+
+#: gphoto2/actions.c:1318
+#, c-format
+msgid "Read-Only"
+msgstr ""
+
+#: gphoto2/actions.c:1321
+#, c-format
+msgid "Read-only with delete"
+msgstr ""
+
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
+#, c-format
+msgid "Unknown"
+msgstr ""
+
+#: gphoto2/actions.c:1337
+#, c-format
+msgid "Fixed ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1340
+#, c-format
+msgid "Removable ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1343
+#, c-format
+msgid "Fixed RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1346
+#, c-format
+msgid "Removable RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1356
+#, c-format
+msgid "Undefined"
+msgstr ""
+
+#: gphoto2/actions.c:1359
+#, c-format
+msgid "Generic Flat"
+msgstr ""
+
+#: gphoto2/actions.c:1362
+#, c-format
+msgid "Generic Hierarchical"
+msgstr ""
+
+#: gphoto2/actions.c:1365
+#, c-format
+msgid "Camera layout (DCIM)"
+msgstr ""
+
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Înlocuiesc ID vendor/produs USB 0x%x/0x%x cu 0x%x/0x%x"
 
-#: gphoto2/actions.c:1066
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "INCLUDEŢI ÎNTORDEAUNA URMĂTOARELE LINII CÂND TRIMITEŢI MESAJE DE DEPANARE LISTEI DE DISCUŢII:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"INCLUDEŢI ÎNTORDEAUNA URMĂTOARELE LINII CÂND TRIMITEŢI MESAJE DE DEPANARE "
+"LISTEI DE DISCUŢII:"
 
-#: gphoto2/actions.c:1081
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s a fost compilat cu următoarele opţiuni:"
 
-#: gphoto2/actions.c:1197
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s nu a fost găsit în arborele de configuraţie."
 
-#: gphoto2/actions.c:1256
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Nu am reuşit să extrag valoarea widget-ului text %s."
 
-#: gphoto2/actions.c:1273
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Nu am reuşit să extrag valorile widget-ului interval %s."
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Nu am reuşit să extrag valorile widget-ului comutator %s."
 
-#: gphoto2/actions.c:1297
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Nu am reuşit să extrag valorile widget-ului dată/timp %s."
 
-#: gphoto2/actions.c:1327
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Nu am reuşit să extrag valorile widget-ului radio %s."
 
-#: gphoto2/actions.c:1368
+#: gphoto2/actions.c:1799
+#, c-format
+msgid "Property %s is read only."
+msgstr ""
+
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Nu am reuşit să setez valoarea widget-ului %s ca %s."
 
-#: gphoto2/actions.c:1378
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Valoarea pasată %s nu este o valoare în virgulă mobilă."
 
-#: gphoto2/actions.c:1383
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "Valoarea pasată %f nu este în intervalus aşteptat %f - %f."
 
-#: gphoto2/actions.c:1389
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Nu am reuşit să setez valoarea widget-ului interval %s ca %f."
 
-#: gphoto2/actions.c:1398
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "închis"
 
-#: gphoto2/actions.c:1399
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "fals"
 
-#: gphoto2/actions.c:1404
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "deschis"
 
-#: gphoto2/actions.c:1405
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "adevărat"
 
-#: gphoto2/actions.c:1409
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Valoarea pasată %s nu este o valoare comutator validă."
 
-#: gphoto2/actions.c:1415
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Nu am reuşit să setez valorile %s ale widget-ului comutator %s."
 
-#: gphoto2/actions.c:1428
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
+#, fuzzy
+msgid "now"
+msgstr "nu"
+
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "Valoarea pasată %s nu este nici n timp valid nici un întreg."
 
-#: gphoto2/actions.c:1435
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Nu am reuşit să setez noul timp pentru widget-ul dată/timp %s ca %s."
 
-#: gphoto2/actions.c:1472
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Alegerea %s nu a fost găsită în lista de opţiuni."
 
-#: gphoto2/actions.c:1480
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Widget-ul %s nu este configurabil."
 
-#: gphoto2/actions.c:1487
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
-msgstr "Nu am reuşit să setez noua valoare de configurare %s pentru întrarea %s."
+msgstr ""
+"Nu am reuşit să setez noua valoare de configurare %s pentru întrarea %s."
 
-#: gphoto2/foreach.c:254
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Număr fişiere incorect. Aţi specificat %i, dar există numai %i fişiere în '%s' sau subdirectoarele sale. Vă rugăm obţineţi un număr de fişiere valid folosind comanda ls."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
 
-#: gphoto2/foreach.c:279
+#: gphoto2/foreach.c:260
+#, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Număr fişiere incorect. Aţi specificat %i, dar există numai %i fişiere în "
+"'%s' sau subdirectoarele sale. Vă rugăm obţineţi un număr de fişiere valid "
+"folosind comanda ls."
+
+#: gphoto2/foreach.c:285
 #, c-format
 msgid "There are no files in folder '%s'."
 msgstr "Nu există nici un fişier în directorul '%s'."
 
-#: gphoto2/foreach.c:285
+#: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Număr fişiere incorect. Aţi specificat %i, dar există numai un fişier în '%s'."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Număr fişiere incorect. Aţi specificat %i, dar există numai un fişier în "
+"'%s'."
 
-#: gphoto2/foreach.c:293
+#: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Număr fişiere incorect. Aţi specificat %i, dar există numai %i fişiere în '%s'. Vă rugăm obţineţi un număr de fişiere valid folosind comanda ls."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Număr fişiere incorect. Aţi specificat %i, dar există numai %i fişiere în "
+"'%s'. Vă rugăm obţineţi un număr de fişiere valid folosind comanda ls."
 
-#: gphoto2/gp-params.c:67
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Eroare ***             \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Apăsaţi orice tastă pentru a continua.\n"
 
-#: gphoto2/gp-params.c:258
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Memorie insuficientă."
@@ -532,162 +758,218 @@ msgstr "Memorie insuficientă."
 msgid "Operation cancelled"
 msgstr "Operaţiune anulată"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Continuă"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Renunţă"
 
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Eroare"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Nu am putut seta configuraţia:"
 
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Ieşire"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Înapoi"
 
-#: gphoto2/gphoto2-cmd-config.c:254
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Timp: "
 
-#: gphoto2/gphoto2-cmd-config.c:313 gphoto2/gphoto2-cmd-config.c:341
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Valoare: "
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Da"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Nu"
 
-#: gphoto2/main.c:225
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "Adăugare de zerouri în numele fişierelor este posibil numai cu %%n."
 
-#: gphoto2/main.c:234
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
-msgstr "Nu puteţi folosi %%n caractere zero adăugate fără o valoare de precizie!"
+msgstr ""
+"Nu puteţi folosi %%n caractere zero adăugate fără o valoare de precizie!"
 
-#: gphoto2/main.c:250
-#, c-format
-msgid "You cannot use '%%n' in combination with non-persistent files!"
-msgstr "Nu puteţi folosi '%%n' în combinaţie cu fişiere ne-permanente!"
-
-#: gphoto2/main.c:281
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Numele de fişier dat de aparatul foto (%s') nu conţine un sufix!"
 
-#: gphoto2/main.c:336
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Format invalid '%s' (eroare la poziţia %i)."
 
-#: gphoto2/main.c:385
+#: gphoto2/main.c:386 gphoto2/main.c:592
+#, fuzzy, c-format
+msgid "Skip existing file %s\n"
+msgstr "Salvez fişierul ca %s\n"
+
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Fişierul %s există. Suprascrie? [d|n] "
 
-#: gphoto2/main.c:397
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Specifică un nou nume de fişier? [y|n] "
 
-#: gphoto2/main.c:407
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Introduceţi un nou nume de fişier: "
 
-#: gphoto2/main.c:413
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Salvez fişierul ca %s\n"
 
-#: gphoto2/main.c:563
-#, c-format
-msgid "Time-lapse mode enabled (interval: %ds).\n"
-msgstr "Modul cu întârziere-timp activat (interval: %ds).\n"
+#: gphoto2/main.c:630
+#, fuzzy
+msgid "Permission denied"
+msgstr "   Permisiuni: "
 
-#: gphoto2/main.c:570
-#, c-format
-msgid "Capturing frame #%d...\n"
-msgstr "Capturez cadrul #%d...\n"
-
-#: gphoto2/main.c:572
-#, c-format
-msgid "Capturing frame #%d/%d...\n"
-msgstr "Capturez cadrul #%d/%d...\n"
-
-#: gphoto2/main.c:579
-msgid "Could not capture."
+#: gphoto2/main.c:800
+#, fuzzy
+msgid "Could not trigger capture."
 msgstr "Nu am putut captura."
 
-#: gphoto2/main.c:588
-#, c-format
-msgid "Capture failed (auto-focus problem?)...\n"
-msgstr "Captura a eşuat (problemă cu auto-focus?)...\n"
-
-#: gphoto2/main.c:602
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Noul fişier este în locaţia %s%s%s în aparatul foto\n"
 
-#: gphoto2/main.c:612
-msgid "Could not set folder."
-msgstr "Nu am putut seta director."
+#: gphoto2/main.c:847 gphoto2/main.c:878
+#, fuzzy, c-format
+msgid "Keeping file %s%s%s on the camera\n"
+msgstr "Şterg fişier %s%s%s din aparatul foto\n"
 
-#: gphoto2/main.c:637
-msgid "Could not get image."
-msgstr "Nu am putut obţine imaginea."
-
-#: gphoto2/main.c:644
-msgid "Buggy libcanon.so?"
-msgstr "libcanon.so cu bug-uri?"
-
-#: gphoto2/main.c:650
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Şterg fişier %s%s%s din aparatul foto\n"
 
-#: gphoto2/main.c:655
-msgid "Could not delete image."
-msgstr "Nu am putut şterge imaginea."
-
-#: gphoto2/main.c:675
-msgid "Could not close camera connection."
-msgstr "Nu am putut închide conectarea cu aparatul foto."
-
-#: gphoto2/main.c:681
+#: gphoto2/main.c:911
 #, c-format
-msgid "Sleeping for %d second(s)...\n"
-msgstr "Adormit pentru %d secunde...\n"
+msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
+msgstr ""
 
-#: gphoto2/main.c:685
+#: gphoto2/main.c:916
 #, c-format
-msgid "not sleeping (%d seconds behind schedule)\n"
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:926
+#, c-format
+msgid "Event UNKNOWN %s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:932
+#, c-format
+msgid "Unknown event type %d during bulb wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:950
+#, fuzzy
+msgid "Could not get capabilities?"
+msgstr "Nu am putut obţine imaginea."
+
+#: gphoto2/main.c:958
+#, c-format
+msgid "Time-lapse mode enabled (interval: %ds).\n"
+msgstr "Modul cu întârziere-timp activat (interval: %ds).\n"
+
+#: gphoto2/main.c:961
+#, c-format
+msgid "Standing by waiting for SIGUSR1 to capture.\n"
+msgstr ""
+
+#: gphoto2/main.c:967
+#, fuzzy, c-format
+msgid "Bulb mode enabled (exposure time: %ds).\n"
+msgstr "Modul cu întârziere-timp activat (interval: %ds).\n"
+
+#: gphoto2/main.c:975
+#, c-format
+msgid "Capturing frame #%d...\n"
+msgstr "Capturez cadrul #%d...\n"
+
+#: gphoto2/main.c:977
+#, c-format
+msgid "Capturing frame #%d/%d...\n"
+msgstr "Capturez cadrul #%d/%d...\n"
+
+#: gphoto2/main.c:987
+#, fuzzy, c-format
+msgid "Could not set bulb capture, result %d."
+msgstr "Nu am putut captura."
+
+#: gphoto2/main.c:1001
+#, fuzzy
+msgid "Could not end capture (bulb mode)."
+msgstr "Nu am putut captura."
+
+#: gphoto2/main.c:1014
+#, fuzzy
+msgid "Could not trigger image capture."
+msgstr "Nu am putut obţine imaginea."
+
+#: gphoto2/main.c:1021
+#, fuzzy
+msgid "Could not capture image."
+msgstr "Nu am putut captura."
+
+#: gphoto2/main.c:1028
+#, c-format
+msgid "Capture failed (auto-focus problem?)...\n"
+msgstr "Captura a eşuat (problemă cu auto-focus?)...\n"
+
+#: gphoto2/main.c:1039
+msgid "Could not capture."
+msgstr "Nu am putut captura."
+
+#: gphoto2/main.c:1074
+#, c-format
+msgid "Waiting for next capture slot %ld seconds...\n"
+msgstr ""
+
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
+#, c-format
+msgid "Awakened by SIGUSR1...\n"
+msgstr ""
+
+#: gphoto2/main.c:1096
+#, fuzzy, c-format
+msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "nu dorm (%d secunde în urmă)\n"
 
-#: gphoto2/main.c:775
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "EROARE: "
 
-#: gphoto2/main.c:798
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -696,12 +978,12 @@ msgstr ""
 "\n"
 "Renunţ...\n"
 
-#: gphoto2/main.c:804
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Am renunţat.\n"
 
-#: gphoto2/main.c:809
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -710,21 +992,33 @@ msgstr ""
 "\n"
 "Renunţ...\n"
 
-#: gphoto2/main.c:943
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Folosiţi următoarea sintaxă a:b=c:d pentru a trata orice dispozitiv USB detectat ca a:b ca c:c in schimb. a b c d trebuie să fie numere hexazecimale începând cu '0x'.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Folosiţi următoarea sintaxă a:b=c:d pentru a trata orice dispozitiv USB "
+"detectat ca a:b ca c:c in schimb. a b c d trebuie să fie numere hexazecimale "
+"începând cu '0x'.\n"
 
-#: gphoto2/main.c:1071
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 a fost compilat fără suport pentru CDK."
 
-#: gphoto2/main.c:1256
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operaţiune anulată.\n"
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1883
+#, c-format
+msgid ""
+"*** Error: No camera found. ***\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -733,7 +1027,7 @@ msgstr ""
 "*** Eroare (%i: '%s') ***      \n"
 "\n"
 
-#: gphoto2/main.c:1264
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -749,340 +1043,422 @@ msgstr ""
 "de discuţii a dezvoltatorilor gphoto <gphoto-devel@lists.sourceforge.net>,\n"
 "vă rugăm rulaţi gphoto2 astfel:\n"
 
-#: gphoto2/main.c:1349
+#: gphoto2/main.c:1911
+#, c-format
+msgid ""
+"Please make sure there is sufficient quoting around the arguments.\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Afişează mesajul complet de ajutor depre cum se foloseşte programul"
 
-#: gphoto2/main.c:1351
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Afişează un scurt mesaj despre cum se foloseşte programul"
 
-#: gphoto2/main.c:1353
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Porniţi depanarea"
 
-#: gphoto2/main.c:1355
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
+
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Numele fişierului în care să fie scrisă informaţiile de depanare"
 
-#: gphoto2/main.c:1355 gphoto2/main.c:1363
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "NUMEFIŞIER"
 
-#: gphoto2/main.c:1357
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Ieşire sumară (implicit=amanunţită)"
 
-#: gphoto2/main.c:1363
-msgid "Specify port device"
+#: gphoto2/main.c:1990
+msgid "Hook script to call after downloads, captures, etc."
+msgstr ""
+
+#: gphoto2/main.c:1997
+#, fuzzy
+msgid "Specify device port"
 msgstr "Specifică porturi de unităţi"
 
-#: gphoto2/main.c:1365
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Specifică viteza de transfer pe serial"
 
-#: gphoto2/main.c:1365
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "VITEZĂ"
 
-#: gphoto2/main.c:1367
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Specifică modelul aparatului foto"
 
-#: gphoto2/main.c:1367
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODEL"
 
-#: gphoto2/main.c:1369
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(numai experţi) Înlocuieşte ID-urile USB"
 
-#: gphoto2/main.c:1369
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "ID-uri USB"
 
-#: gphoto2/main.c:1375
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Afişază versiunea şi termină"
 
-#: gphoto2/main.c:1377
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Enumeră modelele de aparate suportate"
 
-#: gphoto2/main.c:1379
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Enumeră porturi de unităţi suportate"
 
-#: gphoto2/main.c:1381
-msgid "Display camera/driver abilities"
+#: gphoto2/main.c:2015
+#, fuzzy
+msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Afişeaza capabilităţile aparatului foto/driverului"
 
-#: gphoto2/main.c:1388
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Configurează"
 
-#: gphoto2/main.c:1391
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Listează arborele de configuraţie"
 
-#: gphoto2/main.c:1393
+#: gphoto2/main.c:2027
+#, fuzzy
+msgid "Dump full configuration tree"
+msgstr "Listează arborele de configuraţie"
+
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Obţine valoare configuraţie"
 
-#: gphoto2/main.c:1395
+#: gphoto2/main.c:2031
+#, fuzzy
+msgid "Set configuration value or index in choices"
+msgstr "Setează valoare configuraţie"
+
+#: gphoto2/main.c:2033
+#, fuzzy
+msgid "Set configuration value index in choices"
+msgstr "Setează valoare configuraţie"
+
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Setează valoare configuraţie"
 
-#: gphoto2/main.c:1401
-msgid "Wait for event from camera"
+#: gphoto2/main.c:2037
+msgid "Reset device port"
+msgstr ""
+
+#: gphoto2/main.c:2043
+msgid "Keep images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2045
+msgid "Keep RAW images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2047
+msgid "Remove images from camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2049
+#, fuzzy
+msgid "Wait for event(s) from camera"
 msgstr "Aştept eveniment de la aparatul foto"
 
-#: gphoto2/main.c:1404
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
+
+#: gphoto2/main.c:2051
+#, fuzzy
+msgid "Wait for event(s) from the camera and download new images"
+msgstr "Aştept eveniment de la aparatul foto"
+
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Capturează o previzualizare rapidă"
 
-#: gphoto2/main.c:1406
-msgid "Set number of frames to capture (default=infinite)"
-msgstr "Setează numărul de cadre de capturat (implicit=infinit)"
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
 
-#: gphoto2/main.c:1406
-msgid "COUNT"
-msgstr "NUMĂR"
-
-#: gphoto2/main.c:1408
-msgid "Set capture interval in seconds"
+#: gphoto2/main.c:2059
+#, fuzzy
+msgid "Set bulb exposure time in seconds"
 msgstr "Setează intervalul de captură în secunde"
 
-#: gphoto2/main.c:1408
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SECUNDE"
 
-#: gphoto2/main.c:1410
+#: gphoto2/main.c:2061
+msgid "Set number of frames to capture (default=infinite)"
+msgstr "Setează numărul de cadre de capturat (implicit=infinit)"
+
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr "NUMĂR"
+
+#: gphoto2/main.c:2063
+msgid "Set capture interval in seconds"
+msgstr "Setează intervalul de captură în secunde"
+
+#: gphoto2/main.c:2065
+#, fuzzy
+msgid "Reset capture interval on signal (default=no)"
+msgstr "Setează intervalul de captură în secunde"
+
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Capturează o imagine"
 
-#: gphoto2/main.c:1412
+#: gphoto2/main.c:2069
+#, fuzzy
+msgid "Trigger capture of an image"
+msgstr "Capturează o imagine"
+
+#: gphoto2/main.c:2071
+#, fuzzy
+msgid "Capture an image and download it"
+msgstr "Capturează o imagine"
+
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Capturează un film"
 
-#: gphoto2/main.c:1414
+#: gphoto2/main.c:2073
+#, fuzzy
+msgid "COUNT or SECONDS"
+msgstr "SECUNDE"
+
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Capturează un clip audio"
 
-#: gphoto2/main.c:1420
+#: gphoto2/main.c:2077
+msgid "Wait for shutter release on the camera and download"
+msgstr ""
+
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Enumeră directoare în director"
 
-#: gphoto2/main.c:1422
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Enumeră fişierele în director"
 
-#: gphoto2/main.c:1424
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Crează un director"
 
-#: gphoto2/main.c:1424 gphoto2/main.c:1426
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "NUMEDIRECTOR"
 
-#: gphoto2/main.c:1426
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Şterge un director"
 
-#: gphoto2/main.c:1428
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Afişează numărul de fişiere"
 
-#: gphoto2/main.c:1430
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Ia fişierele date în interval"
 
-#: gphoto2/main.c:1430 gphoto2/main.c:1434 gphoto2/main.c:1439
-#: gphoto2/main.c:1446 gphoto2/main.c:1452 gphoto2/main.c:1457
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "INTERVAL"
 
-#: gphoto2/main.c:1432
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Ia toate fişierele din director"
 
-#: gphoto2/main.c:1434
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Ia thumbnail-urile date în interval"
 
-#: gphoto2/main.c:1437
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Ia toate thumbnail-urile din director"
 
-#: gphoto2/main.c:1439
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Ia metadatele date în interval"
 
-#: gphoto2/main.c:1441
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Ia toate metadatele din director"
 
-#: gphoto2/main.c:1443
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Încarcă metadatele pentru fişier"
 
-#: gphoto2/main.c:1446
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Ia datele 'raw' date în interval"
 
-#: gphoto2/main.c:1449
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Ia toată datele 'raw' din director"
 
-#: gphoto2/main.c:1452
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Ia datele audio date în interval"
 
-#: gphoto2/main.c:1455
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Ia toate datele audio din director"
 
-#: gphoto2/main.c:1457
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Şterge toate fişierele date în interval"
 
-#: gphoto2/main.c:1459
-msgid "Delete all files in folder"
+#: gphoto2/main.c:2122
+#, fuzzy
+msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Şterge toate fişierele din director"
 
-#: gphoto2/main.c:1461
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Încarvă un fişier în aparatul foto"
 
-#: gphoto2/main.c:1461
-msgid "filename"
-msgstr "nume fişier"
-
-#: gphoto2/main.c:1463
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Specifică un nume sau pattern de fişier"
 
-#: gphoto2/main.c:1463
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "FILENAME_PATTERN"
 
-#: gphoto2/main.c:1465
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Specifică directorul aparatului foto (implicit=\"/\")"
 
-#: gphoto2/main.c:1465
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "DIRECTOR"
 
-#: gphoto2/main.c:1467
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Recursiv (implicit pentru descărcare)"
 
-#: gphoto2/main.c:1469
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Ne-recursiv (implicit pentru ştergere)"
 
-#: gphoto2/main.c:1471
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Procesează numai noile fişiere"
 
-#: gphoto2/main.c:1473
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Suprascrie fişiere fără a întreba."
 
-#: gphoto2/main.c:1479
+#: gphoto2/main.c:2140
+msgid "Skip existing files"
+msgstr ""
+
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Trimite fişierul la ieşirea standard"
 
-#: gphoto2/main.c:1481
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Afişează dimensiune fişier înainte de date"
 
-#: gphoto2/main.c:1483
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Enumeră aparatele foto auto-detectate"
 
-#: gphoto2/main.c:1487 gphoto2/shell.c:132
-msgid "Show EXIF information"
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
 msgstr "Afişează informaţia EXIF"
 
-#: gphoto2/main.c:1490 gphoto2/shell.c:126
-msgid "Show info"
-msgstr "Afişează info"
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
 
-#: gphoto2/main.c:1492
-msgid "Show summary"
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "Afişează rezumat"
 
-#: gphoto2/main.c:1494
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Afişează manualul driverului aparatului foto"
 
-#: gphoto2/main.c:1496
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Despre manualul driverului aparatului foto"
 
-#: gphoto2/main.c:1498
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
+#, fuzzy
+msgid "Show storage information"
+msgstr "Afişează informaţia EXIF"
+
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "shell gPhoto"
 
-#: gphoto2/main.c:1504
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Opţiuni comune"
 
-#: gphoto2/main.c:1506
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Diferite opţiuni (nesortate)"
 
-#: gphoto2/main.c:1508
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
-msgstr "Ia informaţii despre software şi sistemul gazdă (nu de pe aparatul foto)"
+msgstr ""
+"Ia informaţii despre software şi sistemul gazdă (nu de pe aparatul foto)"
 
-#: gphoto2/main.c:1510
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Specifică aparatului foto de folosit"
 
-#: gphoto2/main.c:1512
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Configurarea aparatului foto şi software-ului"
 
-#: gphoto2/main.c:1514
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Capturează o imagine de pe sau pe aparatul foto"
 
-#: gphoto2/main.c:1516
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Descarc, încarc sau manipulez fişiere"
 
-#: gphoto2/options.c:181
-#, c-format
-msgid "Usage:\n"
-msgstr "Folosire:\n"
-
-#: gphoto2/options.c:184
-#, c-format
-msgid ""
-"Short/long options (& argument)        Description\n"
-"--------------------------------------------------------------------------------\n"
-msgstr ""
-"Opţiuni scurte/lungi (& argument)                  Descriere\n"
-"--------------------------------------------------------------------------------\n"
-
-#: gphoto2/options.c:209
-#, c-format
-msgid "%-38s %s\n"
-msgstr "%-38s %s\n"
-
-#: gphoto2/options.c:214
-#, c-format
-msgid ""
-"--------------------------------------------------------------------------------\n"
-"[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
-msgstr ""
-"--------------------------------------------------------------------------------\n"
-"[Folosiţi argumente între ghilimele duble]    [Numărul pozelor încep cu unu (1)]\n"
-
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1091,7 +1467,7 @@ msgstr ""
 "%s\n"
 "ID-urile imaginilor trebuie să fie numere mai mari decât zero."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1100,7 +1476,7 @@ msgstr ""
 "%s\n"
 "ID-ul imaginii %i prea mare."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1109,7 +1485,7 @@ msgstr ""
 "%s\n"
 "Intervalele trebuie separate de ','."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1118,7 +1494,7 @@ msgstr ""
 "%s\n"
 "Intervalele trebuie să înceapă cu un număr."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1127,186 +1503,289 @@ msgstr ""
 "%s\n"
 "Caracter neaşteptat '%c'."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"Intervalele descrescătoare nu sunt permise. Aţi specificat un interval de la %i la %i."
+"Intervalele descrescătoare nu sunt permise. Aţi specificat un interval de la "
+"%i la %i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Eroare (%i: '%s') ***"
 
-#: gphoto2/shell.c:115
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Schimbă într-un director pe aparatul foto"
 
-#: gphoto2/shell.c:116 gphoto2/shell.c:118 gphoto2/shell.c:129
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "director"
 
-#: gphoto2/shell.c:117
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Schimbă într-un director pe discul local"
 
-#: gphoto2/shell.c:119 gphoto2/shell.c:143 gphoto2/shell.c:144
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Ieşi shell-ul gPhoto"
 
-#: gphoto2/shell.c:120
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Descarcă un fişier"
 
-#: gphoto2/shell.c:120 gphoto2/shell.c:121 gphoto2/shell.c:123
-#: gphoto2/shell.c:125 gphoto2/shell.c:127 gphoto2/shell.c:128
-#: gphoto2/shell.c:133
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[director/]fişier"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Încarcă un fişier"
 
-#: gphoto2/shell.c:122
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Descarcă un thumbnail"
 
-#: gphoto2/shell.c:124
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Descarcă date 'raw'"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Şterge"
 
-#: gphoto2/shell.c:129
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Crează director"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Şterge director"
 
-#: gphoto2/shell.c:135 gphoto2/shell.c:145
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Afişează comenzi de folosire"
 
-#: gphoto2/shell.c:136 gphoto2/shell.c:145
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[comandă]"
 
-#: gphoto2/shell.c:137
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Afişează conţinutul directorului curent"
 
-#: gphoto2/shell.c:138
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[director/]"
 
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Listează variabilele de configurare"
 
-#: gphoto2/shell.c:140
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Obţine variabilele de configurare"
 
-#: gphoto2/shell.c:140
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "nume"
 
-#: gphoto2/shell.c:141
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Setează variabilele de configurare"
 
-#: gphoto2/shell.c:141
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "nume=valoare"
 
-#: gphoto2/shell.c:142
+#: gphoto2/shell.c:155
+#, fuzzy
+msgid "Set configuration variable index"
+msgstr "Setează variabilele de configurare"
+
+#: gphoto2/shell.c:155
+#, fuzzy
+msgid "name=valueindex"
+msgstr "nume=valoare"
+
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Capturează o singură imagine"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Capturează o singură imagine"
 
-#: gphoto2/shell.c:142
-msgid "[name]"
-msgstr "[nume]"
+#: gphoto2/shell.c:159
+#, fuzzy
+msgid "Capture a single image and download it"
+msgstr "Capturează o singură imagine"
 
-#: gphoto2/shell.c:467
+#: gphoto2/shell.c:160
+#, fuzzy
+msgid "Capture a preview image"
+msgstr "Capturează o singură imagine"
+
+#: gphoto2/shell.c:161
+#, fuzzy
+msgid "Wait for an event"
+msgstr "Aştept eveniment de la aparatul foto"
+
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
+#, fuzzy
+msgid "count or seconds"
+msgstr "secunde"
+
+#: gphoto2/shell.c:162
+msgid "Wait for images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:163
+msgid "Wait for events and images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Comandă invalidă."
 
-#: gphoto2/shell.c:476
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Opţiunea `%s' necesită un argument."
 
-#: gphoto2/shell.c:529
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Cale invalidă."
 
-#: gphoto2/shell.c:575
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Nu am putut găsi directorul acasă."
 
-#: gphoto2/shell.c:583
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Nu am putut schimba în directorul local '%s'."
 
-#: gphoto2/shell.c:586
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Directorul local este acum '%s'."
 
-#: gphoto2/shell.c:624
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Directorul remote este acum '%s'."
 
-#: gphoto2/shell.c:840
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config are nevoie de un al doilea argument.\n"
 
-#: gphoto2/shell.c:870
+#: gphoto2/shell.c:895
+#, fuzzy, c-format
+msgid "set-config-value needs a second argument.\n"
+msgstr "set-config are nevoie de un al doilea argument.\n"
+
+#: gphoto2/shell.c:916
+#, fuzzy, c-format
+msgid "set-config-index needs a second argument.\n"
+msgstr "set-config are nevoie de un al doilea argument.\n"
+
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Comanda '%s' nu a fost găsită. Folosiţi 'help' pentru a vedea lista comenzilor disponibile."
+msgstr ""
+"Comanda '%s' nu a fost găsită. Folosiţi 'help' pentru a vedea lista "
+"comenzilor disponibile."
 
-#: gphoto2/shell.c:877
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Ajutor despre \"%s\":"
 
-#: gphoto2/shell.c:879
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Folosire:"
 
-#: gphoto2/shell.c:882
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Descriere:"
 
-#: gphoto2/shell.c:884
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Argumente între parantezele [] sunt opţionale"
 
-#: gphoto2/shell.c:905
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Comenzi disponibile:"
 
-#: gphoto2/shell.c:910
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Pentru a obţine ajutor pentru o anumită comandă, tastaţi 'help nume-comandă'."
+msgstr ""
+"Pentru a obţine ajutor pentru o anumită comandă, tastaţi 'help nume-comandă'."
+
+#, c-format
+#~ msgid "  Name:        '%s'\n"
+#~ msgstr "  Nume:        '%s'\n"
+
+#, c-format
+#~ msgid "You cannot use '%%n' in combination with non-persistent files!"
+#~ msgstr "Nu puteţi folosi '%%n' în combinaţie cu fişiere ne-permanente!"
+
+#~ msgid "Could not close camera connection."
+#~ msgstr "Nu am putut închide conectarea cu aparatul foto."
+
+#, c-format
+#~ msgid "Sleeping for %d second(s)...\n"
+#~ msgstr "Adormit pentru %d secunde...\n"
+
+#~ msgid "filename"
+#~ msgstr "nume fişier"
+
+#~ msgid "Show info"
+#~ msgstr "Afişează info"
+
+#, c-format
+#~ msgid "Usage:\n"
+#~ msgstr "Folosire:\n"
+
+#, c-format
+#~ msgid ""
+#~ "Short/long options (& argument)        Description\n"
+#~ "--------------------------------------------------------------------------------\n"
+#~ msgstr ""
+#~ "Opţiuni scurte/lungi (& argument)                  Descriere\n"
+#~ "--------------------------------------------------------------------------------\n"
+
+#, c-format
+#~ msgid "%-38s %s\n"
+#~ msgstr "%-38s %s\n"
+
+#, c-format
+#~ msgid ""
+#~ "--------------------------------------------------------------------------------\n"
+#~ "[Use double-quotes around arguments]        [Picture numbers begin with "
+#~ "one (1)]\n"
+#~ msgstr ""
+#~ "--------------------------------------------------------------------------------\n"
+#~ "[Folosiţi argumente între ghilimele duble]    [Numărul pozelor încep cu "
+#~ "unu (1)]\n"
+
+#~ msgid "[name]"
+#~ msgstr "[nume]"
 
 #~ msgid "There are no folders in folder '%s'."
 #~ msgstr "Nu există nici un director în directorul '%s'."
@@ -1353,14 +1832,21 @@ msgstr "Pentru a obţine ajutor pentru o anumită comandă, tastaţi 'help nume-
 #~ msgid "count"
 #~ msgstr "număr(ă)"
 
-#~ msgid "seconds"
-#~ msgstr "secunde"
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the "
+#~ "location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgstr ""
+#~ "gPhoto2 pentru OS/2 necesită să setaţi variabila de mediu CAMLIBS cu "
+#~ "locaţia bibliotecilor pentru aparatul foto, de exemplu SET CAMLIBS=C:"
+#~ "\\GPHOTO2\\CAM\n"
 
-#~ msgid "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
-#~ msgstr "gPhoto2 pentru OS/2 necesită să setaţi variabila de mediu CAMLIBS cu locaţia bibliotecilor pentru aparatul foto, de exemplu SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
-
-#~ msgid "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
-#~ msgstr "gPhoto2 pentru OS/2 necesită să setaţi variabila de mediu IOLIBS cu locaţia bibliotecilor io (intrare/ieşire), de exemplu SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the "
+#~ "location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgstr ""
+#~ "gPhoto2 pentru OS/2 necesită să setaţi variabila de mediu IOLIBS cu "
+#~ "locaţia bibliotecilor io (intrare/ieşire), de exemplu SET IOLIBS=C:"
+#~ "\\GPHOTO2\\IOLIB\n"
 
 #~ msgid "Jan"
 #~ msgstr "Ian"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,24 +8,25 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.9\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-11-18 22:19+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2015-11-22 09:43+0300\n"
 "Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
 "Language-Team: Russian <gnu@d07.ru>\n"
 "Language: ru\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Lokalize 1.5\n"
-"Plural-Forms:  nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms:  nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Количество файлов в каталоге «%s»: %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
@@ -33,12 +34,12 @@ msgstr[0] "%d каталог в каталоге «%s».\n"
 msgstr[1] "%d каталога в каталоге «%s».\n"
 msgstr[2] "%d каталогов в каталоге «%s».\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "В каталоге «%s» файлы отсутствуют.\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
@@ -46,111 +47,111 @@ msgstr[0] "%d файл в каталоге «%s».\n"
 msgstr[1] "%d файла в каталоге «%s».\n"
 msgstr[2] "%d файлов в каталоге «%s».\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Сведения о файле «%s» (каталог «%s»):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Файл:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Нет ничего.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Тип MIME:    «%s»\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Размер:      %lu байт(ов)\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Ширина:      %i пиксель(ей)\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Высота:       %i пиксель(ей)\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Скачано:  %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "да"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "нет"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Права доступа: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "чтение/удаление"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "чтение"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "удаление"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "ничего"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Время:       %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Миниатюра:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Звукозапись:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Тип MIME:   «%s»\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Размер:     %lu байт(ов)\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Скачано: %s\n"
@@ -172,46 +173,46 @@ msgstr "Метка"
 msgid "Value"
 msgstr "Значение"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Данные EXIF содержат миниатюру (%i байт)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "Программа gphoto2 собрана без поддержки EXIF."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Число поддерживаемых фотоаппаратов: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Поддерживаемые фотоаппараты:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t«%s» (ТЕСТ)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t«%s» (ЭКСПЕРИМЕНТАЛЬНЫЙ)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t«%s»\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Найдено устройств: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -220,458 +221,507 @@ msgstr ""
 "Путь                             Описание\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Модель"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Порт"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Функции фотоаппарата             : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Поддержка послед. порта          : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Поддержка USB                    : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Поддерживаемые скорости передачи :\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Режимы съёмки                    :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Фото\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Видео\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Аудио\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Предв. просмотр\n"
 
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr "                                 : Запустить процесс съёмки\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : Драйвер не поддерживает режим съёмки\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : Драйвер не поддерживает режим съёмки\n"
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Поддержка настройки             : %s\n"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Удаление выбранных файлов с фотоаппарата: %s\n"
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Удаление всех файлов с фотоаппарата: %s\n"
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Поддержка миниатюр               : %s\n"
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Поддержка загрузки файлов        : %s\n"
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Порт должен быть указан так: «serial:/dev/ttyS0» или «usb:», но в строке «%s» нет двоеточия. Программа попытается угадать, чего вы хотите."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Порт должен быть указан так: «serial:/dev/ttyS0» или «usb:», но в строке "
+"«%s» нет двоеточия. Программа попытается угадать, чего вы хотите."
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Указанный порт («%s») не найден. Пожалуйста, выберите один из портов обнаруженных командой «gphoto2 --list-ports» и убедитесь, что нет опечаток (например в префиксах «serial:» и «usb:»)."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Указанный порт («%s») не найден. Пожалуйста, выберите один из портов "
+"обнаруженных командой «gphoto2 --list-ports» и убедитесь, что нет опечаток "
+"(например в префиксах «serial:» и «usb:»)."
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "О драйвере фотоаппарата:"
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Краткие сведения о фотоаппарате:"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Руководство пользователя фотоаппарата:"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Скорость можно указывать только для последовательных портов."
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "Версия для OS/2 написана Бартом ван Лёвином\n"
 
-#: gphoto2/actions.c:907
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
 "Copyright (c) 2000-%d Лутц Мюллер и другие\n"
 "%s\n"
-"gphoto2 поставляется БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ, за исключением предписанных законом. \n"
-"Вы можете распространять копии программы gphoto2 согласно условиям GNU General \n"
+"gphoto2 поставляется БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ, за исключением предписанных "
+"законом. \n"
+"Вы можете распространять копии программы gphoto2 согласно условиям GNU "
+"General \n"
 "Public License. Более подробно об этом можно прочитать в файлах COPYING.\n"
 "\n"
-"Данная версия gphoto2 использует следующие версии программного обеспечения и настройки:\n"
+"Данная версия gphoto2 использует следующие версии программного обеспечения и "
+"настройки:\n"
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Не удалось открыть movie.mjpg."
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Идёт съёмка пробных кадров фильма в «%s». Чтобы прервать, нажмите Ctrl-C.\n"
+msgstr ""
+"Идёт съёмка пробных кадров фильма в «%s». Чтобы прервать, нажмите Ctrl-C.\n"
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr "Идёт съёмка %2$d секунд пробных кадров фильма в «%1$s».\n"
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Идёт съёмка %d пробных кадров фильма в «%s».\n"
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Ошибка съёмки фильма... Завершение."
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Ошибка съёмки фильма... Необработанный тип MIME «%s»."
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Нажата Ctrl-C... Завершение.\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Съёмка фильма закончена (количество кадров: %d)\n"
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "Ожидание событий фотоаппарата. Чтобы прервать, нажмите Ctrl-C.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr "Ожидание %d кадров фотоаппарата. Чтобы прервать, нажмите Ctrl-C.\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Ожидание событий фотоаппарата в течение %d миллисекунд. Чтобы прервать, нажмите Ctrl-C.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Ожидание событий фотоаппарата в течение %d миллисекунд. Чтобы прервать, "
+"нажмите Ctrl-C.\n"
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Ожидание событий фотоаппарата в течение %d секунд. Чтобы прервать, нажмите Ctrl-C.\n"
+msgstr ""
+"Ожидание событий фотоаппарата в течение %d секунд. Чтобы прервать, нажмите "
+"Ctrl-C.\n"
 
-#: gphoto2/actions.c:1121
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
 msgstr "Ожидание %d событий фотоаппарата. Чтобы прервать, нажмите Ctrl-C.\n"
 
-#: gphoto2/actions.c:1125
-#, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
 msgstr "Ожидание события %s фотоаппарата. Чтобы прервать, нажмите Ctrl-C.\n"
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "событие найдено, остановка ожидания!\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "событие найдено, остановка ожидания!\n"
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Невозможно задать каталог."
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Невозможно извлечь снимок."
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "Ошибка в файле libcanon.so?"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Невозможно удалить снимок."
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
-msgstr "Получение информации о хранилище не поддерживается данным фотоаппаратом.\n"
+msgstr ""
+"Получение информации о хранилище не поддерживается данным фотоаппаратом.\n"
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Чтение-Запись"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Только-Чтение"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Только-чтение с удалением"
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "Несъёмная ROM"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "Съёмная ROM"
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "Несъёмная RAM"
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "Съёмная RAM"
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Не определено"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Обычная плоская"
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Обычная иерархическая"
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Расположение камеры (DCIM)"
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Подмена ID изготовителя/модели USB устройства 0x%x/0x%x на 0x%x/0x%x"
 
-#: gphoto2/actions.c:1435
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "ОТСЫЛАЯ ОТЛАДОЧНЫЕ СООБЩЕНИЯ В СПИСОК РАССЫЛКИ ВСЕГДА ВКЛЮЧАЙТЕ В НИХ СЛЕДУЮЩИЕ СТРОКИ:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"ОТСЫЛАЯ ОТЛАДОЧНЫЕ СООБЩЕНИЯ В СПИСОК РАССЫЛКИ ВСЕГДА ВКЛЮЧАЙТЕ В НИХ "
+"СЛЕДУЮЩИЕ СТРОКИ:"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s собрана со следующими параметрами:"
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s не найден в дереве настроек."
 
-#: gphoto2/actions.c:1630
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Невозможно получить содержимое текстового поля %s."
 
-#: gphoto2/actions.c:1647
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Невозможно получить крайние значения диапазона из %s."
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Невозможно получить значения переключателя %s."
 
-#: gphoto2/actions.c:1671
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Невозможно получить значения даты/времени %s."
 
-#: gphoto2/actions.c:1680
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "Используйте «now» для указания текущего времени.\n"
 
-#: gphoto2/actions.c:1702
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Невозможно получить состояние радиокопки %s."
 
-#: gphoto2/actions.c:1746
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "Свойство %s доступно только для чтения."
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Невозможно задать значение текстового поля %s в %s."
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Переданное значение %s не является значением с плавающей точкой."
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "Переданное значение %f вне пределов диапазона %f - %f."
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Невозможно задать крайние значения диапазона %s в %f."
 
-#: gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "выкл"
 
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "ложно"
 
-#: gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "вкл"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "истинно"
 
-#: gphoto2/actions.c:1802 gphoto2/actions.c:2039
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Переданное значение %s не является значением переключателя."
 
-#: gphoto2/actions.c:1808 gphoto2/actions.c:2045
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Невозможно задать значения %s для переключателя %s."
 
-#: gphoto2/actions.c:1820
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "сейчас"
 
-#: gphoto2/actions.c:1832 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "Переданное значение %s не является числом или временем."
 
-#: gphoto2/actions.c:1840 gphoto2/actions.c:2065
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Невозможно задать новое значение для даты/времени %s в %s."
 
-#: gphoto2/actions.c:1887 gphoto2/actions.c:1951 gphoto2/actions.c:2095
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Вариант %s не найден в списке вариантов."
 
-#: gphoto2/actions.c:1895 gphoto2/actions.c:2103
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Элемент интерфейса %s не настраиваем."
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:1970 gphoto2/actions.c:2110
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
-msgstr "Невозможно задать новое значение настройки %s для настроечной единицы %s."
+msgstr ""
+"Невозможно задать новое значение настройки %s для настроечной единицы %s."
 
-#: gphoto2/actions.c:1963
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "Граф. элемент %s не имеет проиндексированного списка выбора. Вместо этого используйте --set-config-value."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"Граф. элемент %s не имеет проиндексированного списка выбора. Вместо этого "
+"используйте --set-config-value."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Неверное число файлов. Было задано %1$i, но в каталоге «%3$s» и его подкаталогах находится лишь %2$i файл(ов). Правильное число можно узнать из списка файлов."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Неверное число файлов. Было задано %1$i, но в каталоге «%3$s» и его "
+"подкаталогах находится лишь %2$i файл(ов). Правильное число можно узнать из "
+"списка файлов."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -680,25 +730,33 @@ msgstr "В каталоге «%s» нет файлов."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Неверное число файлов. Было задано %i, но в каталоге «%s» и его подкаталогах находится лишь 1 файл."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Неверное число файлов. Было задано %i, но в каталоге «%s» и его подкаталогах "
+"находится лишь 1 файл."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Неверное число файлов. Было задано %1$i, но в каталоге «%3$s» находится лишь %2$i файл(ов). Правильное число можно узнать из списка файлов."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Неверное число файлов. Было задано %1$i, но в каталоге «%3$s» находится лишь "
+"%2$i файл(ов). Правильное число можно узнать из списка файлов."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Ошибка ***              \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Нажмите любую клавишу чтобы продолжить.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Недостаточно памяти."
@@ -707,206 +765,215 @@ msgstr "Недостаточно памяти."
 msgid "Operation cancelled"
 msgstr "Действие отменено."
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Продолжить"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Отмена"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Ошибка"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Невозможно задать настройки:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Выход"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Назад"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Время: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Значение: "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Да"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Нет"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "Номера с нулями в именах файлов возможны только с %%n."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "Нельзя использовать «%%n» заполнение нулями без точного значения!"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Предоставленное фотоаппаратом имя файла («%s») не имеет расширения!"
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Неверный формат «%s» (ошибка в позиции %i)."
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Пропускается существующий файл %s\n"
 
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Файл %s существует. Перезаписать? [y|n] "
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Указать новое имя файла? [y|n] "
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Введите новое имя файла: "
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Файл сохраняется с именем %s\n"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Отказано в доступе"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Невозможно запустить процесс съёмки."
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Новый файл находится в фотоаппарате в %s%s%s\n"
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Оставляется файл %s%s%s в фотоаппарате\n"
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Удаляется файл %s%s%s в фотоаппарате\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
-msgstr "Во время ожидания произошло событие FOLDER_ADDED %s/%s, игнорируется.\n"
+msgstr ""
+"Во время ожидания произошло событие FOLDER_ADDED %s/%s, игнорируется.\n"
 
 #: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+"Во время ожидания произошло событие FOLDER_ADDED %s/%s, игнорируется.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Во время ожидания произошло событие UNKNOWN %s, игнорируется.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
-msgstr "Во время ожидания с ручной выдержкой произошло событие %d неизвестного типа, игнорируется.\n"
+msgstr ""
+"Во время ожидания с ручной выдержкой произошло событие %d неизвестного типа, "
+"игнорируется.\n"
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Не удалось определить возможности?"
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Включён режим отложенного спуска (задержка: %dсек).\n"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Ожидание SIGUSR1 для съёмки.\n"
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Включён режим ручной выдержки (время экспозиции: %dсек).\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Снимается кадр %d...\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Снимается кадр %d/%d...\n"
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Невозможно включить съёмку с выдержкой от руки, результат %d."
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Невозможно завершить съёмку (режим выдержки от руки)."
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Невозможно запустить процесс съёмки снимка."
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Невозможно сделать снимок."
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Съёмка не удалась (проблема с автофокусировкой?)...\n"
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Невозможно сделать снимок."
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Ожидание %ld секунд перед следующим снимком...\n"
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Начало работы по сигналу SIGUSR1...\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "без ожидания (%ld секунд до запланированного времени)\n"
 
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "ОШИБКА: "
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -915,12 +982,12 @@ msgstr ""
 "\n"
 "Прерывание...\n"
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Прервано.\n"
 
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -929,21 +996,26 @@ msgstr ""
 "\n"
 "Отмена...\n"
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Используйте следующую запись: a:b=c:d чтобы работать с любым устройством USB, определяемым как a:b, как с устройством c:d. a b c d - шестнадцатеричные числа, начинающиеся с «0x».\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Используйте следующую запись: a:b=c:d чтобы работать с любым устройством "
+"USB, определяемым как a:b, как с устройством c:d. a b c d - "
+"шестнадцатеричные числа, начинающиеся с «0x».\n"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "Программа gphoto2 собрана без поддержки CDK."
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Действие отменено.\n"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -952,7 +1024,7 @@ msgstr ""
 "*** Ошибка: фотоаппарат не найден. ***\n"
 "\n"
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -961,7 +1033,7 @@ msgstr ""
 "*** Ошибка (%i: «%s») ***       \n"
 "\n"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -978,7 +1050,7 @@ msgstr ""
 "gphoto2 со следующими параметрами:\n"
 "\n"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
@@ -987,393 +1059,399 @@ msgstr ""
 "Проверьте, что аргументы надёжно экранированы.\n"
 "\n"
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Показ полной справки по работе с программой"
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Показ короткой справки по работе с программой"
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Включить режим отладки"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Задать уровень отладки [error|debug|data|all]"
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Имя файла, куда будет писаться отладочная информация"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "ИМЯ_ФАЙЛА"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Не выводить сообщения (по умолчанию - выводить все)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Сценарий, выполняющийся после скачивания, съёмки и т.д."
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Задать порт устройства"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Задать скорость передачи по последовательному порту"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "СКОРОСТЬ"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Задать модель фотоаппарата"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "МОДЕЛЬ"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(для специалистов) Подмена ID USB устройств"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBID"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Показать версию и выйти"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Показать список поддерживаемых моделей"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Показать список поддерживаемых портов"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Показать возможности фотоаппарата/драйвера из базы данных libgphoto2"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Настроить"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Показать дерево настроек"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Дамп всего дерева настроек"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Получить значение параметра настройки"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Задать значение параметра настройки или индекс из списков выбора"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Задать значение настройки индекса из списков выбора"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Задать значение параметра настройки"
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Сбросить порт устройства"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Оставлять снимки в камере после съёмки"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr "Оставлять RAW-снимки в камере после съёмки"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Удалять снимки в камере после съёмки"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Ждать события(й) от фотоаппарата"
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr "ЧИСЛО, СЕКУНД, МИЛЛИСЕКУНД или СТРОКАСОВПАДЕНИЙ"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Ждать события(й) от фотоаппарата и скачать новые снимки"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Сделать пробный снимок"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr "Показать пробный снимок в виде Ascii Art"
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Задать время экcпозиции при ручной выдержке в секундах"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "СЕКУНДЫ"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Задать число снимаемых кадров (по умолчанию — бесконечное)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "ЧИСЛО"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Задать интервал между снимками"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Сбрасывать интервал между снимками по сигналу (по умолчанию — нет)"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Сделать снимок"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Запустить процесс съёмки снимка"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Сделать снимок и скачать его"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Снять фильм"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "ЧИСЛО или СЕКУНД"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Сделать звукозапись"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Ждать спуска затвора фотоаппарата и скачать"
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr "Запустить процесс съёмки"
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Показать список каталогов внутри каталога"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Показать список файлов в каталоге"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Создать каталог"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "ИМЯ_КАТАЛОГА"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Удалить каталог"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Показать количество файлов"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Извлечь файлы в диапазоне"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "ДИАПАЗОН"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Извлечь все файлы из каталога"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Извлечь миниатюры в диапазоне"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Извлечь все миниатюры из каталога"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Извлечь метаданные в диапазоне"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Извлечь все метаданные из каталога"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Загрузить метаданные файла"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Извлечь исходные данные в диапазоне"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Извлечь все исходные данные из каталога"
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Извлечь звукозаписи в диапазоне"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Извлечь все звукозаписи из каталога"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Удалить файлы в диапазоне"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Удалить все файлы в каталоге (--no-recurse по умолчанию включён)"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Загрузить файл в память фотоаппарата"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Указать имя файла или шаблон"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "ИМЯ_ФАЙЛА_ШАБЛОН"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Указать каталог фотоаппарата (по умолчанию — «/»)"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "КАТАЛОГ"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Рекурсивно (по умолчанию при копировании)"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Нерекурсивно (по умолчанию при удалении)"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Обработать только новые файлы"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Перезаписывать файлы не спрашивая"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Пропускать существующие файлы"
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Посылать файл на стандартный вывод"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Выводить размер файла перед датой"
 
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Показать список автоматически распознаваемых фотоаппаратов"
 
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "Показать данные EXIF изображений JPEG"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
-msgstr "Показать информацию об изображении, например ширину, высоту и время съёмки"
+msgstr ""
+"Показать информацию об изображении, например ширину, высоту и время съёмки"
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr "Показать краткие сведения о фотоаппарате"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Показать описание драйвера фотоаппарата"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Об описании драйвера фотоаппарата"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Показать данные о хранилище"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "Интерпретатор команд gPhoto"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Общие параметры"
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Прочие параметры (без сортировки)"
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "Получить информацию о ПО и компьютере (не фотоаппарата)"
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Указать модель фотоаппарата"
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Настройки фотоаппарата и ПО"
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Сделать снимок с или на фотоаппарат"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Скачивание, загрузка и управление файлами"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1382,7 +1460,7 @@ msgstr ""
 "%s\n"
 "ID снимков должны быть числами больше ноля."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1391,7 +1469,7 @@ msgstr ""
 "%s\n"
 "Слишком большой ID снимка %i."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1400,7 +1478,7 @@ msgstr ""
 "%s\n"
 "Диапазоны должны разделяться «,»."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1409,7 +1487,7 @@ msgstr ""
 "%s\n"
 "Диапазоны должны начинаться с цифры."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1418,224 +1496,235 @@ msgstr ""
 "%s\n"
 "Недопустимый символ «%c»."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"Нельзя указывать диапазон начиная с меньшего числа. Задан диапазон от %i до %i."
+"Нельзя указывать диапазон начиная с меньшего числа. Задан диапазон от %i до "
+"%i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Ошибка (%i: «%s») ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Перейти в каталог в памяти фотоаппарата"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "каталог"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Перейти в каталог на жёстком диске"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Выход из интерпретатора команд gPhoto"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Скачать файл"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[каталог/]файл"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Загрузить файл"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Скачать миниатюру"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Скачать исходные данные"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Удалить"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Создать каталог"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Удалить каталог"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Справка по командам"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[команда]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Показать содержимое текущего каталога"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[каталог/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Список переменных настройки"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Извлечь переменную настройки"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "имя"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Задать переменную настройки"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "имя=значение"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Задать индекс переменной настройки"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "имя=значение_индекса"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Запустить процесс съёмки снимка"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Сделать одиночный снимок"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Сделать одиночный снимок и скачать его"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Сделать снимок для предварительного просмотра"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Ждать события"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "количество или секунд"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Ждать захвата снимков и скачать их"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Ждать событий и захвата снимков скачать их"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Неверная команда."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Для команды «%s» необходимо указать аргумент."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Неверный путь."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Не найден домашний каталог."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Невозможно перейти в локальный каталог «%s»."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Текущий локальный каталог «%s»."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Текущий удалённый каталог «%s»."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "Для set-config необходимо указать второй аргумент.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "Для set-config-value необходимо указать второй аргумент.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "Для set-config-index необходимо указать второй аргумент.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Команды «%s» не существует. Введите «help» для получения списка доступных команд."
+msgstr ""
+"Команды «%s» не существует. Введите «help» для получения списка доступных "
+"команд."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Справка по «%s»:"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Использование:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Описание:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Аргументы в скобках [] могут отсутствовать"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Доступные команды:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr "Чтобы получить справку по определенной команде введите «help команда»."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Запустить процесс съёмки"
 
 #~ msgid "Show info"
 #~ msgstr "Показать сведения"

--- a/po/rw.po
+++ b/po/rw.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.1.5\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2016-03-23 21:57+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2005-04-04 10:55-0700\n"
 "Last-Translator: Steven Michael Murphy <murf@e-tools.com>\n"
 "Language-Team: Kinyarwanda <translation-team-rw@lists.sourceforge.net>\n"
@@ -25,139 +25,139 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, fuzzy, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Bya Idosiye in Ububiko"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, fuzzy, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "ni Ububiko in Ububiko"
 msgstr[1] "ni Ububiko in Ububiko"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, fuzzy, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "ni IDOSIYE in Ububiko"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, fuzzy, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "ni IDOSIYE in Ububiko"
 msgstr[1] "ni IDOSIYE in Ububiko"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, fuzzy, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "ku IDOSIYE Ububiko"
 
 # sc/source\ui\src\globstr.src:RID_GLOBSTR.STR_LINKERRORFILE.text
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, fuzzy, c-format
 msgid "File:\n"
 msgstr "Idosiye:"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, fuzzy, c-format
 msgid "  None available.\n"
 msgstr "Ntakiboneka"
 
 # framework/source\classes\fltdlg.src:DLG_FILTER_SELECT.FT_DLG_MIMETYPE.text
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, fuzzy, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "Ubwoko bwa MIME:"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, fuzzy, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "Bayite S"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, fuzzy, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "S"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, fuzzy, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "S"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, fuzzy, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "Yimuwe"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1803 gphoto2/actions.c:2046
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "Yego"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1797 gphoto2/actions.c:2040
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 #, fuzzy
 msgid "no"
 msgstr "Oya"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, fuzzy, c-format
 msgid "  Permissions: "
 msgstr "Uruhushya"
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, fuzzy, c-format
 msgid "read/delete"
 msgstr "Gusoma Gusiba"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, fuzzy, c-format
 msgid "read"
 msgstr "Soma"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "gusiba"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "ntacyo"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, fuzzy, c-format
 msgid "  Time:        %s"
 msgstr "Igihe"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr ""
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, fuzzy, c-format
 msgid "Audio data:\n"
 msgstr "Ibyatanzwe"
 
 # framework/source\classes\fltdlg.src:DLG_FILTER_SELECT.FT_DLG_MIMETYPE.text
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, fuzzy, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "Ubwoko bwa MIME:"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, fuzzy, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "Bayite S"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, fuzzy, c-format
 msgid "  Downloaded: %s\n"
 msgstr "Yimuwe"
@@ -180,48 +180,48 @@ msgstr "Itagi"
 msgid "Value"
 msgstr "Agaciro"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, fuzzy, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Ibyatanzwe Kirimo a Bayite"
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 #, fuzzy
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "Gushigikira"
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, fuzzy, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Bya"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr ""
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr ""
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr ""
 
 # desktop/source\app\ssodlg.src:DLG_SSOLOGIN.text
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, fuzzy, c-format
 msgid "\t\"%s\"\n"
 msgstr "\"%s\""
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, fuzzy, c-format
 msgid "Devices found: %i\n"
 msgstr "Byabonetse"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -231,40 +231,40 @@ msgstr ""
 # #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
 # #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
 # #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, fuzzy, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s%-16s"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Urugero"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Umuyoboro"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr ""
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, fuzzy, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "kugirango Kamera"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, fuzzy, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Umuyoboro Gushigikira"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, fuzzy, c-format
 msgid "USB support                      : %s\n"
 msgstr "Gushigikira"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr ""
@@ -272,32 +272,32 @@ msgstr ""
 # #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
 # #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
 # #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, fuzzy, c-format
 msgid "                                 : %i\n"
 msgstr ":%i"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr ""
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr ""
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr ""
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr ""
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr ""
@@ -305,50 +305,50 @@ msgstr ""
 # #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
 # #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
 # #-#-#-#-#  dbaccess.pot (PACKAGE VERSION)  #-#-#-#-#
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, fuzzy, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr ":%i"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, fuzzy, c-format
 msgid ""
 "                                 : Capture not supported by the driver\n"
 msgstr ":OYA ku i"
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, fuzzy, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Gushigikira"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, fuzzy, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Idosiye ku Kamera Gushigikira"
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, fuzzy, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Idosiye ku Kamera Gushigikira"
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, fuzzy, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Idosiye Igaragazambere Gushigikira"
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, fuzzy, c-format
 msgid "File upload support              : %s\n"
 msgstr "Idosiye Gushigikira"
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, fuzzy, c-format
 msgid ""
 "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
 "colon so I am going to guess what you mean."
 msgstr "nka Cyangwa ni Ibuze a Kuri Gukeka Impuzandengo-"
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, fuzzy, c-format
 msgid ""
 "The port you specified ('%s') can not be found. Please specify one of the "
@@ -356,37 +356,37 @@ msgid ""
 "(i.e. with prefix 'serial:' or 'usb:')."
 msgstr "E."
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, fuzzy, c-format
 msgid "About the camera driver:"
 msgstr "i Kamera Musomyi:"
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, fuzzy, c-format
 msgid "Camera summary:"
 msgstr "Inshamake"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, fuzzy, c-format
 msgid "Camera manual:"
 msgstr "Bikorwa"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, fuzzy, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "kugirango"
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 #, fuzzy
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "2. Umuyoboro ku"
 
-#: gphoto2/actions.c:907
+#: gphoto2/actions.c:894
 #, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
@@ -399,300 +399,311 @@ msgstr ""
 "C Na Na: Kuri i Kwagura ku Amakopi Bya i Bya i Birenzeho Ibisobanuro "
 "Ibyerekeye i Idosiye Verisiyo Bya ni ikoresha i Uburyo Na Amahitamo"
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 #, fuzzy
 msgid "Could not open 'movie.mjpg'."
 msgstr "OYA Kubona Ishusho"
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr ""
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr ""
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr ""
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
 msgid ""
 "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1121
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1125
+#: gphoto2/actions.c:1129
 #, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr ""
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 #, fuzzy
 msgid "Could not set folder."
 msgstr "OYA Gushyiraho Ububiko"
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 #, fuzzy
 msgid "Could not get image."
 msgstr "OYA Kubona Ishusho"
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr ""
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 #, fuzzy
 msgid "Could not delete image."
 msgstr "OYA Gusiba Ishusho"
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr ""
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr ""
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr ""
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr ""
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr ""
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr ""
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr ""
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr ""
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr ""
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr ""
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr ""
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr ""
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, fuzzy, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Umucuruzi IGIKUBO ID Na:"
 
-#: gphoto2/actions.c:1435
+#: gphoto2/actions.c:1474
 msgid ""
 "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
 "MAILING LIST:"
 msgstr ""
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, fuzzy, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%sNa: i Amahitamo"
 
-#: gphoto2/actions.c:1590
+#: gphoto2/actions.c:1629
 #, fuzzy, c-format
 msgid "%s not found in configuration tree."
 msgstr "%sOYA Byabonetse in Iboneza"
 
-#: gphoto2/actions.c:1637
+#: gphoto2/actions.c:1681
 #, fuzzy, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Kuri Agaciro Bya Umwandiko"
 
-#: gphoto2/actions.c:1654
+#: gphoto2/actions.c:1698
 #, fuzzy, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Kuri Uduciro Bya Urutonde"
 
-#: gphoto2/actions.c:1666
+#: gphoto2/actions.c:1710
 #, fuzzy, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Kuri Uduciro Bya Mukomatanya"
 
-#: gphoto2/actions.c:1678
+#: gphoto2/actions.c:1722
 #, fuzzy, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Kuri Uduciro Bya Itariki Igihe"
 
-#: gphoto2/actions.c:1687
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr ""
 
-#: gphoto2/actions.c:1709
+#: gphoto2/actions.c:1753
 #, fuzzy, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Kuri Uduciro Bya"
 
-#: gphoto2/actions.c:1753
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr ""
 
-#: gphoto2/actions.c:1767 gphoto2/actions.c:2010
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, fuzzy, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Kuri Agaciro Bya Umwandiko"
 
-#: gphoto2/actions.c:1777 gphoto2/actions.c:2020
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr ""
 
-#: gphoto2/actions.c:1782 gphoto2/actions.c:2025
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr ""
 
-#: gphoto2/actions.c:1788 gphoto2/actions.c:2031
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, fuzzy, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Kuri Uduciro Bya Urutonde"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2040
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr ""
 
-#: gphoto2/actions.c:1798 gphoto2/actions.c:2041
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 #, fuzzy
 msgid "false"
 msgstr "Agaciro"
 
-#: gphoto2/actions.c:1803 gphoto2/actions.c:2046
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 #, fuzzy
 msgid "on"
 msgstr "ntacyo"
 
-#: gphoto2/actions.c:1804 gphoto2/actions.c:2047
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr ""
 
-#: gphoto2/actions.c:1809 gphoto2/actions.c:2052
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr ""
 
-#: gphoto2/actions.c:1815 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, fuzzy, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Kuri Uduciro Bya Mukomatanya"
 
-#: gphoto2/actions.c:1827
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 #, fuzzy
 msgid "now"
 msgstr "Oya"
 
-#: gphoto2/actions.c:1839 gphoto2/actions.c:2071
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr ""
 
-#: gphoto2/actions.c:1847 gphoto2/actions.c:2078
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, fuzzy, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Kuri Uduciro Bya Itariki Igihe"
 
-#: gphoto2/actions.c:1894 gphoto2/actions.c:1961 gphoto2/actions.c:2108
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr ""
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:2116
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr ""
 
-#: gphoto2/actions.c:1912 gphoto2/actions.c:1983 gphoto2/actions.c:2126
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, fuzzy, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr "Kuri Uduciro Bya"
 
-#: gphoto2/actions.c:1973
+#: gphoto2/actions.c:2019
 #, c-format
 msgid ""
 "The %s widget has no indexed list of choices. Use --set-config-value instead."
@@ -730,17 +741,17 @@ msgstr ""
 "Itangira"
 
 # sw/source\ui\utlui\initui.src:RID_SW_SHELLRES.STR_CALC_DEFAULT.text
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, fuzzy, c-format
 msgid "*** Error ***              \n"
 msgstr "***Ikosa**"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, fuzzy, c-format
 msgid "Press any key to continue.\n"
 msgstr "Urufunguzo Kuri urifuzagukomeza"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, fuzzy, c-format
 msgid "Not enough memory."
 msgstr "Ububiko ntibuhagije"
@@ -750,255 +761,260 @@ msgstr "Ububiko ntibuhagije"
 msgid "Operation cancelled"
 msgstr "Kureka"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 #, fuzzy
 msgid "</B/24>Continue"
 msgstr "</Dukomeza"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr ""
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 #, fuzzy
 msgid "<C></5>Error"
 msgstr "<C 5"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 #, fuzzy
 msgid "Could not set configuration:"
 msgstr "OYA Gushyiraho Iboneza"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Gusohoka"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Inyuma"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 #, fuzzy
 msgid "Time: "
 msgstr "Igihe:"
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Agaciro:"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Yego"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Oya"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr ""
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, fuzzy, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "Gukoresha in Ivanga Na: Idosiye"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, fuzzy, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Izina ry'idosiye: ku i Kamera OYA a Ingereka"
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, fuzzy, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Imiterere Ikosa ku Ibirindiro"
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, fuzzy, c-format
 msgid "Skip existing file %s\n"
 msgstr "IDOSIYE Nka"
 
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, fuzzy, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Gusimbuza."
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, fuzzy, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Gishya Izina ry'idosiye: Y N"
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, fuzzy, c-format
 msgid "Enter new filename: "
 msgstr "Gishya Izina ry'idosiye:"
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, fuzzy, c-format
 msgid "Saving file as %s\n"
 msgstr "IDOSIYE Nka"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 #, fuzzy
 msgid "Permission denied"
 msgstr "Uruhushya"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 #, fuzzy
 msgid "Could not trigger capture."
 msgstr "OYA"
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, fuzzy, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "IDOSIYE ni in Ahantu ku i"
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, fuzzy, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "IDOSIYE ku i"
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, fuzzy, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "IDOSIYE ku i"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr ""
 
 #: gphoto2/main.c:916
 #, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:926
+#, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr ""
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr ""
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 #, fuzzy
 msgid "Could not get capabilities?"
 msgstr "OYA Kubona Ishusho"
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, fuzzy, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Ubwoko Bikora Intera"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr ""
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, fuzzy, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Ubwoko Bikora Intera"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, fuzzy, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Ikadiri"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, fuzzy, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Ikadiri"
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, fuzzy, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "OYA"
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 #, fuzzy
 msgid "Could not end capture (bulb mode)."
 msgstr "OYA"
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 #, fuzzy
 msgid "Could not trigger image capture."
 msgstr "OYA Kubona Ishusho"
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 #, fuzzy
 msgid "Could not capture image."
 msgstr "OYA"
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, fuzzy, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Byanze Ikiyega"
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 #, fuzzy
 msgid "Could not capture."
 msgstr "OYA"
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr ""
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr ""
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr ""
 
 # starmath/source\smres.src:RID_ERR_IDENT.text
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, fuzzy, c-format
 msgid "ERROR: "
 msgstr "IKOSA"
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
 "Aborting...\n"
 msgstr ""
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr ""
 
 # # @name NS_MSG_CANCELLING
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, fuzzy, c-format
 msgid ""
 "\n"
 "Cancelling...\n"
 msgstr "Kureka..."
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, fuzzy, c-format
 msgid ""
 "Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
 "c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
 msgstr "i a B C D Kuri APAREYE Nka a B Nka C D a B C D Imibare Itangiriro Na:"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 #, fuzzy
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "Gushigikira kugirango"
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, fuzzy, c-format
 msgid "Operation cancelled.\n"
 msgstr "Kureka"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -1006,14 +1022,14 @@ msgid ""
 msgstr ""
 
 # sw/source\ui\utlui\initui.src:RID_SW_SHELLRES.STR_CALC_DEFAULT.text
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, fuzzy, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
 "\n"
 msgstr "***Ikosa**"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, fuzzy, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -1027,496 +1043,501 @@ msgstr ""
 "Kuri Kuri Kohereza Ikosa Cyangwa Kosora amakosa Ubutumwa Kuri i Urutonde "
 "Intonde Cyuzuye Nka"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
 "\n"
 msgstr ""
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr ""
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr ""
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 #, fuzzy
 msgid "Turn on debugging"
 msgstr "ku"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr ""
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr ""
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr ""
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 #, fuzzy
 msgid "Quiet output (default=verbose)"
 msgstr "Ibisohoka Mburabuzi"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr ""
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 #, fuzzy
 msgid "Specify device port"
 msgstr "Umuyoboro APAREYE"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 #, fuzzy
 msgid "Specify serial transfer speed"
 msgstr "Umuvuduko"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr ""
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 #, fuzzy
 msgid "Specify camera model"
 msgstr "Kamera Urugero"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr ""
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr ""
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr ""
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 #, fuzzy
 msgid "Display version and exit"
 msgstr "Verisiyo Na Gusohoka"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 #, fuzzy
 msgid "List supported camera models"
 msgstr "Kamera Ingerofatizo"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 #, fuzzy
 msgid "List supported port devices"
 msgstr "Umuyoboro"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 #, fuzzy
 msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Kamera"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Kugena Imiterere"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 #, fuzzy
 msgid "List configuration tree"
 msgstr "Iboneza"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 #, fuzzy
 msgid "Dump full configuration tree"
 msgstr "Iboneza"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 #, fuzzy
 msgid "Get configuration value"
 msgstr "Iboneza Agaciro"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 #, fuzzy
 msgid "Set configuration value or index in choices"
 msgstr "Iboneza Agaciro"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 #, fuzzy
 msgid "Set configuration value index in choices"
 msgstr "Iboneza Agaciro"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 #, fuzzy
 msgid "Set configuration value"
 msgstr "Iboneza Agaciro"
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 #, fuzzy
 msgid "Reset device port"
 msgstr "Umuyoboro APAREYE"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr ""
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr ""
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr ""
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr ""
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr ""
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr ""
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 #, fuzzy
 msgid "Capture a quick preview"
 msgstr "a Igaragazambere"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr ""
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 #, fuzzy
 msgid "Set bulb exposure time in seconds"
 msgstr "Intera in amasogonda"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr ""
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 #, fuzzy
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Umubare Bya Amakadiri Kuri Mburabuzi Bidashira"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr ""
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 #, fuzzy
 msgid "Set capture interval in seconds"
 msgstr "Intera in amasogonda"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 #, fuzzy
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Intera in amasogonda"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 #, fuzzy
 msgid "Capture an image"
 msgstr "Ishusho"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 #, fuzzy
 msgid "Trigger capture of an image"
 msgstr "Ishusho"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 #, fuzzy
 msgid "Capture an image and download it"
 msgstr "Ishusho"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 #, fuzzy
 msgid "Capture a movie"
 msgstr "a"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr ""
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr ""
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr ""
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr ""
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 #, fuzzy
 msgid "List folders in folder"
 msgstr "in Ububiko"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 #, fuzzy
 msgid "List files in folder"
 msgstr "Idosiye in Ububiko"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 #, fuzzy
 msgid "Create a directory"
 msgstr "a bushyinguro"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr ""
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 #, fuzzy
 msgid "Remove a directory"
 msgstr "a bushyinguro"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 #, fuzzy
 msgid "Display number of files"
 msgstr "Umubare Bya Idosiye"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 #, fuzzy
 msgid "Get files given in range"
 msgstr "Idosiye in Urutonde"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr ""
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 #, fuzzy
 msgid "Get all files from folder"
 msgstr "Byose Idosiye Bivuye Ububiko"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 #, fuzzy
 msgid "Get thumbnails given in range"
 msgstr "in Urutonde"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 #, fuzzy
 msgid "Get all thumbnails from folder"
 msgstr "Byose Bivuye Ububiko"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 #, fuzzy
 msgid "Get metadata given in range"
 msgstr "Ibyatanzwe in Urutonde"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 #, fuzzy
 msgid "Get all metadata from folder"
 msgstr "Byose Ibyatanzwe Bivuye Ububiko"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 #, fuzzy
 msgid "Upload metadata for file"
 msgstr "a IDOSIYE"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 #, fuzzy
 msgid "Get raw data given in range"
 msgstr "Ibyatanzwe in Urutonde"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 #, fuzzy
 msgid "Get all raw data from folder"
 msgstr "Byose Ibyatanzwe Bivuye Ububiko"
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 #, fuzzy
 msgid "Get audio data given in range"
 msgstr "Ibyatanzwe in Urutonde"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 #, fuzzy
 msgid "Get all audio data from folder"
 msgstr "Byose Ibyatanzwe Bivuye Ububiko"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 #, fuzzy
 msgid "Delete files given in range"
 msgstr "Idosiye in Urutonde"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 #, fuzzy
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Byose Idosiye in Ububiko"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 #, fuzzy
 msgid "Upload a file to camera"
 msgstr "a IDOSIYE Kuri Kamera"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 #, fuzzy
 msgid "Specify a filename or filename pattern"
 msgstr "a Izina ry'idosiye:"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr ""
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 #, fuzzy
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Kamera Ububiko Mburabuzi"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr ""
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 #, fuzzy
 msgid "Recursion (default for download)"
 msgstr "Mburabuzi kugirango Gufungura"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 #, fuzzy
 msgid "No recursion (default for deletion)"
 msgstr "Mburabuzi kugirango Isibwa"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr ""
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 #, fuzzy
 msgid "Overwrite files without asking"
 msgstr "Gusimbuza Idosiye"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
-msgstr ""
-
-#: gphoto2/main.c:2133
-#, fuzzy
-msgid "Send file to stdout"
-msgstr "IDOSIYE Kuri"
-
-#: gphoto2/main.c:2135
-#, fuzzy
-msgid "Print filesize before data"
-msgstr "Mbere Ibyatanzwe"
-
-#: gphoto2/main.c:2137
-#, fuzzy
-msgid "List auto-detected cameras"
-msgstr "Ikiyega"
-
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
-#, fuzzy
-msgid "Show EXIF information of JPEG images"
-msgstr "Ibisobanuro"
-
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
-msgid "Show image information, like width, height, and capture time"
 msgstr ""
 
 #: gphoto2/main.c:2146
 #, fuzzy
+msgid "Send file to stdout"
+msgstr "IDOSIYE Kuri"
+
+#: gphoto2/main.c:2148
+#, fuzzy
+msgid "Print filesize before data"
+msgstr "Mbere Ibyatanzwe"
+
+#: gphoto2/main.c:2150
+#, fuzzy
+msgid "List auto-detected cameras"
+msgstr "Ikiyega"
+
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
+msgstr "Ibisobanuro"
+
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
+
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
 msgid "Show camera summary"
 msgstr "Inshamake"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 #, fuzzy
 msgid "Show camera driver manual"
 msgstr "Kamera Musomyi: Bikorwa"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 #, fuzzy
 msgid "About the camera driver manual"
 msgstr "i Kamera Musomyi: Bikorwa"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 #, fuzzy
 msgid "Show storage information"
 msgstr "Ibisobanuro"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 #, fuzzy
 msgid "gPhoto shell"
 msgstr "Igikonoshwa"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr ""
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr ""
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr ""
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 #, fuzzy
 msgid "Specify the camera to use"
 msgstr "Kamera Urugero"
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 #, fuzzy
 msgid "Camera and software configuration"
 msgstr "OYA Gushyiraho Iboneza"
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 #, fuzzy
 msgid "Capture an image from or on the camera"
 msgstr "Kuri a bushyinguro ku i Kamera"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr ""
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, fuzzy, c-format
 msgid ""
 "%s\n"
 "Image IDs must be a number greater than zero."
 msgstr "%sa Umubare Biruta Zeru"
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, fuzzy, c-format
 msgid ""
 "%s\n"
 "Image ID %i too high."
 msgstr "%skirekire"
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, fuzzy, c-format
 msgid ""
 "%s\n"
 "Ranges must be separated by ','."
 msgstr "%sku"
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, fuzzy, c-format
 msgid ""
 "%s\n"
 "Ranges need to start with a number."
 msgstr "%sKuri Gutangira Na: a Umubare"
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, fuzzy, c-format
 msgid ""
 "%s\n"
 "Unexpected character '%c'."
 msgstr "%sInyuguti"
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, fuzzy, c-format
 msgid ""
 "%s\n"
@@ -1524,239 +1545,244 @@ msgid ""
 msgstr "%sIbice OYA a Urutonde Bivuye Kuri"
 
 # sw/source\ui\utlui\initui.src:RID_SW_SHELLRES.STR_CALC_DEFAULT.text
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, fuzzy, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "***Ikosa**"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 #, fuzzy
 msgid "Change to a directory on the camera"
 msgstr "Kuri a bushyinguro ku i Kamera"
 
 # svtools/source\dialogs\filedlg2.src:STR_FILEDLG_DIR.text
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 #, fuzzy
 msgid "directory"
 msgstr "Ububiko"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 #, fuzzy
 msgid "Change to a directory on the local drive"
 msgstr "Kuri a bushyinguro ku i Porogaramu- shoboza"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 #, fuzzy
 msgid "Exit the gPhoto shell"
 msgstr "i Igikonoshwa"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 #, fuzzy
 msgid "Download a file"
 msgstr "a IDOSIYE"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 #, fuzzy
 msgid "[directory/]filename"
 msgstr "[bushyinguro Izina ry'idosiye:"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 #, fuzzy
 msgid "Upload a file"
 msgstr "a IDOSIYE"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 #, fuzzy
 msgid "Download a thumbnail"
 msgstr "a"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 #, fuzzy
 msgid "Download raw data"
 msgstr "Ibyatanzwe"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Gusiba"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 #, fuzzy
 msgid "Create Directory"
 msgstr "a bushyinguro"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 #, fuzzy
 msgid "Remove Directory"
 msgstr "a bushyinguro"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 #, fuzzy
 msgid "Displays command usage"
 msgstr "Komandi: Ikoresha:"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 #, fuzzy
 msgid "[command]"
 msgstr "[Komandi:"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 #, fuzzy
 msgid "List the contents of the current directory"
 msgstr "i Ibigize Bya i KIGEZWEHO bushyinguro"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 #, fuzzy
 msgid "[directory/]"
 msgstr "[ububiko"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 #, fuzzy
 msgid "List configuration variables"
 msgstr "a Iboneza IMPINDURAGACIRO"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 #, fuzzy
 msgid "Get configuration variable"
 msgstr "a Iboneza IMPINDURAGACIRO"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "izina"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 #, fuzzy
 msgid "Set configuration variable"
 msgstr "a Iboneza IMPINDURAGACIRO"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr ""
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 #, fuzzy
 msgid "Set configuration variable index"
 msgstr "a Iboneza IMPINDURAGACIRO"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr ""
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Ishusho"
+
+#: gphoto2/shell.c:158
 #, fuzzy
 msgid "Capture a single image"
 msgstr "Ishusho"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 #, fuzzy
 msgid "Capture a single image and download it"
 msgstr "Ishusho"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 #, fuzzy
 msgid "Capture a preview image"
 msgstr "Ishusho"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr ""
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 #, fuzzy
 msgid "count or seconds"
 msgstr "amasegonda"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr ""
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr ""
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 #, fuzzy
 msgid "Invalid command."
 msgstr "Komandi:"
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, fuzzy, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Komandi:"
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 #, fuzzy
 msgid "Invalid path."
 msgstr "Inzira siyo"
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 #, fuzzy
 msgid "Could not find home directory."
 msgstr "OYA Gushaka Ku Ntangiriro bushyinguro"
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, fuzzy, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "OYA Guhindura>> Kuri bushyinguro"
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, fuzzy, c-format
 msgid "Local directory now '%s'."
 msgstr "bushyinguro NONEAHA"
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, fuzzy, c-format
 msgid "Remote directory now '%s'."
 msgstr "bushyinguro NONEAHA"
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr ""
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr ""
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr ""
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, fuzzy, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
 msgstr "OYA Byabonetse Kuri Kubona a Urutonde Bya Bihari Amabwiriza"
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, fuzzy, c-format
 msgid "Help on \"%s\":"
 msgstr "ku"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Ikoresha:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Igaragaza Imiterere:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, fuzzy, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "*in Udusodeko Bitari ngombwa"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, fuzzy, c-format
 msgid "Available commands:"
 msgstr "Amabwiriza"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, fuzzy, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr "Kubona Ifashayobora ku a Komandi: Ubwoko in Ifashayobora Komandi:"

--- a/po/sk.po
+++ b/po/sk.po
@@ -6,222 +6,211 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.1.5\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2004-12-15 17:09-0500\n"
+"Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2005-03-05 12:28+0100\n"
 "Last-Translator: Andrej Kacian <andrej@kacian.sk>\n"
 "Language-Team: Slovak <sk-i18n@lists.linux.sk>\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Language: sk\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-2\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: KBabel 1.10\n"
 "Plural-Forms:  nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: gphoto2/actions.c:101
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
-msgstr "PoËet s˙borov v prieËinku '%s': %i\n"
+msgstr "Poƒçet s√∫borov v prieƒçinku '%s': %i\n"
 
-#: gphoto2/actions.c:122
-#, c-format
-msgid "There are no folders in folder '%s'."
-msgstr "V prieËinku '%s' nie s˙ æiadne prieËinky."
+#: gphoto2/actions.c:201
+#, fuzzy, c-format
+msgid "There is %d folder in folder '%s'.\n"
+msgid_plural "There are %d folders in folder '%s'.\n"
+msgstr[0] "V prieƒçinku '%s' je jeden prieƒçinok:"
+msgstr[1] "V prieƒçinku '%s' je jeden prieƒçinok:"
+msgstr[2] "V prieƒçinku '%s' je jeden prieƒçinok:"
 
-#: gphoto2/actions.c:126
-#, c-format
-msgid "There is one folder in folder '%s':"
-msgstr "V prieËinku '%s' je jeden prieËinok:"
+#: gphoto2/actions.c:250
+#, fuzzy, c-format
+msgid "There is no file in folder '%s'.\n"
+msgstr "V prieƒçinku '%s' je jeden s√∫bor:"
 
-#: gphoto2/actions.c:130
-#, c-format
-msgid "There are %i folders in folder '%s':"
-msgstr "%i prieËinkov v prieËinku '%s':"
+#: gphoto2/actions.c:253
+#, fuzzy, c-format
+msgid "There is %d file in folder '%s'.\n"
+msgid_plural "There are %d files in folder '%s'.\n"
+msgstr[0] "V prieƒçinku '%s' je jeden s√∫bor:"
+msgstr[1] "V prieƒçinku '%s' je jeden s√∫bor:"
+msgstr[2] "V prieƒçinku '%s' je jeden s√∫bor:"
 
-#: gphoto2/actions.c:157 gphoto2/foreach.c:277
-#, c-format
-msgid "There are no files in folder '%s'."
-msgstr "V prieËinku '%s' nie s˙ æiadne s˙bory."
-
-#: gphoto2/actions.c:162
-#, c-format
-msgid "There is one file in folder '%s':"
-msgstr "V prieËinku '%s' je jeden s˙bor:"
-
-#: gphoto2/actions.c:167
-#, c-format
-msgid "There are %i files in folder '%s':"
-msgstr "%i s˙borov v prieËinku '%s':"
-
-#: gphoto2/actions.c:188
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
-msgstr "Inform·cie o s˙bore '%s' (prieËinok '%s'):\n"
+msgstr "Inform√°cie o s√∫bore '%s' (prieƒçinok '%s'):\n"
 
-#: gphoto2/actions.c:190
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
-msgstr "S˙bor:\n"
+msgstr "S√∫bor:\n"
 
-#: gphoto2/actions.c:192 gphoto2/actions.c:226 gphoto2/actions.c:242
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
-msgstr "  Æiadne inform·cie nie s˙ dostupnÈ.\n"
+msgstr "  ≈Ωiadne inform√°cie nie s√∫ dostupn√©.\n"
 
-#: gphoto2/actions.c:195
-#, c-format
-msgid "  Name:        '%s'\n"
-msgstr "  N·zov:        '%s'\n"
-
-#: gphoto2/actions.c:197 gphoto2/actions.c:229
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Mime typ:   '%s'\n"
 
-#: gphoto2/actions.c:199 gphoto2/actions.c:231
-#, c-format
-msgid "  Size:        %li byte(s)\n"
-msgstr "  Veµkosª:        %li bajtov\n"
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#, fuzzy, c-format
+msgid "  Size:        %lu byte(s)\n"
+msgstr "  Veƒækos≈•:        %li bajtov\n"
 
-#: gphoto2/actions.c:201 gphoto2/actions.c:233
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
-msgstr "  ©Ìrka:       %i pixelov\n"
+msgstr "  ≈†√≠rka:       %i pixelov\n"
 
-#: gphoto2/actions.c:203 gphoto2/actions.c:235
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
-msgstr "  V˝πka:      %i pixelov\n"
+msgstr "  V√Ω≈°ka:      %i pixelov\n"
 
-#: gphoto2/actions.c:205 gphoto2/actions.c:237
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
-msgstr "  StiahnutÈ:  %s\n"
+msgstr "  Stiahnut√©:  %s\n"
 
-#: gphoto2/actions.c:206 gphoto2/actions.c:238 gphoto2/actions.c:250
-#: gphoto2/actions.c:567 gphoto2/actions.c:569 gphoto2/actions.c:597
-#: gphoto2/actions.c:600 gphoto2/actions.c:603 gphoto2/actions.c:606
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
-msgstr "·no"
+msgstr "√°no"
 
-#: gphoto2/actions.c:206 gphoto2/actions.c:238 gphoto2/actions.c:250
-#: gphoto2/actions.c:567 gphoto2/actions.c:569 gphoto2/actions.c:597
-#: gphoto2/actions.c:600 gphoto2/actions.c:603 gphoto2/actions.c:606
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "nie"
 
-#: gphoto2/actions.c:208
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
-msgstr "  PrÌstupovÈ pr·va: "
+msgstr "  Pr√≠stupov√© pr√°va: "
 
-#: gphoto2/actions.c:211
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
-msgstr "ËÌtanie/vymazanie"
+msgstr "ƒç√≠tanie/vymazanie"
 
-#: gphoto2/actions.c:213
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
-msgstr "ËÌtanie"
+msgstr "ƒç√≠tanie"
 
-#: gphoto2/actions.c:215
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "vymazanie"
 
-#: gphoto2/actions.c:217
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
-msgstr "æiadne"
+msgstr "≈æiadne"
 
-#: gphoto2/actions.c:221
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
-msgstr "  »as:        %s"
+msgstr "  ƒåas:        %s"
 
-#: gphoto2/actions.c:224
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
-msgstr "N·hµad:\n"
+msgstr "N√°hƒæad:\n"
 
-#: gphoto2/actions.c:240
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
-msgstr "ZvukovÈ data:\n"
+msgstr "Zvukov√© data:\n"
 
-#: gphoto2/actions.c:245
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Mime typ:  '%s'\n"
 
-#: gphoto2/actions.c:247
-#, c-format
-msgid "  Size:       %li byte(s)\n"
-msgstr "  Veµkosª:       %li bajtov\n"
+#: gphoto2/actions.c:332
+#, fuzzy, c-format
+msgid "  Size:       %lu byte(s)\n"
+msgstr "  Veƒækos≈•:       %li bajtov\n"
 
-#: gphoto2/actions.c:249
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
-msgstr "  StiahnutÈ: %s\n"
+msgstr "  Stiahnut√©: %s\n"
 
-#: gphoto2/actions.c:398
+#: gphoto2/actions.c:504
 msgid "Could not parse EXIF data."
-msgstr "NemÙæem preËÌtaª data EXIF."
+msgstr "Nem√¥≈æem preƒç√≠ta≈• data EXIF."
 
-#: gphoto2/actions.c:402
+#: gphoto2/actions.c:508
 #, c-format
 msgid "EXIF tags:"
 msgstr "Tagy EXIF:"
 
-#: gphoto2/actions.c:405
+#: gphoto2/actions.c:511
 msgid "Tag"
 msgstr "Tag"
 
-#: gphoto2/actions.c:407
+#: gphoto2/actions.c:513
 msgid "Value"
 msgstr "Hodnota"
 
-#: gphoto2/actions.c:428
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
-msgstr "Data EXIF obsahuj˙ n·hµad (%i bajtov)."
+msgstr "Data EXIF obsahuj√∫ n√°hƒæad (%i bajtov)."
 
-#: gphoto2/actions.c:437
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
-msgstr "aplik·cia gphoto2 bola skompilovan· bez podpory EXIF."
+msgstr "aplik√°cia gphoto2 bola skompilovan√° bez podpory EXIF."
 
-#: gphoto2/actions.c:455
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
-msgstr "PoËet podporovan˝ch fotoapar·tov: %i\n"
+msgstr "Poƒçet podporovan√Ωch fotoapar√°tov: %i\n"
 
-#: gphoto2/actions.c:457
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
-msgstr "PodporovanÈ fotoapar·ty:\n"
+msgstr "Podporovan√© fotoapar√°ty:\n"
 
-#: gphoto2/actions.c:470
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (TEST)\n"
 
-#: gphoto2/actions.c:473
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
-msgstr "\t\"%s\" (EXPERIMENT¡LNE)\n"
+msgstr "\t\"%s\" (EXPERIMENT√ÅLNE)\n"
 
-#: gphoto2/actions.c:478
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
-#: gphoto2/actions.c:506
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
-msgstr "PoËet n·jden˝ch zariadenÌ: %i\n"
+msgstr "Poƒçet n√°jden√Ωch zariaden√≠: %i\n"
 
-#: gphoto2/actions.c:507
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -230,760 +219,799 @@ msgstr ""
 "Cesta                             Popis\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:546 gphoto2/actions.c:551
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:546
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Model"
 
-#: gphoto2/actions.c:546
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Port"
 
-#: gphoto2/actions.c:547
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:565
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
-msgstr "Moænosti fotoapar·tu             : %s\n"
+msgstr "Mo≈ænosti fotoapar√°tu             : %s\n"
 
-#: gphoto2/actions.c:566
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
-msgstr "Podpora sÈriovÈho portu              : %s\n"
+msgstr "Podpora s√©riov√©ho portu              : %s\n"
 
-#: gphoto2/actions.c:568
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Podpora USB                      : %s\n"
 
-#: gphoto2/actions.c:571
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
-msgstr "PodporovanÈ r˝chlosti prenosu        :\n"
+msgstr "Podporovan√© r√Ωchlosti prenosu        :\n"
 
-#: gphoto2/actions.c:573
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:576
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
-msgstr "SpÙsoby pr·ce                  :\n"
+msgstr "Sp√¥soby pr√°ce                  :\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
-msgstr "                                 : Obr·zok\n"
+msgstr "                                 : Obr√°zok\n"
 
-#: gphoto2/actions.c:582
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:586
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Zvuk\n"
 
-#: gphoto2/actions.c:590
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
-msgstr "                                 : N·hµad\n"
+msgstr "                                 : N√°hƒæad\n"
 
-#: gphoto2/actions.c:594
-#, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : Ovl·daË nepodporuje zachytenie\n"
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:596
-#, c-format
-msgid "Configuration support            : %s\n"
-msgstr "Podpora konfigur·cie            : %s\n"
-
-#: gphoto2/actions.c:598
-#, c-format
-msgid "Delete files on camera support   : %s\n"
-msgstr "Podpora vymaz·vania s˙borov vo fotoapar·te   : %s\n"
-
-#: gphoto2/actions.c:601
-#, c-format
-msgid "File preview (thumbnail) support : %s\n"
-msgstr "Podpora n·hµadu : %s\n"
-
-#: gphoto2/actions.c:604
-#, c-format
-msgid "File upload support              : %s\n"
-msgstr "Podpora nahr·vania s˙borov do zariadenia              : %s\n"
-
-#: gphoto2/actions.c:621
-#, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Port musÌ byª v tvare 'serial:/dev/ttyS0' alebo 'usb:', ale v '%s' ch˝ba dvojbodka, preto budem h·daª, Ëo ste mysleli."
-
-#: gphoto2/actions.c:660
-#, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Vami zadan˝ port ('%s') nebol n·jden˝. ProsÌm zadajte jeden z portov n·jden˝ch pomocou prÌkazu 'gphoto --list-ports' a uistite sa, æe ste ho zadali spr·vne."
-
-#: gphoto2/actions.c:698
-#, c-format
-msgid "About the camera driver:"
-msgstr "O ovl·daËi zariadenia:"
-
-#: gphoto2/actions.c:712
-#, c-format
-msgid "Camera summary:"
-msgstr "S˙hrn o fotoapar·te:"
-
-#: gphoto2/actions.c:726
-#, c-format
-msgid "Camera manual:"
-msgstr "Manu·l k fotoapar·tu:"
-
-#: gphoto2/actions.c:742
-#, c-format
-msgid "You can only specify speeds for serial ports."
-msgstr "R˝chlosª mÙæete zadaª len pri sÈriov˝ch portoch."
-
-#: gphoto2/actions.c:793
+#: gphoto2/actions.c:700
 #, c-format
 msgid ""
-"gphoto2 %s\n"
-"\n"
-"Copyright (c) 2000-2004 Lutz Mueller and others\n"
-"%s\n"
-"gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
-"redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
-"\n"
-"This version of gphoto2 is using the following software versions and options:\n"
-msgstr ""
-"gphoto2 %s\n"
-"\n"
-"Copyright (C) 2000-2004 Lutz Mueller a ÔalπÌ\n"
-"%s\n"
-"gphoto2 je πÌrenÈ BEZ AKEJKO•VEK Z¡RUKY, v rozsahu povolenom z·konmi.\n"
-"KÛpie gphoto2 s˙ voµne πÌriteµnÈ pod podmienkami Vπeobecnej verejnej\n"
-"licencie GNU. œalπie inform·cie n·jdete v s˙bore nazvanom COPYING.\n"
-"\n"
-"T·to verzia gphoto2 pouæÌva nasledovnÈ nastavenia a verzie softwaru:\n"
+"                                 : Capture not supported by the driver\n"
+msgstr "                                 : Ovl√°daƒç nepodporuje zachytenie\n"
 
-#: gphoto2/actions.c:806
+#: gphoto2/actions.c:702
+#, c-format
+msgid "Configuration support            : %s\n"
+msgstr "Podpora konfigur√°cie            : %s\n"
+
+#: gphoto2/actions.c:704
+#, fuzzy, c-format
+msgid "Delete selected files on camera  : %s\n"
+msgstr "Podpora vymaz√°vania s√∫borov vo fotoapar√°te   : %s\n"
+
+#: gphoto2/actions.c:707
+#, fuzzy, c-format
+msgid "Delete all files on camera       : %s\n"
+msgstr "Podpora vymaz√°vania s√∫borov vo fotoapar√°te   : %s\n"
+
+#: gphoto2/actions.c:710
+#, c-format
+msgid "File preview (thumbnail) support : %s\n"
+msgstr "Podpora n√°hƒæadu : %s\n"
+
+#: gphoto2/actions.c:713
+#, c-format
+msgid "File upload support              : %s\n"
+msgstr "Podpora nahr√°vania s√∫borov do zariadenia              : %s\n"
+
+#: gphoto2/actions.c:730
+#, c-format
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Port mus√≠ by≈• v tvare 'serial:/dev/ttyS0' alebo 'usb:', ale v '%s' ch√Ωba "
+"dvojbodka, preto budem h√°da≈•, ƒço ste mysleli."
+
+#: gphoto2/actions.c:764
+#, c-format
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Vami zadan√Ω port ('%s') nebol n√°jden√Ω. Pros√≠m zadajte jeden z portov "
+"n√°jden√Ωch pomocou pr√≠kazu 'gphoto --list-ports' a uistite sa, ≈æe ste ho "
+"zadali spr√°vne."
+
+#: gphoto2/actions.c:797
+#, c-format
+msgid "About the camera driver:"
+msgstr "O ovl√°daƒçi zariadenia:"
+
+#: gphoto2/actions.c:810
+#, c-format
+msgid "Camera summary:"
+msgstr "S√∫hrn o fotoapar√°te:"
+
+#: gphoto2/actions.c:823
+#, c-format
+msgid "Camera manual:"
+msgstr "Manu√°l k fotoapar√°tu:"
+
+#: gphoto2/actions.c:840
+#, c-format
+msgid "You can only specify speeds for serial ports."
+msgstr "R√Ωchlos≈• m√¥≈æete zada≈• len pri s√©riov√Ωch portoch."
+
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "OS/2 port - Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:880
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
+msgid ""
+"gphoto2 %s\n"
+"\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
+"%s\n"
+"gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
+"redistribute copies of gphoto2 under the terms of the GNU General Public\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
+"\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
+msgstr ""
+"gphoto2 %s\n"
+"\n"
+"Copyright (C) 2000-2004 Lutz Mueller a ƒèal≈°√≠\n"
+"%s\n"
+"gphoto2 je ≈°√≠ren√© BEZ AKEJKOƒΩVEK Z√ÅRUKY, v rozsahu povolenom z√°konmi.\n"
+"K√≥pie gphoto2 s√∫ voƒæne ≈°√≠riteƒæn√© pod podmienkami V≈°eobecnej verejnej\n"
+"licencie GNU. ƒéal≈°ie inform√°cie n√°jdete v s√∫bore nazvanom COPYING.\n"
+"\n"
+"T√°to verzia gphoto2 pou≈æ√≠va nasledovn√© nastavenia a verzie softwaru:\n"
+
+#: gphoto2/actions.c:1015
+#, fuzzy
+msgid "Could not open 'movie.mjpg'."
+msgstr "Ned√° sa z√≠ska≈• obr√°zok."
+
+#: gphoto2/actions.c:1022
+#, c-format
+msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1026
+#, c-format
+msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1031
+#, c-format
+msgid "Capturing %d preview frames as movie to '%s'.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1047
+msgid "Movie capture error... Exiting."
+msgstr ""
+
+#: gphoto2/actions.c:1053
+#, c-format
+msgid "Movie capture error... Unhandled MIME type '%s'."
+msgstr ""
+
+#: gphoto2/actions.c:1060
+#, c-format
+msgid "Ctrl-C pressed ... Exiting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1074
+#, c-format
+msgid "Movie capture finished (%d frames)\n"
+msgstr ""
+
+#: gphoto2/actions.c:1106
+#, c-format
+msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1112
+#, c-format
+msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1117
+#, c-format
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1122
+#, c-format
+msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1125
+#, c-format
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1129
+#, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
+#, c-format
+msgid "event found, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
+msgid "Could not set folder."
+msgstr "Ned√° sa nastavi≈• prieƒçinok."
+
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
+msgid "Could not get image."
+msgstr "Ned√° sa z√≠ska≈• obr√°zok."
+
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
+msgid "Buggy libcanon.so?"
+msgstr "Chybn√Ω libcanon.so?"
+
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
+#, fuzzy
+msgid "Could not delete image."
+msgstr "Obr√°zok sa ned√° odstr√°ni≈•."
+
+#: gphoto2/actions.c:1300
+#, c-format
+msgid "Getting storage information not supported for this camera.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1315
+#, c-format
+msgid "Read-Write"
+msgstr ""
+
+#: gphoto2/actions.c:1318
+#, c-format
+msgid "Read-Only"
+msgstr ""
+
+#: gphoto2/actions.c:1321
+#, c-format
+msgid "Read-only with delete"
+msgstr ""
+
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
+#, c-format
+msgid "Unknown"
+msgstr ""
+
+#: gphoto2/actions.c:1337
+#, c-format
+msgid "Fixed ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1340
+#, c-format
+msgid "Removable ROM"
+msgstr ""
+
+#: gphoto2/actions.c:1343
+#, c-format
+msgid "Fixed RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1346
+#, c-format
+msgid "Removable RAM"
+msgstr ""
+
+#: gphoto2/actions.c:1356
+#, c-format
+msgid "Undefined"
+msgstr ""
+
+#: gphoto2/actions.c:1359
+#, c-format
+msgid "Generic Flat"
+msgstr ""
+
+#: gphoto2/actions.c:1362
+#, c-format
+msgid "Generic Hierarchical"
+msgstr ""
+
+#: gphoto2/actions.c:1365
+#, c-format
+msgid "Camera layout (DCIM)"
+msgstr ""
+
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
-msgstr "PouæÌvam USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
+msgstr "Pou≈æ√≠vam USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 
-#: gphoto2/actions.c:931
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "PRI ODOSIELANÕ SPR¡V O CHYB¡CH DO MAILINGLISTU VÆDY PRIPOJTE TIETO RIADKY:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"PRI ODOSIELAN√ç SPR√ÅV O CHYB√ÅCH DO MAILINGLISTU V≈ΩDY PRIPOJTE TIETO RIADKY:"
 
-#: gphoto2/actions.c:946
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
-msgstr "%s bolo skompilovanÈ s t˝mito voµbami:"
+msgstr "%s bolo skompilovan√© s t√Ωmito voƒæbami:"
 
-#: gphoto2/actions.c:1042
-#, c-format
-msgid "%s not found in configuration tree.\n"
-msgstr "%s nebolo n·jdenÈ v konfiguraËnom strome.\n"
+#: gphoto2/actions.c:1629
+#, fuzzy, c-format
+msgid "%s not found in configuration tree."
+msgstr "%s nebolo n√°jden√© v konfiguraƒçnom strome.\n"
 
-#: gphoto2/actions.c:1070
-#, c-format
-msgid "Failed to retrieve value of text widget %s.\n"
-msgstr "Nepodarilo sa zÌskaª hodnotu textu %s.\n"
+#: gphoto2/actions.c:1681
+#, fuzzy, c-format
+msgid "Failed to retrieve value of text widget %s."
+msgstr "Nepodarilo sa z√≠ska≈• hodnotu textu %s.\n"
 
-#: gphoto2/actions.c:1087
-#, c-format
-msgid "Failed to retrieve values of range widget %s.\n"
-msgstr "Nepodarilo sa zÌskaª hodnotu rozsahu %s.\n"
+#: gphoto2/actions.c:1698
+#, fuzzy, c-format
+msgid "Failed to retrieve values of range widget %s."
+msgstr "Nepodarilo sa z√≠ska≈• hodnotu rozsahu %s.\n"
 
-#: gphoto2/actions.c:1099
-#, c-format
-msgid "Failed to retrieve values of toggle widget %s.\n"
-msgstr "Nepodarilo sa zÌskaª hodnotu prepÌnaËa %s.\n"
+#: gphoto2/actions.c:1710
+#, fuzzy, c-format
+msgid "Failed to retrieve values of toggle widget %s."
+msgstr "Nepodarilo sa z√≠ska≈• hodnotu prep√≠naƒça %s.\n"
 
-#: gphoto2/actions.c:1114
-#, c-format
-msgid "Failed to retrieve values of date/time widget %s.\n"
-msgstr "Nepodarilo sa zÌskaª hodnotu d·tumu/Ëasu %s.\n"
+#: gphoto2/actions.c:1722
+#, fuzzy, c-format
+msgid "Failed to retrieve values of date/time widget %s."
+msgstr "Nepodarilo sa z√≠ska≈• hodnotu d√°tumu/ƒçasu %s.\n"
 
-#: gphoto2/actions.c:1137
-#, c-format
-msgid "Failed to retrieve values of radio widget %s.\n"
-msgstr "Nepodarilo sa zÌskaª hodnotu voµby %s.\n"
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
 
-#: gphoto2/foreach.c:254
-#, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "ZlÈ ËÌslo s˙boru. Zadali ste %i, ale v prieËinku a jeho podprieËinkoch sa nach·dza iba %i s˙borov. PlatnÈ ËÌslo s˙boru zistÌte zo zoznamu s˙borov prieËinku '%s'."
+#: gphoto2/actions.c:1753
+#, fuzzy, c-format
+msgid "Failed to retrieve values of radio widget %s."
+msgstr "Nepodarilo sa z√≠ska≈• hodnotu voƒæby %s.\n"
 
-#: gphoto2/foreach.c:283
+#: gphoto2/actions.c:1799
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "ZlÈ ËÌslo s˙boru. Zadali ste %i, ale v prieËinku '%s' sa nach·dza iba jeden s˙bor"
+msgid "Property %s is read only."
+msgstr ""
+
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
+#, fuzzy, c-format
+msgid "Failed to set the value of text widget %s to %s."
+msgstr "Nepodarilo sa z√≠ska≈• hodnotu textu %s.\n"
+
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
+#, c-format
+msgid "The passed value %s is not a floating point value."
+msgstr ""
+
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
+#, c-format
+msgid "The passed value %f is not within the expected range %f - %f."
+msgstr ""
+
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
+#, fuzzy, c-format
+msgid "Failed to set the value of range widget %s to %f."
+msgstr "Nepodarilo sa z√≠ska≈• hodnotu rozsahu %s.\n"
+
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
+msgid "off"
+msgstr ""
+
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
+msgid "false"
+msgstr ""
+
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
+#, fuzzy
+msgid "on"
+msgstr "Po"
+
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
+msgid "true"
+msgstr ""
+
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
+#, c-format
+msgid "The passed value %s is not a valid toggle value."
+msgstr ""
+
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
+#, fuzzy, c-format
+msgid "Failed to set values %s of toggle widget %s."
+msgstr "Nepodarilo sa z√≠ska≈• hodnotu prep√≠naƒça %s.\n"
+
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
+#, fuzzy
+msgid "now"
+msgstr "nie"
+
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
+#, c-format
+msgid "The passed value %s is neither a valid time nor an integer."
+msgstr ""
+
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
+#, fuzzy, c-format
+msgid "Failed to set new time of date/time widget %s to %s."
+msgstr "Nepodarilo sa z√≠ska≈• hodnotu d√°tumu/ƒçasu %s.\n"
+
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
+#, c-format
+msgid "Choice %s not found within list of choices."
+msgstr ""
+
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
+#, c-format
+msgid "The %s widget is not configurable."
+msgstr ""
+
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
+#, fuzzy, c-format
+msgid "Failed to set new configuration value %s for configuration entry %s."
+msgstr "Nepodarilo sa z√≠ska≈• hodnotu voƒæby %s.\n"
+
+#: gphoto2/actions.c:2019
+#, c-format
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+
+#: gphoto2/foreach.c:260
+#, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Zl√© ƒç√≠slo s√∫boru. Zadali ste %i, ale v prieƒçinku a jeho podprieƒçinkoch sa "
+"nach√°dza iba %i s√∫borov. Platn√© ƒç√≠slo s√∫boru zist√≠te zo zoznamu s√∫borov "
+"prieƒçinku '%s'."
+
+#: gphoto2/foreach.c:285
+#, c-format
+msgid "There are no files in folder '%s'."
+msgstr "V prieƒçinku '%s' nie s√∫ ≈æiadne s√∫bory."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'.Please obtain a valid file number from a file listing first."
-msgstr "ZlÈ ËÌslo s˙boru. Zadali ste %i, ale v prieËinku sa nach·dza iba %i s˙borov. PlatnÈ ËÌslo s˙boru zistÌte zo zoznamu s˙borov v prieËinku '%s'."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Zl√© ƒç√≠slo s√∫boru. Zadali ste %i, ale v prieƒçinku '%s' sa nach√°dza iba jeden "
+"s√∫bor"
 
-#: gphoto2/gp-params.c:59
+#: gphoto2/foreach.c:299
+#, fuzzy, c-format
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Zl√© ƒç√≠slo s√∫boru. Zadali ste %i, ale v prieƒçinku sa nach√°dza iba %i s√∫borov. "
+"Platn√© ƒç√≠slo s√∫boru zist√≠te zo zoznamu s√∫borov v prieƒçinku '%s'."
+
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Chyba ***              \n"
 
-#: gphoto2/gp-params.c:232
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
-msgstr "StlaËte kl·vesu pre pokraËovanie.\n"
+msgstr "Stlaƒçte kl√°vesu pre pokraƒçovanie.\n"
 
-#: gphoto2/gp-params.c:249
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
-msgstr "Nedostatok pam‰te."
+msgstr "Nedostatok pam√§te."
 
-#: gphoto2/gphoto2-cmd-capture.c:201
+#: gphoto2/gphoto2-cmd-capture.c:211
 msgid "Operation cancelled"
-msgstr "Oper·cia zruπen·"
+msgstr "Oper√°cia zru≈°en√°"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
-msgstr "</B/24>PokraËovaª"
+msgstr "</B/24>Pokraƒçova≈•"
 
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Storno"
 
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Chyba"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
-msgstr "Nastavenie sa ned· pouæiª:"
+msgstr "Nastavenie sa ned√° pou≈æi≈•:"
 
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
-msgstr "UkonËiª"
+msgstr "Ukonƒçi≈•"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
-msgstr "Nasp‰ª"
+msgstr "Nasp√§≈•"
 
-#: gphoto2/gphoto2-cmd-config.c:254
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
-msgstr "»as: "
+msgstr "ƒåas: "
 
-#: gphoto2/gphoto2-cmd-config.c:313 gphoto2/gphoto2-cmd-config.c:341
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Hodnota: "
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
-msgstr "¡no"
+msgstr "√Åno"
 
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Nie"
 
-#: gphoto2/main.c:165 gphoto2/main.c:1636
-msgid "Turn on debugging"
-msgstr "Zapn˙ª ladenie"
-
-#: gphoto2/main.c:166 gphoto2/main.c:1638
-msgid "Quiet output (default=verbose)"
-msgstr "Tich˝ v˝stup (implicitne=detailn˝)"
-
-#: gphoto2/main.c:170 gphoto2/main.c:1642
-msgid "Display version and exit"
-msgstr "ZobrazÌ verziu a ukonËÌ sa"
-
-#: gphoto2/main.c:171
-msgid "Displays this help screen"
-msgstr "ZobrazÌ tento text"
-
-#: gphoto2/main.c:172 gphoto2/main.c:1644
-msgid "List supported camera models"
-msgstr "VypÌπe zoznam podporovan˝ch typov fotoapar·tov"
-
-#: gphoto2/main.c:173 gphoto2/main.c:1646
-msgid "List supported port devices"
-msgstr "VypÌπe zoznam podporovan˝ch portov"
-
-#: gphoto2/main.c:174 gphoto2/main.c:1648
-msgid "Send file to stdout"
-msgstr "Odoπle s˙bor na πtandardn˝ v˝stup"
-
-#: gphoto2/main.c:175 gphoto2/main.c:1650
-msgid "Print filesize before data"
-msgstr "Pred d·tami vypÌπe veµkosª s˙boru"
-
-#: gphoto2/main.c:176 gphoto2/main.c:1652
-msgid "List auto-detected cameras"
-msgstr "VypÌπe zoznam n·jden˝ch fotoapar·tov"
-
-#: gphoto2/main.c:179 gphoto2/main.c:1654
-msgid "Specify port device"
-msgstr "UrËenie portu"
-
-#: gphoto2/main.c:180 gphoto2/main.c:1656
-msgid "Specify serial transfer speed"
-msgstr "UrËenie prenosovej r˝chlosti pri sÈriovom porte"
-
-#: gphoto2/main.c:181 gphoto2/main.c:1658
-msgid "Specify camera model"
-msgstr "UrËÌ typ fotoapar·tu"
-
-#: gphoto2/main.c:182 gphoto2/main.c:1660
-msgid "Specify a filename"
-msgstr "UrËÌ n·zov s˙boru"
-
-#: gphoto2/main.c:183 gphoto2/main.c:1662
-msgid "(expert only) Override USB IDs"
-msgstr "(pre pokroËil˝ch) UrËiª USB ID"
-
-#: gphoto2/main.c:186 gphoto2/main.c:1664
-msgid "Display camera abilities"
-msgstr "ZobrazÌ moænosti fotoapar·tu"
-
-#: gphoto2/main.c:187 gphoto2/main.c:1666
-msgid "Specify camera folder (default=\"/\")"
-msgstr "UrËÌ prieËinok fotoapar·tu (implicitne \"/\")"
-
-#: gphoto2/main.c:188 gphoto2/main.c:1668
-msgid "Recursion (default for download)"
-msgstr "Rekurzia (prednastavenÈ pri sªahovanÌ)"
-
-#: gphoto2/main.c:189 gphoto2/main.c:1670
-msgid "No recursion (default for deletion)"
-msgstr "Bez rekurzie (prednastavenÈ pri mazanÌ)"
-
-#: gphoto2/main.c:190 gphoto2/main.c:1672
-msgid "List folders in folder"
-msgstr "ZobrazÌ zoznam podprieËinkov v prieËinku"
-
-#: gphoto2/main.c:191 gphoto2/main.c:1674
-msgid "List files in folder"
-msgstr "VypÌπe zoznam s˙borov v prieËinku"
-
-#: gphoto2/main.c:192 gphoto2/main.c:193
-msgid "name"
-msgstr "n·zov"
-
-#: gphoto2/main.c:192 gphoto2/main.c:1676
-msgid "Create a directory"
-msgstr "VytvorÌ prieËinok"
-
-#: gphoto2/main.c:193 gphoto2/main.c:1678
-msgid "Remove a directory"
-msgstr "Odstr·ni prieËinok"
-
-#: gphoto2/main.c:194 gphoto2/main.c:1680
-msgid "Display number of files"
-msgstr "ZobrazÌ poËet s˙borov"
-
-#: gphoto2/main.c:195 gphoto2/main.c:1682
-msgid "Get files given in range"
-msgstr "Stiahne s˙bory v danom rozsahu"
-
-#: gphoto2/main.c:196 gphoto2/main.c:1684
-msgid "Get all files from folder"
-msgstr "Stiahne vπetky s˙bory v prieËinku"
-
-#: gphoto2/main.c:197 gphoto2/main.c:1686
-msgid "Get thumbnails given in range"
-msgstr "Stiahne n·hµady v danom rozsahu"
-
-#: gphoto2/main.c:198 gphoto2/main.c:1689
-msgid "Get all thumbnails from folder"
-msgstr "Stiahne n·hµady z celÈho prieËinku"
-
-#: gphoto2/main.c:199 gphoto2/main.c:1692
-msgid "Get raw data given in range"
-msgstr "Stiahne ËistÈ data v danom rozsahu"
-
-#: gphoto2/main.c:200 gphoto2/main.c:1695
-msgid "Get all raw data from folder"
-msgstr "Stiahne ËistÈ data z celÈho prieËinku"
-
-#: gphoto2/main.c:201 gphoto2/main.c:1698
-msgid "Get audio data given in range"
-msgstr "Stiahne zvukovÈ data v danom rozsahu"
-
-#: gphoto2/main.c:202 gphoto2/main.c:1701
-msgid "Get all audio data from folder"
-msgstr "Stiahne zvukovÈ data z celÈho prieËinku"
-
-#: gphoto2/main.c:203 gphoto2/main.c:1703
-msgid "Delete files given in range"
-msgstr "Vymaæe s˙bory v danom rozsahu"
-
-#: gphoto2/main.c:204 gphoto2/main.c:1705
-msgid "Delete all files in folder"
-msgstr "Vymaæe vπetky s˙bory z prieËinku"
-
-#: gphoto2/main.c:205 gphoto2/main.c:1707
-msgid "Upload a file to camera"
-msgstr "Nahr· s˙bor do fotoapar·tu"
-
-#: gphoto2/main.c:207 gphoto2/main.c:1710
-msgid "Configure"
-msgstr "Konfigur·cia"
-
-#: gphoto2/main.c:209
-msgid "List the configuration tree"
-msgstr "Zobraziª konfiguraËn˝ strom"
-
-#: gphoto2/main.c:210
-msgid "Get a configuration variable"
-msgstr "ZÌskaª konfiguraËn˙ premenn˙"
-
-#: gphoto2/main.c:211 gphoto2/main.c:1720
-msgid "Set number of frames to capture (default=infinite)"
-msgstr "Zadajte poËet obr·zkov pre zachytenie (prednastavenÈ=nekoneËno)"
-
-#: gphoto2/main.c:212 gphoto2/main.c:1722
-msgid "Set capture interval in seconds"
-msgstr "Zadajte interval zachyt·vania v sekund·ch"
-
-#: gphoto2/main.c:213 gphoto2/main.c:1718
-msgid "Capture a quick preview"
-msgstr "ZÌska r˝chly n·hµad"
-
-#: gphoto2/main.c:214 gphoto2/main.c:1724
-msgid "Capture an image"
-msgstr "ZachytÌ obr·zok"
-
-#: gphoto2/main.c:215
-msgid "Capture a movie "
-msgstr "ZachytÌ film "
-
-#: gphoto2/main.c:216 gphoto2/main.c:1728
-msgid "Capture an audio clip"
-msgstr "ZachytÌ zvukov˝ klip"
-
-#: gphoto2/main.c:218 gphoto2/main.c:1731 gphoto2/shell.c:113
-msgid "Show EXIF information"
-msgstr "ZobrazÌ inform·cie EXIF"
-
-#: gphoto2/main.c:220 gphoto2/main.c:1734 gphoto2/shell.c:109
-msgid "Show info"
-msgstr "ZobrazÌ inform·cie"
-
-#: gphoto2/main.c:221
-msgid "Summary of camera status"
-msgstr "S˙hrn stavu fotoapar·tu"
-
-#: gphoto2/main.c:222
-msgid "Camera driver manual"
-msgstr "Manu·l ovl·daËa fotoapar·tu"
-
-#: gphoto2/main.c:223
-msgid "About the camera driver"
-msgstr "O ovl·daËi fotoapar·tu"
-
-#: gphoto2/main.c:224 gphoto2/main.c:1742
-msgid "gPhoto shell"
-msgstr "prÌkazov˝ riadok gPhoto"
-
-#: gphoto2/main.c:367 gphoto2/main.c:1354
+#: gphoto2/main.c:220
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Pouæite syntax a:b=c:d, ak chcete pristupovaª spÙsobom c:d k zariadeniu n·jdenÈmu ako a:b. a b c d musia byª hexadecim·lne ËÌsla zaËÌnaj˙ce '0x'.\n"
+msgid "Zero padding numbers in file names is only possible with %%n."
+msgstr ""
 
-#: gphoto2/main.c:504
-msgid "Jan"
-msgstr "Jan"
+#: gphoto2/main.c:229
+#, fuzzy, c-format
+msgid "You cannot use %%n zero padding without a precision value!"
+msgstr "Nem√¥≈æete pou≈æi≈• '%%n' v kombin√°cii s nest√°lymi s√∫bormi!"
 
-#: gphoto2/main.c:504
-msgid "January"
-msgstr "Janu·r"
-
-#: gphoto2/main.c:505
-msgid "Feb"
-msgstr "Feb"
-
-#: gphoto2/main.c:505
-msgid "February"
-msgstr "Febru·r"
-
-#: gphoto2/main.c:506
-msgid "Mar"
-msgstr "Mar"
-
-#: gphoto2/main.c:506
-msgid "March"
-msgstr "Marec"
-
-#: gphoto2/main.c:507
-msgid "Apr"
-msgstr "Apr"
-
-#: gphoto2/main.c:507
-msgid "April"
-msgstr "AprÌl"
-
-#: gphoto2/main.c:508
-msgid "May"
-msgstr "M·j"
-
-#: gphoto2/main.c:509
-msgid "Jun"
-msgstr "J˙n"
-
-#: gphoto2/main.c:509
-msgid "June"
-msgstr "J˙n"
-
-#: gphoto2/main.c:510
-msgid "Jul"
-msgstr "J˙l"
-
-#: gphoto2/main.c:510
-msgid "July"
-msgstr "J˙l"
-
-#: gphoto2/main.c:511
-msgid "Aug"
-msgstr "Aug"
-
-#: gphoto2/main.c:511
-msgid "August"
-msgstr "August"
-
-#: gphoto2/main.c:512
-msgid "Sep"
-msgstr "Sep"
-
-#: gphoto2/main.c:512
-msgid "September"
-msgstr "September"
-
-#: gphoto2/main.c:513
-msgid "Oct"
-msgstr "Okt"
-
-#: gphoto2/main.c:513
-msgid "October"
-msgstr "OktÛber"
-
-#: gphoto2/main.c:514
-msgid "Nov"
-msgstr "Nov"
-
-#: gphoto2/main.c:514
-msgid "November"
-msgstr "November"
-
-#: gphoto2/main.c:515
-msgid "Dec"
-msgstr "Dec"
-
-#: gphoto2/main.c:515
-msgid "December"
-msgstr "December"
-
-#: gphoto2/main.c:522
-msgid "Sun"
-msgstr "Ne"
-
-#: gphoto2/main.c:522
-msgid "Sunday"
-msgstr "Nedeµa"
-
-#: gphoto2/main.c:523
-msgid "Mon"
-msgstr "Po"
-
-#: gphoto2/main.c:523
-msgid "Monday"
-msgstr "Pondelok"
-
-#: gphoto2/main.c:524
-msgid "Tue"
-msgstr "Ut"
-
-#: gphoto2/main.c:524
-msgid "Tuesday"
-msgstr "Utorok"
-
-#: gphoto2/main.c:525
-msgid "Wed"
-msgstr "St"
-
-#: gphoto2/main.c:525
-msgid "Wednesday"
-msgstr "Streda"
-
-#: gphoto2/main.c:526
-msgid "Thu"
-msgstr "©t"
-
-#: gphoto2/main.c:526
-msgid "Thursday"
-msgstr "©tvrtok"
-
-#: gphoto2/main.c:527
-msgid "Fri"
-msgstr "Pi"
-
-#: gphoto2/main.c:527
-msgid "Friday"
-msgstr "Piatok"
-
-#: gphoto2/main.c:528
-msgid "Sat"
-msgstr "So"
-
-#: gphoto2/main.c:528
-msgid "Saturday"
-msgstr "Sobota"
-
-#: gphoto2/main.c:590
-#, c-format
-msgid "You cannot use '%%n' in combination with non-persistent files!"
-msgstr "NemÙæete pouæiª '%%n' v kombin·cii s nest·lymi s˙bormi!"
-
-#: gphoto2/main.c:613
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
-msgstr "N·zov s˙boru zÌskan˝ z fotoapar·tu ('%s') neobsahuje prÌponu!"
+msgstr "N√°zov s√∫boru z√≠skan√Ω z fotoapar√°tu ('%s') neobsahuje pr√≠ponu!"
 
-#: gphoto2/main.c:692
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
-msgstr "Neplatn˝ form·t '%s' (chyba na pozÌcii %i)."
+msgstr "Neplatn√Ω form√°t '%s' (chyba na poz√≠cii %i)."
 
-#: gphoto2/main.c:739
+#: gphoto2/main.c:386 gphoto2/main.c:592
+#, fuzzy, c-format
+msgid "Skip existing file %s\n"
+msgstr "Uklad√°m s√∫bor ako %s\n"
+
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
-msgstr "S˙bor %s existuje. PrepÌsaª ho? [y/n] "
+msgstr "S√∫bor %s existuje. Prep√≠sa≈• ho? [y/n] "
 
-#: gphoto2/main.c:750
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
-msgstr "Zadaª nov˝ n·zov? [y/n] "
+msgstr "Zada≈• nov√Ω n√°zov? [y/n] "
 
-#: gphoto2/main.c:759
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
-msgstr "Zadajte nov˝ n·zov: "
+msgstr "Zadajte nov√Ω n√°zov: "
 
-#: gphoto2/main.c:764
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
-msgstr "Uklad·m s˙bor ako %s\n"
+msgstr "Uklad√°m s√∫bor ako %s\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:630
+#, fuzzy
+msgid "Permission denied"
+msgstr "  Pr√≠stupov√© pr√°va: "
+
+#: gphoto2/main.c:800
+#, fuzzy
+msgid "Could not trigger capture."
+msgstr "Nem√¥≈æem z√≠skava≈•."
+
+#: gphoto2/main.c:830
+#, c-format
+msgid "New file is in location %s%s%s on the camera\n"
+msgstr "Nov√Ω s√∫bor bol ulo≈æen√Ω na fotoapar√°t ako %s%s%s\n"
+
+#: gphoto2/main.c:847 gphoto2/main.c:878
+#, fuzzy, c-format
+msgid "Keeping file %s%s%s on the camera\n"
+msgstr "Odstra≈àujem s√∫bor %s%s%s vo fotoapar√°te\n"
+
+#: gphoto2/main.c:868
+#, c-format
+msgid "Deleting file %s%s%s on the camera\n"
+msgstr "Odstra≈àujem s√∫bor %s%s%s vo fotoapar√°te\n"
+
+#: gphoto2/main.c:911
+#, c-format
+msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:916
+#, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:926
+#, c-format
+msgid "Event UNKNOWN %s during wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:932
+#, c-format
+msgid "Unknown event type %d during bulb wait, ignoring.\n"
+msgstr ""
+
+#: gphoto2/main.c:950
+#, fuzzy
+msgid "Could not get capabilities?"
+msgstr "Ned√° sa z√≠ska≈• obr√°zok."
+
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
-msgstr "Reæim r˝chleho zachyt·vania (interval: %ds).\n"
+msgstr "Re≈æim r√Ωchleho zachyt√°vania (interval: %ds).\n"
+
+#: gphoto2/main.c:961
+#, c-format
+msgid "Standing by waiting for SIGUSR1 to capture.\n"
+msgstr ""
+
+#: gphoto2/main.c:967
+#, fuzzy, c-format
+msgid "Bulb mode enabled (exposure time: %ds).\n"
+msgstr "Re≈æim r√Ωchleho zachyt√°vania (interval: %ds).\n"
+
+#: gphoto2/main.c:975
+#, c-format
+msgid "Capturing frame #%d...\n"
+msgstr "Z√≠skavam obr√°zok #%d...\n"
 
 #: gphoto2/main.c:977
 #, c-format
-msgid "Capturing frame #%d...\n"
-msgstr "ZÌskavam obr·zok #%d...\n"
-
-#: gphoto2/main.c:979
-#, c-format
 msgid "Capturing frame #%d/%d...\n"
-msgstr "ZÌskavam obr·zok #%d/%d...\n"
+msgstr "Z√≠skavam obr√°zok #%d/%d...\n"
 
-#: gphoto2/main.c:986
-msgid "Could not capture."
-msgstr "NemÙæem zÌskavaª."
+#: gphoto2/main.c:987
+#, fuzzy, c-format
+msgid "Could not set bulb capture, result %d."
+msgstr "Nem√¥≈æem z√≠skava≈•."
 
-#: gphoto2/main.c:995
+#: gphoto2/main.c:1001
+#, fuzzy
+msgid "Could not end capture (bulb mode)."
+msgstr "Nem√¥≈æem z√≠skava≈•."
+
+#: gphoto2/main.c:1014
+#, fuzzy
+msgid "Could not trigger image capture."
+msgstr "Ned√° sa z√≠ska≈• obr√°zok."
+
+#: gphoto2/main.c:1021
+#, fuzzy
+msgid "Could not capture image."
+msgstr "Nem√¥≈æem z√≠skava≈•."
+
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
-msgstr "ZÌskavanie zlyhalo (problÈm s automatick˝m zaostrovanÌm?)...\n"
+msgstr "Z√≠skavanie zlyhalo (probl√©m s automatick√Ωm zaostrovan√≠m?)...\n"
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1039
+msgid "Could not capture."
+msgstr "Nem√¥≈æem z√≠skava≈•."
+
+#: gphoto2/main.c:1074
 #, c-format
-msgid "New file is in location %s%s%s on the camera\n"
-msgstr "Nov˝ s˙bor bol uloæen˝ na fotoapar·t ako %s%s%s\n"
+msgid "Waiting for next capture slot %ld seconds...\n"
+msgstr ""
 
-#: gphoto2/main.c:1019
-msgid "Could not set folder."
-msgstr "Ned· sa nastaviª prieËinok."
-
-#: gphoto2/main.c:1037
-msgid "Could not get image."
-msgstr "Ned· sa zÌskaª obr·zok."
-
-#: gphoto2/main.c:1044
-msgid "Buggy libcanon.so?"
-msgstr "Chybn˝ libcanon.so?"
-
-#: gphoto2/main.c:1050
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
-msgid "Deleting file %s%s%s on the camera\n"
-msgstr "OdstraÚujem s˙bor %s%s%s vo fotoapar·te\n"
+msgid "Awakened by SIGUSR1...\n"
+msgstr ""
 
-#: gphoto2/main.c:1055
-msgid "Count not delete image."
-msgstr "Obr·zok sa ned· odstr·niª."
-
-#: gphoto2/main.c:1069
-msgid "Could not close camera connection."
-msgstr "Ned· sa uzavrieª spojenie s fotoapar·tom."
-
-#: gphoto2/main.c:1073
+#: gphoto2/main.c:1096
 #, c-format
-msgid "Sleeping for %d second(s)...\n"
-msgstr "SpÌm %d sek˙nd...\n"
+msgid "not sleeping (%ld seconds behind schedule)\n"
+msgstr ""
 
-#: gphoto2/main.c:1207
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "CHYBA: "
 
-#: gphoto2/main.c:1230
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
 "Aborting...\n"
 msgstr ""
 "\n"
-"UkonËujem...\n"
+"Ukonƒçujem...\n"
 
-#: gphoto2/main.c:1236
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
-msgstr "UkonËenÈ.\n"
+msgstr "Ukonƒçen√©.\n"
 
-#: gphoto2/main.c:1241
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
 "Cancelling...\n"
 msgstr ""
 "\n"
-"RuπÌm...\n"
+"Ru≈°√≠m...\n"
 
-#: gphoto2/main.c:1459
+#: gphoto2/main.c:1426
+#, c-format
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Pou≈æite syntax a:b=c:d, ak chcete pristupova≈• sp√¥sobom c:d k zariadeniu "
+"n√°jden√©mu ako a:b. a b c d musia by≈• hexadecim√°lne ƒç√≠sla zaƒç√≠naj√∫ce '0x'.\n"
+
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
-msgstr "aplik·cia gphoto2 bola skompilovan· bez podpory pre CDK."
+msgstr "aplik√°cia gphoto2 bola skompilovan√° bez podpory pre CDK."
 
-#: gphoto2/main.c:1579
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
-msgstr "Oper·cia zruπen·.\n"
+msgstr "Oper√°cia zru≈°en√°.\n"
 
-#: gphoto2/main.c:1583
+#: gphoto2/main.c:1883
+#, c-format
+msgid ""
+"*** Error: No camera found. ***\n"
+"\n"
+msgstr ""
+
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -992,7 +1020,7 @@ msgstr ""
 "*** Chyba (%i: '%s') ***       \n"
 "\n"
 
-#: gphoto2/main.c:1587
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -1002,286 +1030,924 @@ msgid ""
 "gphoto2 as follows:\n"
 "\n"
 msgstr ""
-"Pre ladiace spr·vy pouæite voµbu --debug.\n"
-"Ladiace spr·vy V·m mÙæu pomÙcª vyrieπiª v·π problÈm.\n"
-"Ak chcete poslaª chybovÈ alebo ladiace spr·vy na mailinglist\n"
-"v˝voj·rov gphoto <gphoto-devel@lists.sourceforge.net>, spustite prosÌm\n"
+"Pre ladiace spr√°vy pou≈æite voƒæbu --debug.\n"
+"Ladiace spr√°vy V√°m m√¥≈æu pom√¥c≈• vyrie≈°i≈• v√°≈° probl√©m.\n"
+"Ak chcete posla≈• chybov√© alebo ladiace spr√°vy na mailinglist\n"
+"v√Ωvoj√°rov gphoto <gphoto-devel@lists.sourceforge.net>, spustite pros√≠m\n"
 "gphoto2 takto:\n"
 "\n"
 
-#: gphoto2/main.c:1640
-msgid "Overwrite files without asking."
-msgstr "PrepÌπe s˙bory bez upozornenia"
+#: gphoto2/main.c:1911
+#, c-format
+msgid ""
+"Please make sure there is sufficient quoting around the arguments.\n"
+"\n"
+msgstr ""
 
-#: gphoto2/main.c:1654
-msgid "path"
-msgstr "cesta"
+#: gphoto2/main.c:1978
+msgid "Print complete help message on program usage"
+msgstr ""
 
-#: gphoto2/main.c:1656
-msgid "speed"
-msgstr "r˝chlosª"
+#: gphoto2/main.c:1980
+msgid "Print short message on program usage"
+msgstr ""
 
-#: gphoto2/main.c:1658
-msgid "model"
-msgstr "typ"
+#: gphoto2/main.c:1982
+msgid "Turn on debugging"
+msgstr "Zapn√∫≈• ladenie"
 
-#: gphoto2/main.c:1660
-msgid "filename"
-msgstr "n·zov s˙boru"
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
 
-#: gphoto2/main.c:1662
-msgid "usbid"
-msgstr "usbid"
+#: gphoto2/main.c:1986
+msgid "Name of file to write debug info to"
+msgstr ""
 
-#: gphoto2/main.c:1666
-msgid "folder"
-msgstr "prieËinok"
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
+msgid "FILENAME"
+msgstr ""
 
-#: gphoto2/main.c:1713
+#: gphoto2/main.c:1988
+msgid "Quiet output (default=verbose)"
+msgstr "Tich√Ω v√Ωstup (implicitne=detailn√Ω)"
+
+#: gphoto2/main.c:1990
+msgid "Hook script to call after downloads, captures, etc."
+msgstr ""
+
+#: gphoto2/main.c:1997
+#, fuzzy
+msgid "Specify device port"
+msgstr "Urƒçenie portu"
+
+#: gphoto2/main.c:1999
+msgid "Specify serial transfer speed"
+msgstr "Urƒçenie prenosovej r√Ωchlosti pri s√©riovom porte"
+
+#: gphoto2/main.c:1999
+msgid "SPEED"
+msgstr ""
+
+#: gphoto2/main.c:2001
+msgid "Specify camera model"
+msgstr "Urƒç√≠ typ fotoapar√°tu"
+
+#: gphoto2/main.c:2001
+msgid "MODEL"
+msgstr ""
+
+#: gphoto2/main.c:2003
+msgid "(expert only) Override USB IDs"
+msgstr "(pre pokroƒçil√Ωch) Urƒçi≈• USB ID"
+
+#: gphoto2/main.c:2003
+msgid "USBIDs"
+msgstr ""
+
+#: gphoto2/main.c:2009
+msgid "Display version and exit"
+msgstr "Zobraz√≠ verziu a ukonƒç√≠ sa"
+
+#: gphoto2/main.c:2011
+msgid "List supported camera models"
+msgstr "Vyp√≠≈°e zoznam podporovan√Ωch typov fotoapar√°tov"
+
+#: gphoto2/main.c:2013
+msgid "List supported port devices"
+msgstr "Vyp√≠≈°e zoznam podporovan√Ωch portov"
+
+#: gphoto2/main.c:2015
+msgid "Display the camera/driver abilities in the libgphoto2 database"
+msgstr ""
+
+#: gphoto2/main.c:2022
+msgid "Configure"
+msgstr "Konfigur√°cia"
+
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
-msgstr "Zobrazenie konfiguraËnÈho stromu"
+msgstr "Zobrazenie konfiguraƒçn√©ho stromu"
 
-#: gphoto2/main.c:1715
+#: gphoto2/main.c:2027
+#, fuzzy
+msgid "Dump full configuration tree"
+msgstr "Zobrazenie konfiguraƒçn√©ho stromu"
+
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
-msgstr "ZÌskaª konfiguraËn˙ hodnotu"
+msgstr "Z√≠ska≈• konfiguraƒçn√∫ hodnotu"
 
-#: gphoto2/main.c:1720
-msgid "count"
-msgstr "poËet"
+#: gphoto2/main.c:2031
+#, fuzzy
+msgid "Set configuration value or index in choices"
+msgstr "Z√≠ska≈• konfiguraƒçn√∫ hodnotu"
 
-#: gphoto2/main.c:1722
-msgid "seconds"
-msgstr "sek˙nd"
+#: gphoto2/main.c:2033
+#, fuzzy
+msgid "Set configuration value index in choices"
+msgstr "Z√≠ska≈• konfiguraƒçn√∫ hodnotu"
 
-#: gphoto2/main.c:1726
+#: gphoto2/main.c:2035
+#, fuzzy
+msgid "Set configuration value"
+msgstr "Z√≠ska≈• konfiguraƒçn√∫ hodnotu"
+
+#: gphoto2/main.c:2037
+msgid "Reset device port"
+msgstr ""
+
+#: gphoto2/main.c:2043
+msgid "Keep images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2045
+msgid "Keep RAW images on camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2047
+msgid "Remove images from camera after capturing"
+msgstr ""
+
+#: gphoto2/main.c:2049
+msgid "Wait for event(s) from camera"
+msgstr ""
+
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
+
+#: gphoto2/main.c:2051
+msgid "Wait for event(s) from the camera and download new images"
+msgstr ""
+
+#: gphoto2/main.c:2054
+msgid "Capture a quick preview"
+msgstr "Z√≠ska r√Ωchly n√°hƒæad"
+
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
+
+#: gphoto2/main.c:2059
+#, fuzzy
+msgid "Set bulb exposure time in seconds"
+msgstr "Zadajte interval zachyt√°vania v sekund√°ch"
+
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
+msgid "SECONDS"
+msgstr ""
+
+#: gphoto2/main.c:2061
+msgid "Set number of frames to capture (default=infinite)"
+msgstr "Zadajte poƒçet obr√°zkov pre zachytenie (prednastaven√©=nekoneƒçno)"
+
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr ""
+
+#: gphoto2/main.c:2063
+msgid "Set capture interval in seconds"
+msgstr "Zadajte interval zachyt√°vania v sekund√°ch"
+
+#: gphoto2/main.c:2065
+#, fuzzy
+msgid "Reset capture interval on signal (default=no)"
+msgstr "Zadajte interval zachyt√°vania v sekund√°ch"
+
+#: gphoto2/main.c:2067
+msgid "Capture an image"
+msgstr "Zachyt√≠ obr√°zok"
+
+#: gphoto2/main.c:2069
+#, fuzzy
+msgid "Trigger capture of an image"
+msgstr "Zachyt√≠ obr√°zok"
+
+#: gphoto2/main.c:2071
+#, fuzzy
+msgid "Capture an image and download it"
+msgstr "Zachyt√≠ obr√°zok"
+
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
-msgstr "ZachytÌ film"
+msgstr "Zachyt√≠ film"
 
-#: gphoto2/main.c:1736
-msgid "Show summary"
-msgstr "ZobrazÌ s˙hrn"
+#: gphoto2/main.c:2073
+msgid "COUNT or SECONDS"
+msgstr ""
 
-#: gphoto2/main.c:1738
+#: gphoto2/main.c:2075
+msgid "Capture an audio clip"
+msgstr "Zachyt√≠ zvukov√Ω klip"
+
+#: gphoto2/main.c:2077
+msgid "Wait for shutter release on the camera and download"
+msgstr ""
+
+#: gphoto2/main.c:2083
+msgid "List folders in folder"
+msgstr "Zobraz√≠ zoznam podprieƒçinkov v prieƒçinku"
+
+#: gphoto2/main.c:2085
+msgid "List files in folder"
+msgstr "Vyp√≠≈°e zoznam s√∫borov v prieƒçinku"
+
+#: gphoto2/main.c:2087
+msgid "Create a directory"
+msgstr "Vytvor√≠ prieƒçinok"
+
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
+msgid "DIRNAME"
+msgstr ""
+
+#: gphoto2/main.c:2089
+msgid "Remove a directory"
+msgstr "Odstr√°ni prieƒçinok"
+
+#: gphoto2/main.c:2091
+msgid "Display number of files"
+msgstr "Zobraz√≠ poƒçet s√∫borov"
+
+#: gphoto2/main.c:2093
+msgid "Get files given in range"
+msgstr "Stiahne s√∫bory v danom rozsahu"
+
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
+msgid "RANGE"
+msgstr ""
+
+#: gphoto2/main.c:2095
+msgid "Get all files from folder"
+msgstr "Stiahne v≈°etky s√∫bory v prieƒçinku"
+
+#: gphoto2/main.c:2097
+msgid "Get thumbnails given in range"
+msgstr "Stiahne n√°hƒæady v danom rozsahu"
+
+#: gphoto2/main.c:2100
+msgid "Get all thumbnails from folder"
+msgstr "Stiahne n√°hƒæady z cel√©ho prieƒçinku"
+
+#: gphoto2/main.c:2102
+#, fuzzy
+msgid "Get metadata given in range"
+msgstr "Stiahne ƒçist√© data v danom rozsahu"
+
+#: gphoto2/main.c:2104
+#, fuzzy
+msgid "Get all metadata from folder"
+msgstr "Stiahne ƒçist√© data z cel√©ho prieƒçinku"
+
+#: gphoto2/main.c:2106
+msgid "Upload metadata for file"
+msgstr ""
+
+#: gphoto2/main.c:2109
+msgid "Get raw data given in range"
+msgstr "Stiahne ƒçist√© data v danom rozsahu"
+
+#: gphoto2/main.c:2112
+msgid "Get all raw data from folder"
+msgstr "Stiahne ƒçist√© data z cel√©ho prieƒçinku"
+
+#: gphoto2/main.c:2115
+msgid "Get audio data given in range"
+msgstr "Stiahne zvukov√© data v danom rozsahu"
+
+#: gphoto2/main.c:2118
+msgid "Get all audio data from folder"
+msgstr "Stiahne zvukov√© data z cel√©ho prieƒçinku"
+
+#: gphoto2/main.c:2120
+msgid "Delete files given in range"
+msgstr "Vyma≈æe s√∫bory v danom rozsahu"
+
+#: gphoto2/main.c:2122
+#, fuzzy
+msgid "Delete all files in folder (--no-recurse by default)"
+msgstr "Vyma≈æe v≈°etky s√∫bory z prieƒçinku"
+
+#: gphoto2/main.c:2124
+msgid "Upload a file to camera"
+msgstr "Nahr√° s√∫bor do fotoapar√°tu"
+
+#: gphoto2/main.c:2126
+#, fuzzy
+msgid "Specify a filename or filename pattern"
+msgstr "Urƒç√≠ n√°zov s√∫boru"
+
+#: gphoto2/main.c:2126
+msgid "FILENAME_PATTERN"
+msgstr ""
+
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
+msgid "Specify camera folder (default=\"/\")"
+msgstr "Urƒç√≠ prieƒçinok fotoapar√°tu (implicitne \"/\")"
+
+#: gphoto2/main.c:2130
+msgid "FOLDER"
+msgstr ""
+
+#: gphoto2/main.c:2132
+msgid "Recursion (default for download)"
+msgstr "Rekurzia (prednastaven√© pri s≈•ahovan√≠)"
+
+#: gphoto2/main.c:2134
+msgid "No recursion (default for deletion)"
+msgstr "Bez rekurzie (prednastaven√© pri mazan√≠)"
+
+#: gphoto2/main.c:2136
+msgid "Process new files only"
+msgstr ""
+
+#: gphoto2/main.c:2138
+#, fuzzy
+msgid "Overwrite files without asking"
+msgstr "Prep√≠≈°e s√∫bory bez upozornenia"
+
+#: gphoto2/main.c:2140
+msgid "Skip existing files"
+msgstr ""
+
+#: gphoto2/main.c:2146
+msgid "Send file to stdout"
+msgstr "Odo≈°le s√∫bor na ≈°tandardn√Ω v√Ωstup"
+
+#: gphoto2/main.c:2148
+msgid "Print filesize before data"
+msgstr "Pred d√°tami vyp√≠≈°e veƒækos≈• s√∫boru"
+
+#: gphoto2/main.c:2150
+msgid "List auto-detected cameras"
+msgstr "Vyp√≠≈°e zoznam n√°jden√Ωch fotoapar√°tov"
+
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
+msgstr "Zobraz√≠ inform√°cie EXIF"
+
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
+
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
+msgstr "Zobraz√≠ s√∫hrn"
+
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
-msgstr "ZobrazÌ manu·l k ovl·daËu fotoapar·tu"
+msgstr "Zobraz√≠ manu√°l k ovl√°daƒçu fotoapar√°tu"
 
-#: gphoto2/main.c:1740
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
-msgstr "O ovl·daËi fotoapar·tu"
+msgstr "O ovl√°daƒçi fotoapar√°tu"
 
-#: gphoto2/main.c:1967
-#, c-format
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
-msgstr "gPhoto2 pre OS/2 vyæaduje, aby ste nastavili premenn˙ prostredia CAMLIBS na umiestnenie kniænÌc fotoapar·tov. Napr. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
+#, fuzzy
+msgid "Show storage information"
+msgstr "Zobraz√≠ inform√°cie EXIF"
 
-#: gphoto2/main.c:1977
-#, c-format
-msgid "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
-msgstr "gPhoto2 pre OS/2 vyæaduje, aby ste nastavili premenn˙ prostredia IOLIBS na umiestnenie kniænÌc fotoapar·tov. Napr. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#: gphoto2/main.c:2167
+msgid "gPhoto shell"
+msgstr "pr√≠kazov√Ω riadok gPhoto"
 
-#: gphoto2/options.c:181
-#, c-format
-msgid "Usage:\n"
-msgstr "Pouæitie:\n"
-
-#: gphoto2/options.c:184
-#, c-format
-msgid ""
-"Short/long options (& argument)        Description\n"
-"--------------------------------------------------------------------------------\n"
+#: gphoto2/main.c:2173
+msgid "Common options"
 msgstr ""
-"Kr·tke/dlhÈ voµby (a parametre)        Popis\n"
-"--------------------------------------------------------------------------------\n"
 
-#: gphoto2/options.c:209
-#, c-format
-msgid "%-38s %s\n"
-msgstr "%-38s %s\n"
-
-#: gphoto2/options.c:214
-#, c-format
-msgid ""
-"--------------------------------------------------------------------------------\n"
-"[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
+#: gphoto2/main.c:2175
+msgid "Miscellaneous options (unsorted)"
 msgstr ""
-"--------------------------------------------------------------------------------\n"
-"[Pouæite ˙vodzovky pred a za parametrami]        [»Ìsla obr·zkov zaËÌnaj˙ ËÌslom jedna (1)]\n"
 
-#: gphoto2/range.c:103 gphoto2/range.c:157
+#: gphoto2/main.c:2177
+msgid "Get information on software and host system (not from the camera)"
+msgstr ""
+
+#: gphoto2/main.c:2179
+#, fuzzy
+msgid "Specify the camera to use"
+msgstr "Urƒç√≠ typ fotoapar√°tu"
+
+#: gphoto2/main.c:2181
+#, fuzzy
+msgid "Camera and software configuration"
+msgstr "Nastavenie sa ned√° pou≈æi≈•:"
+
+#: gphoto2/main.c:2183
+#, fuzzy
+msgid "Capture an image from or on the camera"
+msgstr "Zmen√≠ prieƒçinok vo fotoapar√°te"
+
+#: gphoto2/main.c:2185
+msgid "Downloading, uploading and manipulating files"
+msgstr ""
+
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
 "Image IDs must be a number greater than zero."
 msgstr ""
 "%s\n"
-"ID obr·zkov musia byª v‰Ëπie ako nula."
+"ID obr√°zkov musia by≈• v√§ƒç≈°ie ako nula."
 
-#: gphoto2/range.c:109 gphoto2/range.c:163
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
 "Image ID %i too high."
 msgstr ""
 "%s\n"
-"ID obr·zku %i je prÌliπ vysokÈ."
+"ID obr√°zku %i je pr√≠li≈° vysok√©."
 
-#: gphoto2/range.c:125
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
 "Ranges must be separated by ','."
 msgstr ""
 "%s\n"
-"Rozsahy musia byª oddelenÈ Ëiarkou."
+"Rozsahy musia by≈• oddelen√© ƒçiarkou."
 
-#: gphoto2/range.c:139
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
 "Ranges need to start with a number."
 msgstr ""
 "%s\n"
-"Rozsahy musia zaËÌnaª ËÌslom."
+"Rozsahy musia zaƒç√≠na≈• ƒç√≠slom."
 
-#: gphoto2/range.c:179
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
 "Unexpected character '%c'."
 msgstr ""
 "%s\n"
-"NeoËak·van˝ znak '%c'."
+"Neoƒçak√°van√Ω znak '%c'."
 
-#: gphoto2/range.c:202
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"Rozsahy musia zaËÌnaª menπÌm ËÌslom. Zadali ste rozsah od %i do %i."
+"Rozsahy musia zaƒç√≠na≈• men≈°√≠m ƒç√≠slom. Zadali ste rozsah od %i do %i."
 
-#: gphoto2/shell.c:55
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Chyba (%i: '%s') ***"
 
-#: gphoto2/shell.c:98
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
-msgstr "ZmenÌ prieËinok vo fotoapar·te"
+msgstr "Zmen√≠ prieƒçinok vo fotoapar√°te"
 
-#: gphoto2/shell.c:99 gphoto2/shell.c:101
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
-msgstr "prieËinok"
+msgstr "prieƒçinok"
 
-#: gphoto2/shell.c:100
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
-msgstr "ZmenÌ prieËinok na lok·lnom disku"
+msgstr "Zmen√≠ prieƒçinok na lok√°lnom disku"
 
-#: gphoto2/shell.c:102 gphoto2/shell.c:120 gphoto2/shell.c:121
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
-msgstr "OpustÌ prÌkazov˝ riadok gPhoto"
+msgstr "Opust√≠ pr√≠kazov√Ω riadok gPhoto"
 
-#: gphoto2/shell.c:103
+#: gphoto2/shell.c:131
 msgid "Download a file"
-msgstr "Stiahne s˙bor"
+msgstr "Stiahne s√∫bor"
 
-#: gphoto2/shell.c:103 gphoto2/shell.c:106 gphoto2/shell.c:108
-#: gphoto2/shell.c:110 gphoto2/shell.c:111 gphoto2/shell.c:114
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
-msgstr "[prieËinok/]s˙bor"
+msgstr "[prieƒçinok/]s√∫bor"
 
-#: gphoto2/shell.c:105
+#: gphoto2/shell.c:132
+#, fuzzy
+msgid "Upload a file"
+msgstr "Stiahne s√∫bor"
+
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
-msgstr "Stiahne n·hµad"
+msgstr "Stiahne n√°hƒæad"
 
-#: gphoto2/shell.c:107
+#: gphoto2/shell.c:135
 msgid "Download raw data"
-msgstr "Stiahne ËistÈ data"
+msgstr "Stiahne ƒçist√© data"
 
-#: gphoto2/shell.c:111
+#: gphoto2/shell.c:139
 msgid "Delete"
-msgstr "Vymaæe"
+msgstr "Vyma≈æe"
 
-#: gphoto2/shell.c:116 gphoto2/shell.c:122
+#: gphoto2/shell.c:140
+#, fuzzy
+msgid "Create Directory"
+msgstr "Vytvor√≠ prieƒçinok"
+
+#: gphoto2/shell.c:141
+#, fuzzy
+msgid "Remove Directory"
+msgstr "Odstr√°ni prieƒçinok"
+
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
-msgstr "ZobrazÌ pouæitie prÌkazov"
+msgstr "Zobraz√≠ pou≈æitie pr√≠kazov"
 
-#: gphoto2/shell.c:117 gphoto2/shell.c:122
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
-msgstr "[prÌkaz]"
+msgstr "[pr√≠kaz]"
 
-#: gphoto2/shell.c:118
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
-msgstr "ZobrazÌ obsah aktu·lneho prieËinku"
+msgstr "Zobraz√≠ obsah aktu√°lneho prieƒçinku"
 
-#: gphoto2/shell.c:119
+#: gphoto2/shell.c:149
 msgid "[directory/]"
-msgstr "[prieËinok/]"
+msgstr "[prieƒçinok/]"
 
-#: gphoto2/shell.c:425
+#: gphoto2/shell.c:152
+#, fuzzy
+msgid "List configuration variables"
+msgstr "Z√≠ska≈• konfiguraƒçn√∫ premenn√∫"
+
+#: gphoto2/shell.c:153
+#, fuzzy
+msgid "Get configuration variable"
+msgstr "Z√≠ska≈• konfiguraƒçn√∫ premenn√∫"
+
+#: gphoto2/shell.c:153
+msgid "name"
+msgstr "n√°zov"
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+#, fuzzy
+msgid "Set configuration variable"
+msgstr "Z√≠ska≈• konfiguraƒçn√∫ premenn√∫"
+
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
+msgid "name=value"
+msgstr ""
+
+#: gphoto2/shell.c:155
+#, fuzzy
+msgid "Set configuration variable index"
+msgstr "Z√≠ska≈• konfiguraƒçn√∫ premenn√∫"
+
+#: gphoto2/shell.c:155
+msgid "name=valueindex"
+msgstr ""
+
+#: gphoto2/shell.c:157
+msgid "Triggers the capture of a single image"
+msgstr ""
+
+#: gphoto2/shell.c:158
+#, fuzzy
+msgid "Capture a single image"
+msgstr "Zachyt√≠ obr√°zok"
+
+#: gphoto2/shell.c:159
+msgid "Capture a single image and download it"
+msgstr ""
+
+#: gphoto2/shell.c:160
+#, fuzzy
+msgid "Capture a preview image"
+msgstr "Zachyt√≠ obr√°zok"
+
+#: gphoto2/shell.c:161
+msgid "Wait for an event"
+msgstr ""
+
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
+#, fuzzy
+msgid "count or seconds"
+msgstr "sek√∫nd"
+
+#: gphoto2/shell.c:162
+msgid "Wait for images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:163
+msgid "Wait for events and images to be captured and download it"
+msgstr ""
+
+#: gphoto2/shell.c:488
 msgid "Invalid command."
-msgstr "Neplatn˝ prÌkaz."
+msgstr "Neplatn√Ω pr√≠kaz."
 
-#: gphoto2/shell.c:434
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
-msgstr "PrÌkaz '%s' vyæaduje parameter."
+msgstr "Pr√≠kaz '%s' vy≈æaduje parameter."
 
-#: gphoto2/shell.c:487
+#: gphoto2/shell.c:550
 msgid "Invalid path."
-msgstr "Neplatn· cesta."
+msgstr "Neplatn√° cesta."
 
-#: gphoto2/shell.c:533
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
-msgstr "NemÙæem n·jsª domovsk˝ prieËinok."
+msgstr "Nem√¥≈æem n√°js≈• domovsk√Ω prieƒçinok."
 
-#: gphoto2/shell.c:541
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
-msgstr "NemÙæem zmeniª aktu·lny prieËinok na '%s'."
+msgstr "Nem√¥≈æem zmeni≈• aktu√°lny prieƒçinok na '%s'."
 
-#: gphoto2/shell.c:544
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
-msgstr "Lok·lny prieËinok je teraz '%s'."
+msgstr "Lok√°lny prieƒçinok je teraz '%s'."
 
-#: gphoto2/shell.c:582
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
-msgstr "Vzdialen˝ prieËinok je teraz '%s'."
+msgstr "Vzdialen√Ω prieƒçinok je teraz '%s'."
 
-#: gphoto2/shell.c:738
+#: gphoto2/shell.c:874
+#, c-format
+msgid "set-config needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:895
+#, c-format
+msgid "set-config-value needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:916
+#, c-format
+msgid "set-config-index needs a second argument.\n"
+msgstr ""
+
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "PrÌkaz '%s nebol n·jden˝. Pouæite 'help' pre zoznam dostupn˝ch prÌkazov."
+msgstr ""
+"Pr√≠kaz '%s nebol n√°jden√Ω. Pou≈æite 'help' pre zoznam dostupn√Ωch pr√≠kazov."
 
-#: gphoto2/shell.c:745
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Pomoc k \"%s\":"
 
-#: gphoto2/shell.c:747
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
-msgstr "Pouæitie:"
+msgstr "Pou≈æitie:"
 
-#: gphoto2/shell.c:751
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Popis:"
 
-#: gphoto2/shell.c:753
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
-msgstr "* Parametre v hranat˝ch z·tvork·ch [] s˙ nepovinnÈ"
+msgstr "* Parametre v hranat√Ωch z√°tvork√°ch [] s√∫ nepovinn√©"
 
-#: gphoto2/shell.c:774
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
-msgstr "DostupnÈ prÌkazy:"
+msgstr "Dostupn√© pr√≠kazy:"
 
-#: gphoto2/shell.c:779
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Pre pomoc k jednotliv˝m prÌkazom napÌπte 'help n·zov-prÌkazu'."
+msgstr "Pre pomoc k jednotliv√Ωm pr√≠kazom nap√≠≈°te 'help n√°zov-pr√≠kazu'."
+
+#, c-format
+#~ msgid "There are no folders in folder '%s'."
+#~ msgstr "V prieƒçinku '%s' nie s√∫ ≈æiadne prieƒçinky."
+
+#, c-format
+#~ msgid "There are %i folders in folder '%s':"
+#~ msgstr "%i prieƒçinkov v prieƒçinku '%s':"
+
+#, c-format
+#~ msgid "There are %i files in folder '%s':"
+#~ msgstr "%i s√∫borov v prieƒçinku '%s':"
+
+#, c-format
+#~ msgid "  Name:        '%s'\n"
+#~ msgstr "  N√°zov:        '%s'\n"
+
+#~ msgid "Displays this help screen"
+#~ msgstr "Zobraz√≠ tento text"
+
+#~ msgid "Display camera abilities"
+#~ msgstr "Zobraz√≠ mo≈ænosti fotoapar√°tu"
+
+#~ msgid "List the configuration tree"
+#~ msgstr "Zobrazi≈• konfiguraƒçn√Ω strom"
+
+#~ msgid "Capture a movie "
+#~ msgstr "Zachyt√≠ film "
+
+#~ msgid "Show info"
+#~ msgstr "Zobraz√≠ inform√°cie"
+
+#~ msgid "Summary of camera status"
+#~ msgstr "S√∫hrn stavu fotoapar√°tu"
+
+#~ msgid "Camera driver manual"
+#~ msgstr "Manu√°l ovl√°daƒça fotoapar√°tu"
+
+#~ msgid "About the camera driver"
+#~ msgstr "O ovl√°daƒçi fotoapar√°tu"
+
+#~ msgid "Jan"
+#~ msgstr "Jan"
+
+#~ msgid "January"
+#~ msgstr "Janu√°r"
+
+#~ msgid "Feb"
+#~ msgstr "Feb"
+
+#~ msgid "February"
+#~ msgstr "Febru√°r"
+
+#~ msgid "Mar"
+#~ msgstr "Mar"
+
+#~ msgid "March"
+#~ msgstr "Marec"
+
+#~ msgid "Apr"
+#~ msgstr "Apr"
+
+#~ msgid "April"
+#~ msgstr "Apr√≠l"
+
+#~ msgid "May"
+#~ msgstr "M√°j"
+
+#~ msgid "Jun"
+#~ msgstr "J√∫n"
+
+#~ msgid "June"
+#~ msgstr "J√∫n"
+
+#~ msgid "Jul"
+#~ msgstr "J√∫l"
+
+#~ msgid "July"
+#~ msgstr "J√∫l"
+
+#~ msgid "Aug"
+#~ msgstr "Aug"
+
+#~ msgid "August"
+#~ msgstr "August"
+
+#~ msgid "Sep"
+#~ msgstr "Sep"
+
+#~ msgid "September"
+#~ msgstr "September"
+
+#~ msgid "Oct"
+#~ msgstr "Okt"
+
+#~ msgid "October"
+#~ msgstr "Okt√≥ber"
+
+#~ msgid "Nov"
+#~ msgstr "Nov"
+
+#~ msgid "November"
+#~ msgstr "November"
+
+#~ msgid "Dec"
+#~ msgstr "Dec"
+
+#~ msgid "December"
+#~ msgstr "December"
+
+#~ msgid "Sun"
+#~ msgstr "Ne"
+
+#~ msgid "Sunday"
+#~ msgstr "Nedeƒæa"
+
+#~ msgid "Monday"
+#~ msgstr "Pondelok"
+
+#~ msgid "Tue"
+#~ msgstr "Ut"
+
+#~ msgid "Tuesday"
+#~ msgstr "Utorok"
+
+#~ msgid "Wed"
+#~ msgstr "St"
+
+#~ msgid "Wednesday"
+#~ msgstr "Streda"
+
+#~ msgid "Thu"
+#~ msgstr "≈†t"
+
+#~ msgid "Thursday"
+#~ msgstr "≈†tvrtok"
+
+#~ msgid "Fri"
+#~ msgstr "Pi"
+
+#~ msgid "Friday"
+#~ msgstr "Piatok"
+
+#~ msgid "Sat"
+#~ msgstr "So"
+
+#~ msgid "Saturday"
+#~ msgstr "Sobota"
+
+#~ msgid "Could not close camera connection."
+#~ msgstr "Ned√° sa uzavrie≈• spojenie s fotoapar√°tom."
+
+#, c-format
+#~ msgid "Sleeping for %d second(s)...\n"
+#~ msgstr "Sp√≠m %d sek√∫nd...\n"
+
+#~ msgid "path"
+#~ msgstr "cesta"
+
+#~ msgid "speed"
+#~ msgstr "r√Ωchlos≈•"
+
+#~ msgid "model"
+#~ msgstr "typ"
+
+#~ msgid "filename"
+#~ msgstr "n√°zov s√∫boru"
+
+#~ msgid "usbid"
+#~ msgstr "usbid"
+
+#~ msgid "folder"
+#~ msgstr "prieƒçinok"
+
+#~ msgid "count"
+#~ msgstr "poƒçet"
+
+#, c-format
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the "
+#~ "location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgstr ""
+#~ "gPhoto2 pre OS/2 vy≈æaduje, aby ste nastavili premenn√∫ prostredia CAMLIBS "
+#~ "na umiestnenie kni≈æn√≠c fotoapar√°tov. Napr. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+
+#, c-format
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the "
+#~ "location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgstr ""
+#~ "gPhoto2 pre OS/2 vy≈æaduje, aby ste nastavili premenn√∫ prostredia IOLIBS "
+#~ "na umiestnenie kni≈æn√≠c fotoapar√°tov. Napr. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+
+#, c-format
+#~ msgid "Usage:\n"
+#~ msgstr "Pou≈æitie:\n"
+
+#, c-format
+#~ msgid ""
+#~ "Short/long options (& argument)        Description\n"
+#~ "--------------------------------------------------------------------------------\n"
+#~ msgstr ""
+#~ "Kr√°tke/dlh√© voƒæby (a parametre)        Popis\n"
+#~ "--------------------------------------------------------------------------------\n"
+
+#, c-format
+#~ msgid "%-38s %s\n"
+#~ msgstr "%-38s %s\n"
+
+#, c-format
+#~ msgid ""
+#~ "--------------------------------------------------------------------------------\n"
+#~ "[Use double-quotes around arguments]        [Picture numbers begin with "
+#~ "one (1)]\n"
+#~ msgstr ""
+#~ "--------------------------------------------------------------------------------\n"
+#~ "[Pou≈æite √∫vodzovky pred a za parametrami]        [ƒå√≠sla obr√°zkov zaƒç√≠naj√∫ "
+#~ "ƒç√≠slom jedna (1)]\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,23 +7,24 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2-2.5.9\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-11-18 22:19+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2015-12-24 11:10+0200\n"
 "Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
 "Language-Team: Serbian <(nothing)>\n"
 "Language: sr\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Број датотека у фасцикли „%s“: %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
@@ -31,12 +32,12 @@ msgstr[0] "%d фасцикла је у фасцикли „%s“.\n"
 msgstr[1] "%d фасцикле су у фасцикли „%s“.\n"
 msgstr[2] "%d фасцикли је у фасцикли „%s“.\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Нема датотека у фасцикли „%s“.\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
@@ -44,111 +45,111 @@ msgstr[0] "%d датотека је у фасцикли „%s“.\n"
 msgstr[1] "%d датотеке су у фасцикли „%s“.\n"
 msgstr[2] "%d датотека је у фасцикли „%s“.\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Подаци о датотеци „%s“ (фасцикла „%s“):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Датотека:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Ништа није доступно.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  МИМЕ врста:  „%s“\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Величина:    %lu бајт(а/ова)\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Ширина:      %i пиксел(а)\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Висина:      %i пиксел(а)\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Преузето:    %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "да"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "не"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Дозволе:     "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "чита/брише"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "чита"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "брише"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "ништа"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Време:       %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Сличица:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Звучни записи:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  МИМЕ врста: „%s“\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Величина:   %lu бајт(а/ова)\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Преузето:   %s\n"
@@ -170,46 +171,46 @@ msgstr "Ознака"
 msgid "Value"
 msgstr "Вредност"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "ЕКСИФ подаци садрже сличицу (%i бајта)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "Гфото2 је преведен без ЕКСИФ подршке."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Број подржаних фото-апарата: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Подржани фото-апарати:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t„%s“ (ПРОБНО)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t„%s“ (ЕКСПЕРИМЕНТАЛНО)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t„%s“\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Нађених уређаја: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -218,155 +219,169 @@ msgstr ""
 "Путања                           Опис\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Модел"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Прикључник"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Могућности фото-апарата          : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Подршка серијског прикључника    : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "УСБ подршка                      : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Подржане брзине преноса          :\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Одабир снимања                   :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Слика\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Видео\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Звук\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Преглед\n"
 
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr "                                 : Окида снимање\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : Управљачки програм не подржава снимањ\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : Управљачки програм не подржава снимањ\n"
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Подршка за подешавање            : %s\n"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Брише означене датотеке на апарату: %s\n"
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Брише све датотеке на апарату    : %s\n"
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Преглед датотека (сличице)       : %s\n"
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Подршка слања датотека           : %s\n"
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Прикључници морају да изгледају као „serial:/dev/ttyS0“ или „usb:“, али „%s“ недостаје двотачка па ћу да нагађам шта сте мислили."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Прикључници морају да изгледају као „serial:/dev/ttyS0“ или „usb:“, али „%s“ "
+"недостаје двотачка па ћу да нагађам шта сте мислили."
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Прикључник који сте навели („%s“) не може бити нађен. Наведите један од прикључника које сте нашли уз „gphoto2 --list-ports“ и побрините се да је редослед слова тачан (нпр. префикс „serial:“ или „usb:“)."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Прикључник који сте навели („%s“) не може бити нађен. Наведите један од "
+"прикључника које сте нашли уз „gphoto2 --list-ports“ и побрините се да је "
+"редослед слова тачан (нпр. префикс „serial:“ или „usb:“)."
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "О управљачком програму фото-апарата:"
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Сажетак фото-апарата:"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Упутство фото-апарата:"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Можете да наведете само брзине серијских прикључника."
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "ОС/2 прикључник: Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:907
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "Гфото2 %s\n"
 "\n"
@@ -378,298 +393,330 @@ msgstr ""
 "\n"
 "Ова верзија Гфото2 користи следеће опције и верзије софтвера:\n"
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Не могу да отворим „movie.mjpg“."
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Снимам кадрове прегледа као филм у „%s“. Притисните Ктрл-Ц да прекинете.\n"
+msgstr ""
+"Снимам кадрове прегледа као филм у „%s“. Притисните Ктрл-Ц да прекинете.\n"
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr "Снимам кадрове прегледа као филм у „%s“ за %d секунде.\n"
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Снимам %d кадра прегледа као филм у „%s“.\n"
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Грешка снимања филма... Излазим."
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Грешка снимања филма... Нерукована МИМЕ врста „%s“."
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ктрл-Ц је притиснуто ... Излазим.\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Снимање филма је завршено (%d кадра)\n"
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "Чекам на догађаје са фото-апарата. Притисните Ктрл-Ц да прекинете.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr "Чекам на %d кадра са фото-апарат. Притисните Ктрл-Ц да прекинете.\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Чекам на %d милисекунде на догађаје са фото-апарата. Притисните Ктрл-Ц да прекинете.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Чекам на %d милисекунде на догађаје са фото-апарата. Притисните Ктрл-Ц да "
+"прекинете.\n"
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Чекам на %d секунде на догађаје са фото-апарата. Притисните Ктрл-Ц да прекинете.\n"
-
-#: gphoto2/actions.c:1121
-#, c-format
-msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
-msgstr "Чекам на %d догађаја са фото-апарата. Притисните Ктрл-Ц да прекинете.\n"
+msgstr ""
+"Чекам на %d секунде на догађаје са фото-апарата. Притисните Ктрл-Ц да "
+"прекинете.\n"
 
 #: gphoto2/actions.c:1125
 #, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Чекам на %d догађаја са фото-апарата. Притисните Ктрл-Ц да прекинете.\n"
+
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
 msgstr "Чекам на %s догађај са фото-апарата. Притисните Ктрл-Ц да прекинете.\n"
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "нашао сам догађај, заустављам чекање!\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "нашао сам догађај, заустављам чекање!\n"
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Не могу да подесим фасциклу."
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Не могу да добавим слику."
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "„libcanon.so“ пун грешака?"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Не могу да обришем слику."
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr "Добављање података о складиштењу није подржано за овај фото-апарат.\n"
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Чита-пише"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Само чита"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Само чита са брисањем"
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Непознато"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "Стални РОМ"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "Уклоњиви РОМ"
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "Стални РАМ"
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "Уклоњиви РАМ"
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Неодређено"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Општи раван"
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Општи хијерархијски"
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Фото-апарат (ДЦИМ)"
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Замењујем УСБ иб произвођача/производа 0x%x/0x%x са 0x%x/0x%x"
 
-#: gphoto2/actions.c:1435
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "УВЕК УВРСТИТЕ СЛЕДЕЋЕ РЕДОВЕ КАДА ШАЉЕТЕ ПОРУКЕ ЗА ИСПРАВЉАЊЕ ГРЕШАКА НА ДОПИСНУ ЛИСТУ:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"УВЕК УВРСТИТЕ СЛЕДЕЋЕ РЕДОВЕ КАДА ШАЉЕТЕ ПОРУКЕ ЗА ИСПРАВЉАЊЕ ГРЕШАКА НА "
+"ДОПИСНУ ЛИСТУ:"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s је био преведен са следећим опцијама:"
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s није нађен у стаблу подешавања."
 
-#: gphoto2/actions.c:1630
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Нисам успео да довучем вредности текстуалног графичког објекта %s."
 
-#: gphoto2/actions.c:1647
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Нисам успео да довучем вредности графичког објекта опсега %s."
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Нисам успео да довучем вредности преклопног графичког објекта %s."
 
-#: gphoto2/actions.c:1671
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Нисам успео да довучем вредности графичког објекта за датум/време %s."
 
-#: gphoto2/actions.c:1680
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "Користи „now“ (сада) као текуће време приликом подешавања.\n"
 
-#: gphoto2/actions.c:1702
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Нисам успео да довучем вредности радио графичког објекта %s."
 
-#: gphoto2/actions.c:1746
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "Својство „%s“ је само за читање."
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
-msgstr "Нисам успео да подесим вредност текстуалног графичког објекта %s на %s."
+msgstr ""
+"Нисам успео да подесим вредност текстуалног графичког објекта %s на %s."
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Прослеђена вредност %s није у облику покретног зареза."
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "Прослеђена вредност %f није у очекиваном опсегу %f – %f."
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Нисам успео да подесим вредност графичког објекта за опсег %s на %f."
 
-#: gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "искључено"
 
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "нетачно"
 
-#: gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "укључено"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "тачно"
 
-#: gphoto2/actions.c:1802 gphoto2/actions.c:2039
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Прослеђена вредност „%s“ није исправна вредност преклопника."
 
-#: gphoto2/actions.c:1808 gphoto2/actions.c:2045
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Нисам успео да подесим вредности %s преклопног графичког објекта %s."
 
-#: gphoto2/actions.c:1820
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "сада"
 
-#: gphoto2/actions.c:1832 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "Прослеђена вредност %s није ни исправно време ни цео број."
 
-#: gphoto2/actions.c:1840 gphoto2/actions.c:2065
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
-msgstr "Нисам успео да подесим ново време графичког објекта датума/времена %s на %s."
+msgstr ""
+"Нисам успео да подесим ново време графичког објекта датума/времена %s на %s."
 
-#: gphoto2/actions.c:1887 gphoto2/actions.c:1951 gphoto2/actions.c:2095
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Нисма пронашао избор %s унутар списка избора."
 
-#: gphoto2/actions.c:1895 gphoto2/actions.c:2103
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Елемент %s није за подешавање."
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:1970 gphoto2/actions.c:2110
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
-msgstr "Нисам успео да подесим нову вредност подешавања %s за ставку подешавања %s."
+msgstr ""
+"Нисам успео да подесим нову вредност подешавања %s за ставку подешавања %s."
 
-#: gphoto2/actions.c:1963
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "Елемент „%s“ нема пописан списак избора. Користите „--set-config-value“."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"Елемент „%s“ нема пописан списак избора. Користите „--set-config-value“."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Лош број датотеке. Задали сте %i, а доступно је само %i датотека у „%s“ или његовим подфасциклама. Сазнајте прво тачан број из списка датотека."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Лош број датотеке. Задали сте %i, а доступно је само %i датотека у „%s“ или "
+"његовим подфасциклама. Сазнајте прво тачан број из списка датотека."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -678,25 +725,32 @@ msgstr "Нема датотека у фасцикли „%s“."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Лош број датотеке. Задали сте %i, а доступна је само 1 датотека у „%s“."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Лош број датотеке. Задали сте %i, а доступна је само 1 датотека у „%s“."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Лош број датотеке. Задали сте %i, а доступно је свега %i датотека у „%s“. Прибавите прво исправан број датотеке из списка датотека."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Лош број датотеке. Задали сте %i, а доступно је свега %i датотека у „%s“. "
+"Прибавите прво исправан број датотеке из списка датотека."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Грешка ***             \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Притисните било који тастер да наставите.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Нема довољно меморије."
@@ -705,206 +759,211 @@ msgstr "Нема довољно меморије."
 msgid "Operation cancelled"
 msgstr "Радња је отказана"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Настави"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Откажи"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Грешка"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Не могу да поставим подешавање:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Изађи"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Назад"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Време:"
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Вредност:"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Да"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Не"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "Бројеви попуњени нулом у називима датотека су једино могући са „%%n“."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "Не можете користити „%%n“ попуњавање нулом без вредности тачности!"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Назив датотеке који даје фото-апарат („%s“) не садржи наставак!"
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Неисправан запис „%s“ (грешка на положају %i)."
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Прескочите постојећу датотеку „%s“\n"
 
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Датотека „%s“ постоји. Да је препишем? [y|n] "
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Да наведем нови назив датотеке? [y|n] "
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Унесите нови назив датотеке: "
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Чувам датотеку као „%s“\n"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Овлашћење је одбијено"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Не могу да окинем снимање."
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Нова датотека је на месту „%s%s%s“ на фото-апарату\n"
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Задржавам датотеку „%s%s%s“ на фото-апарату\n"
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Бришем датотеку „%s%s%s“ на фото-апарату\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "Догађај ДОДАТА_ФАСЦИКЛА %s/%s за време чекања, занемарујем.\n"
 
 #: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "Догађај ДОДАТА_ФАСЦИКЛА %s/%s за време чекања, занемарујем.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Догађај НЕПОЗНАТО %s за време чекања, занемарујем.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr "Непознат догађај врсте %d за време чекања блица, занемарујем.\n"
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Не могу да добавим могућности?"
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Режим временског клизања је укључен (период: %dс).\n"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Приправнност чека да „SIGUSR1“ снима.\n"
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Режим блица је укључен (време излагања: %dс).\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Снимам кадар бр. %d...\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Снимам кадар бр. %d/%d...\n"
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Не могу да подесим снимање блица, резултат %d."
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Не могу да завршим снимање (режим блица)."
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Не могу да окинем снимање слике."
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Не могу да снимим слику."
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Снимање није успело (проблем само-фокуса?)...\n"
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Не могу да снимим."
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Чекам на следећи прикључак снимања %ld секунде...\n"
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Пробуђен сам „SIGUSR1“...\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "не спавам (%ld секунде иза планираног)\n"
 
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "ГРЕШКА: "
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -913,12 +972,12 @@ msgstr ""
 "\n"
 "Прекидам...\n"
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Прекинуто.\n"
 
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -927,21 +986,26 @@ msgstr ""
 "\n"
 "Отказујем...\n"
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Користите следећу синтаксу „a:b=c:d“ за преименовање сваког откривеног УСБ уређаја као „a:b“ у „c:d“. a b c d треба да буду хексадецимални бројеви и да почињу на „0x“.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Користите следећу синтаксу „a:b=c:d“ за преименовање сваког откривеног УСБ "
+"уређаја као „a:b“ у „c:d“. a b c d треба да буду хексадецимални бројеви и да "
+"почињу на „0x“.\n"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "Гфото2 је преведен без подршке за ЦДК."
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Радња је отказана.\n"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -950,7 +1014,7 @@ msgstr ""
 "*** Грешка: Нисам пронашао фото-апарат. ***\n"
 "\n"
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -959,7 +1023,7 @@ msgstr ""
 "*** Грешка (%i: „%s“) ***      \n"
 "\n"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -971,11 +1035,12 @@ msgid ""
 msgstr ""
 "Користите опцију „--debug“ за поруке за откривање грешака. Овакве поруке\n"
 "могу да помогну при решавању ваших проблема. Уколико намеравате да пошаљете\n"
-"поруке о грешкама или за исправљање грешака на дописну листу програмера гфотоа <gphoto-devel@lists.sourceforge.net>,\n"
+"поруке о грешкама или за исправљање грешака на дописну листу програмера "
+"гфотоа <gphoto-devel@lists.sourceforge.net>,\n"
 "покрените Гфото2 на следећи начин:\n"
 "\n"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
@@ -984,393 +1049,400 @@ msgstr ""
 "Уверите се да има довољно цитирања око аргумената.\n"
 "\n"
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Исписује потпуну поруку о употреби програма"
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Исписује кратку поруку о употреби програма"
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Укључује откривање грешака"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Подешава ниво прочишћавања [error|debug|data|all]"
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Назив датотеке за упис података о уклањању грешака"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "ДАТОТЕКА"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Тихи излаз (основно=опширно)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Прикачи скрипту на позив након преузимања, снимања, итд."
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Наводи прикључник уређаја"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Наводи брзину серијског преноса"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "БРЗИНА"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Наводи модел фото-апарата"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "МОДЕЛ"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(само за стручњаке) Заобилази ИБ-ове УСБ-а"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "УСБИБ-ови"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Приказује издање и излази"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Исписује моделе подржаних фото-апарата"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Исписује подржане уређаје прикључника"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
-msgstr "Приказује могућности фото-апарата/управљачког програма у бази података либгфото2"
+msgstr ""
+"Приказује могућности фото-апарата/управљачког програма у бази података "
+"либгфото2"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Подешава"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Исписује стабло подешавања"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Избацује читаво стабло подешавања"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Добавља вредност подешавања"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Подешава вредност подешавања или попис у изборима"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Подешава попис вредности подешавања у изборима"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Поставља вредност подешавања"
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Враћа прикључник уређаја"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Задржава слике на фото-апарату након снимања"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr "Задржава сирове слике на фото-апарату након снимања"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Уклања слике са фото-апарата након снимања"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Чека на догађај(е) са фото-апарата"
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr "БРОЈ, СЕКУНДЕ, МИЛИСЕКУНДЕ или НИСКАПОРЕЂЕЊА"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Чека на догађај(е) са фото-апарата и преузима нове слике"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Снима брзи преглед"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr "Приказује брзи преглед као Аскри уметност"
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Подешава време излагање блица у секундама"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "СЕКУНДЕ"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Подешава број кадрова за снимање (подразумевано=infinite)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "БРОЈ"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Подешава период снимања у секундама"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Враћа период снимања на сигналу (основно=no)"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Снима слику"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Окида снимање слике"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Снима слику и прузима је"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Снима филм"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "БРОЈ или СЕКУНДЕ"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Снима звучни одломак"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Чека на отпуштање бленде на фото-апарату и преузима"
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr "Окида снимање слике"
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Исписује подфасцикле у фасцикли"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Наброј датотеке у фасцикли"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Прави фасциклу"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "НАЗИВДИР."
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Уклања фасциклу"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Приказује број датотека"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Добавља датотеке у датом опсегу"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "ОПСЕГ"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Добавља све датотеке из фасцикле"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Добавља сличице у датом опсегу"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Добавља све сличице из фасцикле"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Добавља метаподатке у датом опсегу"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Добавља све метаподатке из фасцикле"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Шаље метаподатке за датотеку"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Добавља сирове податке у датом опсегу"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Добавља све сирове податке из фасцикле"
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Добавља звучне записе у датом опсегу"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Добавља све звучне записе из фасцикле"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Брише датотеке у датом опсегу"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Брише све дтотеке у фасцикли („--no-recurse“ је основно)"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Шаље датотеку фото-апарату"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Наводи назив датотеке или образац назива датотеке"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "ОБРАЗАЦ_НАЗИВА_ДАТОТЕКЕ"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Наводи фасциклу за фото-апарат (основно=„/“)"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "ФАСЦИКЛА"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Дубачење (основно за преузимање)"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Без дубачења (основно за брисање)"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Обрађује само нове датотеке"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Пребрисава датотеке без питања"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Прескаче постојеће датотеке"
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Шаље датотеку на стандардни излаз"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Исписује величину датотеке пре података"
 
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Наводи самостално откривене фото-апарате"
 
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "Приказује ЕКСИФ податке ЈПЕГ слика"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
 msgstr "Приказује податке слике, као што је ширина, висина и време снимања"
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr "Приказује сажетак фото-апарата"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Приказује упутство управљача фото-апарата"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "О упутству управљача фото-апарата"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Приказује податке складишта"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "Љуска гФотоа"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Заједничке опције"
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Разноврсне опције (непоређане)"
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "Добавља податке о софтверу и домаћину (не од фото-апарата)"
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Наводи фото-апарат за коришћење"
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Подешавања фото-апарата и софтвера"
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Снима слику са или на фото-апарат"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Преузима, шаље и управља датотекама"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1379,7 +1451,7 @@ msgstr ""
 "%s\n"
 "ИБ слике мора да буде број већи од нуле."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1388,7 +1460,7 @@ msgstr ""
 "%s\n"
 "ИБ слике је превелик %i."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1397,7 +1469,7 @@ msgstr ""
 "%s\n"
 "Опсези морају бити раздвојени зарезима (,)."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1406,7 +1478,7 @@ msgstr ""
 "%s\n"
 "Опсези треба да започињу бројем."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1415,7 +1487,7 @@ msgstr ""
 "%s\n"
 "Неочекивани знак „%c“."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -1424,215 +1496,224 @@ msgstr ""
 "%s\n"
 "Опадајући опсези нису дозвољени. Задали сте опсег од %i до %i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Грешка (%i: „%s“) ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Прелази у фасциклу на фото-апарату"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "фасцикла"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Прелази у фасциклу на месном уређају"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Напушта љуску Гфотоа"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Преузима датотеку"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[фасцикла/]датотека"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Шаље датотеку"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Преузима сличицу"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Преузима сирове податке"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Брише"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Прави фасциклу"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Уклања фасциклу"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Приказује употребу наредби"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[наредба]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Исписује садржај тренутне фасцикле"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[фасцикла/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Исписује променљиве подешавања"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Добавља променљиву подешавања"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "назив"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Поставља променљиву подешавања"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "назив=вредност"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Поставља попис променљиве подешавања"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "назив=попис вредности"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Окида снимање слике"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Снима једну слику"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Снима једну слику и прузима је"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Снима слику прегледа"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Чека на догађај"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "износ или секунде"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Чека на слике да буду снимљене и преузима их"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Чека на догађаје и слике да буду снимљене и преузима их"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Погрешна наредба."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Наредба „%s“ захтева аргумент."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Погрешна путања."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Не могу да нађем личну фасциклу."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Не могу да пређем у месну фасциклу „%s“."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Месна фасцикла сада „%s“."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Удаљена фасцикла сада „%s“."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "„set-config“ тражи и други аргумент.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "„set-config-value“ тражи и други аргумент.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "„set-config-index“ тражи и други аргумент.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Наредба „%s“ не постоји. Употребите „help“ за списак доступних наредби."
+msgstr ""
+"Наредба „%s“ не постоји. Употребите „help“ за списак доступних наредби."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Објашњење за „%s“:"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Употреба:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Опис:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Аргументи у [] заградама су необавезни"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Доступне наредбе:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr "За објашњење неке наредбе куцајте „help назив-наредбе“."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Окида снимање слике"
 
 #~ msgid "Show info"
 #~ msgstr "Приказује податке"

--- a/po/sv.po
+++ b/po/sv.po
@@ -11,147 +11,147 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.9\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-11-18 22:19+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2015-12-28 00:05+0100\n"
 "Last-Translator: Sebastian Rasmussen <sebras@gmail.com>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.6\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Antal filer i mappen ”%s”: %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "Det finns %d mapp i mappen ”%s”.\n"
 msgstr[1] "Det finns %d mappar i mappen ”%s”.\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Det finns ingen fil i mappen ”%s”.\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "Det finns %d fil i mappen ”%s”.\n"
 msgstr[1] "Det finns %d filer i mappen ”%s”.\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Information om filen ”%s” (mapp ”%s”):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Fil:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Ingen tillgänglig.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Mime-typ:    ”%s”\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Storlek:     %lu byte\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Bredd:       %i bildpunkt(er)\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Höjd:        %i bildpunkt(er)\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Hämtat:      %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "ja"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "nej"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Rättigheter: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "läsa/ta bort"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "läsa"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "ta bort"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "ingen"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Tid:         %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Miniatyrbild:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Ljuddata:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Mime-typ:  ”%s”\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Storlek:    %lu byte\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Hämtat: %s\n"
@@ -173,46 +173,46 @@ msgstr "Tagg"
 msgid "Value"
 msgstr "Värde"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "EXIF-data innehåller en miniatyrbild (%i byte)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 har kompilerats utan EXIF-stöd."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Antal kameror som stöds: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Kameror som stöds:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t”%s” (TEST)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t”%s” (EXPERIMENTELL)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t”%s”\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Hittade enheter: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -221,155 +221,168 @@ msgstr ""
 "Sökväg                           Beskrivning\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Modell"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Port"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Förmågor hos kameran            : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Serieportsstöd                   : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB-stöd                         : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Överföringshastigheter som stöds :\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Tagningsval                      :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Bild\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Video\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Ljud\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Förhandsgranskning\n"
 
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr "                                 : Utlösartagning\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
 msgstr "                                 : Tagning stöds inte av drivrutinen\n"
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Konfigurationsstöd                :%s\n"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Ta bort markerade filer på kameran : %s\n"
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Ta bort alla filer på kameran    : %s\n"
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Stöd för förhandsgranskning       : %s\n"
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Stöd för filsändningar           : %s\n"
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Portar måste se ut som ”serial:/dev/ttyS0” eller ”usb:”, men ”%s” saknar ett kolon så jag kommer att gissa vad du menar."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Portar måste se ut som ”serial:/dev/ttyS0” eller ”usb:”, men ”%s” saknar ett "
+"kolon så jag kommer att gissa vad du menar."
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Den port som du angav (”%s”) kan inte hittas. Ange en av de portar som hittades av ”gphoto2 --list-ports” och försäkra dig om att stavningen är korrekt (använd prefixet ”serial:” eller ”usb:”)."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Den port som du angav (”%s”) kan inte hittas. Ange en av de portar som "
+"hittades av ”gphoto2 --list-ports” och försäkra dig om att stavningen är "
+"korrekt (använd prefixet ”serial:” eller ”usb:”)."
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "Om kameradrivrutinen:"
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Sammanfattning för kamera:"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Kameramanual:"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Du kan endast ange hastigheter för serieportar."
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "OS/2-portering av Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:907
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
@@ -379,300 +392,337 @@ msgstr ""
 "distribuera kopior av gphoto2 under villkoren i GNU General Public\n"
 "License. För ytterligare information, se filerna med namnet COPYING.\n"
 "\n"
-"Denna version av gphoto2 använder följande programvaruversioner och flaggor:\n"
+"Denna version av gphoto2 använder följande programvaruversioner och "
+"flaggor:\n"
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Kunde inte öppna ”movie.mjpg”."
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Tar förhandsgranskningsbilder som film till ”%s”. Tryck Ctrl-C för att avbryta.\n"
+msgstr ""
+"Tar förhandsgranskningsbilder som film till ”%s”. Tryck Ctrl-C för att "
+"avbryta.\n"
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr "Tar förhandsgranskningsbilder som film till ”%s” under %d sekunder.\n"
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Tar %d förhandsgranskningsbilder som film till ”%s”.\n"
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Filmtagningsfel… Avslutar."
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Filmtagningsfel… Ohanterad MIME-typ ”%s”."
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ctrl-C nedtryckt … Avslutar.\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Filmtagning avslutad (%d bildrutor)\n"
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "Väntar på händelser från kamera. Tryck Ctrl-C för att avbryta.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr "Väntar på %d bilder från kameran. Tryck Ctrl-C för att avbryta.\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Väntar i %d millisekunder på händelser från kamera. Tryck Ctrl-C för att avbryta.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Väntar i %d millisekunder på händelser från kamera. Tryck Ctrl-C för att "
+"avbryta.\n"
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Väntar i %d sekunder på händelser från kamera. Tryck Ctrl-C för att avbryta.\n"
+msgstr ""
+"Väntar i %d sekunder på händelser från kamera. Tryck Ctrl-C för att "
+"avbryta.\n"
 
-#: gphoto2/actions.c:1121
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
 msgstr "Väntar på %d händelser från kamera. Tryck Ctrl-C för att avbryta.\n"
 
-#: gphoto2/actions.c:1125
-#, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
 msgstr "Väntar på %s-händelse från kamera. Tryck Ctrl-C för att avbryta.\n"
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "händelse hittad, avslutar väntan!\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "händelse hittad, avslutar väntan!\n"
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Kunde inte ställa in mapp."
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Kunde inte hämta bild."
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "Felaktig libcanon.so?"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Kunde inte ta bort bild."
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr "Hämtning av lagringsinformation stöds inte för denna kamera.\n"
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Läs-skriv"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Skrivskyddad"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Skrivskyddad med borttagning"
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Okänt"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "Fast ROM"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "Flyttbart ROM"
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "Fast RAM"
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "Flyttbart RAM"
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Odefinierat"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Allmänt platt"
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Allmänt hierarkisk"
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Kameralayout (DCIM)"
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Åsidosätt USB-id för tillverkare/produkt 0x%x/0x%x med 0x%x/0x%x"
 
-#: gphoto2/actions.c:1435
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "INKLUDERA ALLTID DE FÖLJANDE RADERNA NÄR DU SKICKAR FELSÖKNINGSMEDDELANDEN TILL SÄNDLISTAN:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"INKLUDERA ALLTID DE FÖLJANDE RADERNA NÄR DU SKICKAR FELSÖKNINGSMEDDELANDEN "
+"TILL SÄNDLISTAN:"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s har kompilerats med följande flaggor:"
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "%s hittades inte i konfigurationsträdet."
 
-#: gphoto2/actions.c:1630
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Misslyckades med att hämta värde för textkomponenten %s."
 
-#: gphoto2/actions.c:1647
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Misslyckades med att hämta värden för intervallkomponenten %s."
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Misslyckades med att hämta värden för växlingskomponenten %s."
 
-#: gphoto2/actions.c:1671
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Misslyckades med att hämta värden för datum/tid-komponenten %s."
 
-#: gphoto2/actions.c:1680
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "Använd ”nu” som aktuell tid vid inställning.\n"
 
-#: gphoto2/actions.c:1702
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Misslyckades med att hämta värden för radiokomponenten %s."
 
-#: gphoto2/actions.c:1746
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "Egenskapen %s är skrivskyddad."
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Misslyckades med att ställa in värdet för textkomponenten %s till %s."
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Det vidaresända värdet %s är inte ett flyttalsvärde."
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
-msgstr "Det vidaresända värdet %f är inte inom det förväntade intervallet %f - %f."
+msgstr ""
+"Det vidaresända värdet %f är inte inom det förväntade intervallet %f - %f."
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
-msgstr "Misslyckades med att ställa in värdet för intervallkomponenten %s till %f."
+msgstr ""
+"Misslyckades med att ställa in värdet för intervallkomponenten %s till %f."
 
-#: gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "av"
 
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "falskt"
 
-#: gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "på"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "sant"
 
-#: gphoto2/actions.c:1802 gphoto2/actions.c:2039
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Det vidaresända värdet %s är inte ett giltigt växlingsvärde."
 
-#: gphoto2/actions.c:1808 gphoto2/actions.c:2045
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Misslyckades att ställa in värden %s för växlingskomponenten %s."
 
-#: gphoto2/actions.c:1820
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "nu"
 
-#: gphoto2/actions.c:1832 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "Det vidaresända värdet %s är varken en giltig tid eller ett heltal."
 
-#: gphoto2/actions.c:1840 gphoto2/actions.c:2065
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
-msgstr "Misslyckades med att ställa in ny tid för datum/tid-komponenten %s till %s."
+msgstr ""
+"Misslyckades med att ställa in ny tid för datum/tid-komponenten %s till %s."
 
-#: gphoto2/actions.c:1887 gphoto2/actions.c:1951 gphoto2/actions.c:2095
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Valet %s hittades inte i listan över val."
 
-#: gphoto2/actions.c:1895 gphoto2/actions.c:2103
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Komponenten %s är inte konfigurerbar."
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:1970 gphoto2/actions.c:2110
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
-msgstr "Misslyckades med att ställa in nytt konfigurationsvärde %s för konfigurationsposten %s."
+msgstr ""
+"Misslyckades med att ställa in nytt konfigurationsvärde %s för "
+"konfigurationsposten %s."
 
-#: gphoto2/actions.c:1963
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "Komponenten %s har ingen indexerad lista över val. Använd --set-config-value istället."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"Komponenten %s har ingen indexerad lista över val. Använd --set-config-value "
+"istället."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Felaktigt filnummer. Du angav %i, men det fanns bara %i filer tillgängliga i ”%s” eller dess underkataloger. Leta fram ett giltigt filnummer från en fillista först."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Felaktigt filnummer. Du angav %i, men det fanns bara %i filer tillgängliga i "
+"”%s” eller dess underkataloger. Leta fram ett giltigt filnummer från en "
+"fillista först."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -681,25 +731,33 @@ msgstr "Det finns inga filer i mappen ”%s”."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Felaktigt filnummer. Du angav %i, men det finns bara 1 fil tillgänglig i ”%s”."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Felaktigt filnummer. Du angav %i, men det finns bara 1 fil tillgänglig i "
+"”%s”."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Felaktigt filnummer. Du angav %i, men det finns bara %i filer tillgängliga i ”%s”. Skaffa fram ett giltigt filnummer från en fillista först."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Felaktigt filnummer. Du angav %i, men det finns bara %i filer tillgängliga i "
+"”%s”. Skaffa fram ett giltigt filnummer från en fillista först."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "***  Fel  ***              \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Tryck på en tangent för att fortsätta.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Slut på minne."
@@ -708,206 +766,212 @@ msgstr "Slut på minne."
 msgid "Operation cancelled"
 msgstr "Åtgärden avbröts"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Fortsätt"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Avbryt"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Fel"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Kunde inte ställa in konfiguration:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Avsluta"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Bakåt"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Tid: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Värde: "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Ja"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Nej"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "Utfyllning med nollor i filnamn är endast möjligt med %%n."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "Du kan inte använda %%n utfyllning med nollor utan ett precist värde!"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
-msgstr "Filnamnet tillhandahållet av kameran (”%s”) innehåller inte ett suffix!"
+msgstr ""
+"Filnamnet tillhandahållet av kameran (”%s”) innehåller inte ett suffix!"
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Ogiltigt format ”%s” (fel vid position %i)."
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Hoppa över existerande fil %s\n"
 
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Filen %s finns redan. Skriv över? Ja/Nej [y|n] "
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Ange filnamn? Ja/Nej [y|n] "
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Ange nytt filnamn: "
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Sparar fil som %s\n"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Åtkomst nekad"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Kunde inte utlösa tagning."
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Ny fil finns på platsen %s%s%s på kameran\n"
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Behåll fil %s%s%s på kameran\n"
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Tar bort filen %s%s%s på kameran\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "Händelse KATALOG_TILLAGD %s/%s under väntan, ignorerar.\n"
 
 #: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "Händelse KATALOG_TILLAGD %s/%s under väntan, ignorerar.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Händelse OKÄND %s under väntan, ignorerar.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr "Okänd händelsetyp %d under långtidsexponering, ignorerar.\n"
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Kunde inte hämta egenskaper?"
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Tidsförloppsläge aktiverat (intervall: %ds).\n"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Väntar på SIGUSR1 för att fånga in.\n"
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Långtidsexponering aktiverat (exponeringstid: %ds).\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Fångar in bildruta nr. %d…\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Fångar in bildruta nr. %d/%d…\n"
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Kunde inte ställa in långtidsexponering, resultat %d."
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Kunde inte avsluta tagning (långtidsexponering)."
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Kunde inte utläsa bildtagning."
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Kunde inte fånga in bild."
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Tagning misslyckades (problem med autofokus?)…\n"
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Kunde inte fånga in."
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Väntar på nästa tagningsöppning %ld sekunder…\n"
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Väckt av SIGUSR1…\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "sover inte (%ld sekunder efter schema)\n"
 
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "FEL: "
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -916,12 +980,12 @@ msgstr ""
 "\n"
 "Avbryter…\n"
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Avbruten.\n"
 
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -930,21 +994,26 @@ msgstr ""
 "\n"
 "Avbryter…\n"
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Använd följande syntax a:b=c:d för att behandla en USB-enhet som identifierats som a:b som c:d istället. a b c d skall vara hexadecimala tal som börjar med ”0x”.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Använd följande syntax a:b=c:d för att behandla en USB-enhet som "
+"identifierats som a:b som c:d istället. a b c d skall vara hexadecimala tal "
+"som börjar med ”0x”.\n"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 har kompilerats utan stöd för CDK."
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Åtgärden avbruten.\n"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -953,7 +1022,7 @@ msgstr ""
 "*** Fel: Ingen kamera hittad. ***\n"
 "\n"
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -962,7 +1031,7 @@ msgstr ""
 "***  Fel  (%i: ”%s”) ***       \n"
 "\n"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -973,408 +1042,415 @@ msgid ""
 "\n"
 msgstr ""
 "För felsökningsmeddelanden, använd flaggan --debug.\n"
-"Felsökningsmeddelanden kan hjälpa till att hitta en lösning på ditt problem.\n"
+"Felsökningsmeddelanden kan hjälpa till att hitta en lösning på ditt "
+"problem.\n"
 "Om du avser att sända några fel eller felsökningsmeddelanden till gphoto-\n"
 "utvecklarnas sändlista <gphoto-devel@lists.sourceforge.net>, kör gärna\n"
 "gphoto2 som följer:\n"
 "\n"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
 "\n"
 msgstr ""
-"Vänligen säkerställ att det finns tillräckligt med citationstecken runt argumenten.\n"
+"Vänligen säkerställ att det finns tillräckligt med citationstecken runt "
+"argumenten.\n"
 "\n"
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Skriv ut komplett hjälpmeddelande för användning"
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Skriv ut kort meddelande för användning"
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Aktivera felsökning"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Ställ in felsökningsnivå [error|debug|data|all]"
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Namn på fil att skriva felsökningsinformation till"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "FILNAMN"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Tyst utdata (standard=informativ)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Hook-skript att anropa efter hämtningar, tagningar, etc."
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Ange enhetsport"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Ange seriell överföringshastighet"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "HASTIGHET"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Ange kameramodell"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MODELL"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(endast experter) Åsidosätt USB-ID"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBID"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Visa versionsnummer och avsluta"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Lista kameramodeller som stöds"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Lista portenheter som stöds"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Visa kamera-/drivrutinsförmågor i libgphoto2-databasen"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Konfigurera"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Lista konfigurationsträd"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Mata ut fullständigt konfigurationsträd"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Hämta konfigurationsvärde"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Ställ in konfigurationsvärde eller index i val"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Ställ in konfigurationsvärdeindex i val"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Ställ in konfigurationsvärde"
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Återställ enhetsport"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Behåll bilder på kamera efter tagning"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr "Behåll RAW-bilder på kamera efter tagning"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Ta bort bilder från kamera efter tagning"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Vänta på händelse(r) från kamera"
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr "ANTAL, SEKUNDER, MILLISEKUNDER eller MATCHSTRÄNG"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Vänta på händelse(r) från kameran och hämta nya bilder"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Ta en snabb förhandsgranskning"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr "Visa en snabb förhandsgranskning som Ascii-konst"
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Ställ in långtidsexponeringstid i sekunder"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "SEKUNDER"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Ställ in antal bildrutor att fånga in (standard=oändligt)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "ANTAL"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Ställ in tagningsintervall i sekunder"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Återställ tagningsintervall på signal (standard=nej)"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Ta en bild"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Utlös tagning av en bild"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Ta en bild och hämta den"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Spela in en film"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "ANTAL eller SEKUNDER"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Spela in ett ljudklipp"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Vänta på avtryckaren på kameran och hämta"
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr "Utlös bildtagning"
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Lista mappar i mappen"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Lista filer i mapp"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Skapa en katalog"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "KATNAMN"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Ta bort en katalog"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Visa antalet filer"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Hämta filer i angivet intervall"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "INTERVALL"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Hämta alla filer från mappen"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Hämta alla miniatyrbilder i det angivna intervallet"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Hämta alla miniatyrbilder i mappen"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Hämta metadata i det angivna intervallet"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Hämta all metadata från mapp"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Skicka upp metadata för fil"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Hämta rådata i det angivna intervallet"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Hämta all rådata från mappen"
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Hämta ljuddata i det angivna intervallet"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Hämta all ljuddata från mappen"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Ta bort filer i det angivna intervallet"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Ta bort alla filer i mappen (--no-recurse som standard)"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Skicka upp fil till kamera"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Ange ett filnamn eller filnamnsmönster"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "FILNAMNSMÖNSTER"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Ange kameramapp (standard=”/”)"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "MAPP"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Rekursion (standard för hämtning)"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Ingen rekursion (standard för borttagning)"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Behandla endast nya filer"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Skriv över filer utan att fråga"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Hoppa över existerande filer"
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Skicka fil till standard ut"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Skriv ut filstorlek före data"
 
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Lista automatiskt upptäckta kameror"
 
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "Visa EXIF-information för JPEG-bilder"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
 msgstr "Visa bildinformation, så som bredd, höjd och tagningstid"
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr "Visa kamera-sammandrag"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Visa kameradrivrutinens manual"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Om kameradrivrutinens manual"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Visa lagringsinformation"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "gPhoto-skal"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Vanliga flaggor"
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Diverse flaggor (osorterade)"
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "Hämta information om programvara och värdsystem (inte från kameran)"
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Ange kameran att använda"
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Konfiguration av kamera och programvara"
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Ta en bild från eller på kameran"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Hämtar, skickar upp och manipulerar filer"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1383,7 +1459,7 @@ msgstr ""
 "%s\n"
 "Bild-ID måste vara ett tal större än noll."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1392,7 +1468,7 @@ msgstr ""
 "%s\n"
 "Bildens ID %i är för högt."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1401,7 +1477,7 @@ msgstr ""
 "%s\n"
 "Intervall måste separeras med ”,”."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1410,7 +1486,7 @@ msgstr ""
 "%s\n"
 "Intervall måste börja med ett tal."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1419,7 +1495,7 @@ msgstr ""
 "%s\n"
 "Oväntat tecken ”%c”."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -1428,221 +1504,232 @@ msgstr ""
 "%s\n"
 "Minskande intervall är inte tillåtna. Du angav ett intervall från %i till %i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "***  Fel  (%i: ”%s”) ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Byt till en katalog i kameran"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "katalog"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Byt till en katalog på den lokala disken"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Avsluta gPhoto-skalet"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Hämta en fil"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[katalog/]filnamn"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Skicka upp en fil"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Hämta en miniatyrbild"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Hämta rådata"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Ta bort"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Skapa katalog"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Ta bort katalog"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Visar kommandoanvändning"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[kommando]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Lista innehållet av den aktuella katalogen"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[katalog/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Lista konfigurationsvariabler"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Hämta konfigurationsvariabel"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "namn"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Ställ in konfigurationsvariabel"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "namn=värde"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Ställ in konfigurationsvariabelindex"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "namn=värdeindex"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Utlös tagning av en bild"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Ta en enstaka bild"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Ta en enstaka bild och hämta den"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Ta en förhandsbild"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Vänta på en händelse"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "antal eller sekunder"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Vänta på bilder att fångas in och hämta dem"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Vänta på händelser och bilder att fångas in samt hämta dem"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Ogiltigt kommando."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Kommandot ”%s” kräver ett argument."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Ogiltig sökväg."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Kunde inte hitta hemkatalogen."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Kunde inte byta till lokala katalogen ”%s”."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Lokal katalog är nu ”%s”."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Fjärrkatalogen är nu ”%s”."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config behöver ett andra argument.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "set-config-value behöver ett andra argument.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "set-config-index behöver ett andra argument.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Kommandot ”%s” hittades inte. Använd ”help” för att få en lista av tillgängliga kommandon."
+msgstr ""
+"Kommandot ”%s” hittades inte. Använd ”help” för att få en lista av "
+"tillgängliga kommandon."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Hjälp om ”%s”:"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Användning:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Beskrivning:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Argument inom klamrar [] är valfria"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Tillgängliga kommandon:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr "För att få hjälp om ett speciellt kommando, skriv ”help kommandonamn”."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Utlös bildtagning"
 
 #~ msgid "  Name:        '%s'\n"
 #~ msgstr "  Namn:        \"%s\"\n"
 
 #~ msgid "You cannot use '%%n' in combination with non-persistent files!"
-#~ msgstr "Du kan inte använda \"%%n\" i kombination med icke-beständiga filer!"
+#~ msgstr ""
+#~ "Du kan inte använda \"%%n\" i kombination med icke-beständiga filer!"
 
 #~ msgid "Could not get filename (bulb mode)."
 #~ msgstr "Kunde inte läsa av filnamnet (långtidsexponering)."
@@ -1809,11 +1896,19 @@ msgstr "För att få hjälp om ett speciellt kommando, skriv ”help kommandonam
 #~ msgid "folder"
 #~ msgstr "mapp"
 
-#~ msgid "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
-#~ msgstr "gPhoto2 för OS/2 kräver att du sätter omgivnings-variabeln CAMLIBS till katalogen med kamera-biblioteken, t.ex. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value CAMLIBS to the "
+#~ "location of the camera libraries. e.g. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
+#~ msgstr ""
+#~ "gPhoto2 för OS/2 kräver att du sätter omgivnings-variabeln CAMLIBS till "
+#~ "katalogen med kamera-biblioteken, t.ex. SET CAMLIBS=C:\\GPHOTO2\\CAM\n"
 
-#~ msgid "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
-#~ msgstr "gPhoto2 för OS/2 kräver att du sätter omgivnings-variabeln IOLIBS till katalogen med io-biblioteken, t.ex. SET IOLIBS=C:\\GPHOTO2\\IOLIBS\n"
+#~ msgid ""
+#~ "gPhoto2 for OS/2 requires you to set the enviroment value IOLIBS to the "
+#~ "location of the io libraries. e.g. SET IOLIBS=C:\\GPHOTO2\\IOLIB\n"
+#~ msgstr ""
+#~ "gPhoto2 för OS/2 kräver att du sätter omgivnings-variabeln IOLIBS till "
+#~ "katalogen med io-biblioteken, t.ex. SET IOLIBS=C:\\GPHOTO2\\IOLIBS\n"
 
 #~ msgid "Usage:\n"
 #~ msgstr "Användning:\n"
@@ -1830,7 +1925,9 @@ msgstr "För att få hjälp om ett speciellt kommando, skriv ”help kommandonam
 
 #~ msgid ""
 #~ "--------------------------------------------------------------------------------\n"
-#~ "[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
+#~ "[Use double-quotes around arguments]        [Picture numbers begin with "
+#~ "one (1)]\n"
 #~ msgstr ""
 #~ "--------------------------------------------------------------------------------\n"
-#~ "[Använd dubbel-apostrof omkring argument]   [Foto-nummer börjar med ett (1)    ]\n"
+#~ "[Använd dubbel-apostrof omkring argument]   [Foto-nummer börjar med ett "
+#~ "(1)    ]\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,24 +8,25 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.9\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-11-18 22:19+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2015-11-19 17:35+0200\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <translation-team-uk@lists.sourceforge.net>\n"
 "Language: uk\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Кількість файлів у теці «%s»: %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
@@ -33,12 +34,12 @@ msgstr[0] "У теці \"%2$s\" є %1$d тека.\n"
 msgstr[1] "У теці \"%2$s\" є %1$d теки.\n"
 msgstr[2] "У теці \"%2$s\" є %1$d тек.\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "У теці «%s» немає файлів.\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
@@ -46,111 +47,111 @@ msgstr[0] "У теці \"%2$s\" є %1$d файл.\n"
 msgstr[1] "У теці \"%2$s\" є %1$d файли.\n"
 msgstr[2] "У теці \"%2$s\" є %1$d файлів.\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Інформація про файл «%s» (тека «%s»):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Файл:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Немає.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Тип MIME:    '%s'\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Розмір:      %lu байтів\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Ширина:      %i точок\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Висота:      %i точок\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Скопійовано: %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "так"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "ні"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Права:       "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "читання/вилучення"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "читання"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "вилучення"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "немає"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Час:         %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Мініатюра:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Звукозапис:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Тип MIME:   '%s'\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  Розмір:     %lu байтів\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Скопійовано: %s\n"
@@ -172,46 +173,46 @@ msgstr "Мітка"
 msgid "Value"
 msgstr "Значення"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Дані EXIF містять мініатюру (%i байт)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 скомпільований без підтримки EXIF."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Кількість підтримуваних фотоапаратів: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Підтримувані фотоапарати:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t«%s» (ТЕСТОВИЙ)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t«%s» (ЕКСПЕРИМЕНТАЛЬНИЙ)\n"
 
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t«%s»\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Знайдено пристроїв: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -220,155 +221,170 @@ msgstr ""
 "Шлях                             Опис\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Модель"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Порт"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Функції фотоапарата           : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Підтримка послідовного порту     : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Підтримка USB                    : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Підтримувані швидкості           :\n"
 
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Вибір захоплення                 :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Зображення\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Відео\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Звук\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Перегляд\n"
 
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr "                                 : Ініціювати захоплення\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : Драйвером не підтримується режим захоплення\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : Драйвером не підтримується режим "
+"захоплення\n"
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Підтримка налаштовування         : %s\n"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Вилучити позначені файли         : %s\n"
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Вилучити всі файли у фотоапараті : %s\n"
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Підтримка мініатюр               : %s\n"
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Підтримка завантаження файлів    : %s\n"
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Порт повинен мати формат 'serial:/dev/ttyS0' або 'usb:', але у '%s' відсутня двокрапка, тому програма спробує здогадатись, що ви мали на увазі."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Порт повинен мати формат 'serial:/dev/ttyS0' або 'usb:', але у '%s' відсутня "
+"двокрапка, тому програма спробує здогадатись, що ви мали на увазі."
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Вказаний вами порт ('%s') не знайдено. Вкажіть один з портів з переліку, що виводиться при виконанні 'gphoto2 --list-ports' та перевірте правильність введеного (тобто префікс 'serial:' чи 'usb:')."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Вказаний вами порт ('%s') не знайдено. Вкажіть один з портів з переліку, що "
+"виводиться при виконанні 'gphoto2 --list-ports' та перевірте правильність "
+"введеного (тобто префікс 'serial:' чи 'usb:')."
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "Про драйвер пристрою:"
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Зведена інформація:"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Довідка до фотоапарату:"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Швидкість можна вказувати лише для послідовних портів."
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "Перенос для OS/2 виконав Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:907
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
@@ -380,298 +396,340 @@ msgstr ""
 "\n"
 "Ця версія gphoto2 використовує наступні версії та параметри програм:\n"
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Не вдалося відкрити «movie.mjpg»."
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Захоплюємо кадри попереднього перегляду як відео до «%s». Натисніть Ctrl-C, щоб перервати.\n"
+msgstr ""
+"Захоплюємо кадри попереднього перегляду як відео до «%s». Натисніть Ctrl-C, "
+"щоб перервати.\n"
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
-msgstr "Захоплюємо кадри попереднього перегляду як відео до «%s» протягом %d секунд.\n"
+msgstr ""
+"Захоплюємо кадри попереднього перегляду як відео до «%s» протягом %d "
+"секунд.\n"
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Захоплюємо %d кадрів попереднього перегляду як відео до «%s».\n"
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Помилка під час захоплення відео… Завершуємо роботу."
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
-msgstr "Помилка під час захоплення відео… Непридатний до обробки тип MIME «%s»."
+msgstr ""
+"Помилка під час захоплення відео… Непридатний до обробки тип MIME «%s»."
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Натиснуто Ctrl-C… Перериваємо роботу.\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Захоплення відео завершено (%d кадрів)\n"
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "Очікуємо на події з фотоапарата. Натисніть Ctrl-C, щоб перервати.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
-msgstr "Очікуємо на %d кадрів з фотоапарата. Натисніть Ctrl-C, щоб перервати.\n"
+msgstr ""
+"Очікуємо на %d кадрів з фотоапарата. Натисніть Ctrl-C, щоб перервати.\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Очікуємо %d мілісекунд на події від фотоапарата. Натисніть Ctrl-C, щоб перервати.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Очікуємо %d мілісекунд на події від фотоапарата. Натисніть Ctrl-C, щоб "
+"перервати.\n"
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Очікуємо %d секунд на події з фотоапарата. Натисніть Ctrl-C, щоб перервати.\n"
-
-#: gphoto2/actions.c:1121
-#, c-format
-msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
-msgstr "Очікуємо на повідомлення про %d подій від фотоапарата. Натисніть Ctrl-C, щоб перервати.\n"
+msgstr ""
+"Очікуємо %d секунд на події з фотоапарата. Натисніть Ctrl-C, щоб перервати.\n"
 
 #: gphoto2/actions.c:1125
 #, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
-msgstr "Очікуємо на повідомлення про подію %s від фотоапарата. Натисніть Ctrl-C, щоб перервати.\n"
+msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Очікуємо на повідомлення про %d подій від фотоапарата. Натисніть Ctrl-C, щоб "
+"перервати.\n"
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Очікуємо на повідомлення про подію %s від фотоапарата. Натисніть Ctrl-C, щоб "
+"перервати.\n"
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "отримано повідомлення щодо події, припиняємо очікування!\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "отримано повідомлення щодо події, припиняємо очікування!\n"
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Не вдалося встановити теку"
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Не вдалося отримати зображення"
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "Помилка у файлі libcanon.so?"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Не вдалося вилучити зображення."
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
-msgstr "У цьому фотоапараті не передбачено можливості отримання даних щодо місткості сховища даних.\n"
+msgstr ""
+"У цьому фотоапараті не передбачено можливості отримання даних щодо місткості "
+"сховища даних.\n"
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Читання-запис"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Лише читання"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Лише читання з вилученням"
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Невідомо"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "Фіксована ROM"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "Портативна ROM"
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "Фіксована RAM"
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "Портативна RAM"
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Не визначено"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Звичайна плоска"
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Звичайна ієрархічна"
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Розташування фотоапарата (DCIM)"
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "USB-ідентифікатор виробника/продукту замінено з 0x%x/0x%x на 0x%x/0x%x"
 
-#: gphoto2/actions.c:1435
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "ЗАВЖДИ ВКЛЮЧАЙТЕ НАСТУПНІ РЯДКИ ПРИ НАДСИЛАННІ НАЛАГОДЖУВАЛЬНИХ ПОВІДОМЛЕНЬ У СПИСОК РОЗСИЛКИ:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"ЗАВЖДИ ВКЛЮЧАЙТЕ НАСТУПНІ РЯДКИ ПРИ НАДСИЛАННІ НАЛАГОДЖУВАЛЬНИХ ПОВІДОМЛЕНЬ "
+"У СПИСОК РОЗСИЛКИ:"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s зібрано з наступними параметрами:"
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "Ключ «%s» не знайдено в конфігурації."
 
-#: gphoto2/actions.c:1630
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Не вдалося отримати значення текстового поля: %s."
 
-#: gphoto2/actions.c:1647
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Не вдалося отримати значення поля діапазону %s."
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Не вдалося отримати значення поля перемикачів %s."
 
-#: gphoto2/actions.c:1671
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Не вдалося отримати значення поля дати/часу %s."
 
-#: gphoto2/actions.c:1680
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
-msgstr "Скористайтеся рядком «зараз» як поточним часом під час встановлення значення.\n"
+msgstr ""
+"Скористайтеся рядком «зараз» як поточним часом під час встановлення "
+"значення.\n"
 
-#: gphoto2/actions.c:1702
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Не вдалося отримати значення поля радіо-перемикачів %s."
 
-#: gphoto2/actions.c:1746
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "Властивість %s не можна змінювати."
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Не вдалося встановити значення текстового поля %s у %s."
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Вказане значення %s не є числом з рухомою комою."
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "Вказане значення %f поза допустимим діапазоном %f - %f."
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Не вдалося встановити вилучене поля діапазону %s у %f."
 
-#: gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "off"
 
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "false"
 
-#: gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "on"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "true"
 
-#: gphoto2/actions.c:1802 gphoto2/actions.c:2039
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Вказане значення %s не є правильним значенням для поля перемикача."
 
-#: gphoto2/actions.c:1808 gphoto2/actions.c:2045
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Не вдалося встановити значення %s поля перемикача %s."
 
-#: gphoto2/actions.c:1820
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "зараз"
 
-#: gphoto2/actions.c:1832 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "Передане значення %s не є ані значенням часу, ані цілим числом."
 
-#: gphoto2/actions.c:1840 gphoto2/actions.c:2065
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Не вдалося встановити нове значення дати/часу поля %s у %s."
 
-#: gphoto2/actions.c:1887 gphoto2/actions.c:1951 gphoto2/actions.c:2095
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Варіант %s відсутній у списку варіантів."
 
-#: gphoto2/actions.c:1895 gphoto2/actions.c:2103
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Поле %s не підтримує налаштовування."
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:1970 gphoto2/actions.c:2110
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr "Не вдалося встановити значення %s для запису конфігурації %s."
 
-#: gphoto2/actions.c:1963
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "На віджеті %s немає індексованого списку варіантів. Скористайтеся краще --set-config-value."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"На віджеті %s немає індексованого списку варіантів. Скористайтеся краще --"
+"set-config-value."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Неправильна кількість файлів. Ви вказали %1$i, але у \"%3$s\" або її підтеках доступно лише %2$i файлів. Спочатку визначте правильну кількість файлів з переліку файлів."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Неправильна кількість файлів. Ви вказали %1$i, але у \"%3$s\" або її "
+"підтеках доступно лише %2$i файлів. Спочатку визначте правильну кількість "
+"файлів з переліку файлів."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -680,25 +738,34 @@ msgstr "У теці «%s» немає файлів."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Неправильна кількість файлів. Ви вказали %i, але у теці «%s» доступний лише 1 файл"
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Неправильна кількість файлів. Ви вказали %i, але у теці «%s» доступний лише "
+"1 файл"
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Неправильна кількість файлів. Ви вказали %1$i, але у теці \"%3$s\" доступно лише %2$i файлів. Спочатку визначте правильну кількість файлів з переліку файлів."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Неправильна кількість файлів. Ви вказали %1$i, але у теці \"%3$s\" доступно "
+"лише %2$i файлів. Спочатку визначте правильну кількість файлів з переліку "
+"файлів."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** Помилка ***            \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Натисніть будь-яку клавішу.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Недостатньо пам'яті."
@@ -707,206 +774,216 @@ msgstr "Недостатньо пам'яті."
 msgid "Operation cancelled"
 msgstr "Операція скасована"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Продовжити"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Скасувати"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Помилка"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Не вдалося встановити конфігурацію:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Вийти"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Назад"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Час: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Значення: "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Так"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Ні"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "Доповнення нулями назв файлів можливо лише з %%n."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
-msgstr "Не можна використовувати доповнення нулями поля '%%n' без точного значення!"
+msgstr ""
+"Не можна використовувати доповнення нулями поля '%%n' без точного значення!"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Вказана фотоапаратом назва файлу («%s») не містить розширення!"
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Неправильний формат «%s» (помилка у позиції %i)."
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Пропустити наявний файл %s\n"
 
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Файл %s існує. Переписати? [y|n] "
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Ввести назву файлу? [y|n] "
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Введіть назву файлу: "
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Збереження файлу як %s\n"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Доступ заборонено"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Не вдалося перемкнути стан захоплення."
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Новий файл заходиться у фотоапараті у %s%s%s\n"
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Залишаємо файл %s%s%s на фотоапараті\n"
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Вилучається файл %s%s%s у фотоапараті\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "Подія FOLDER_ADDED %s/%s під час очікування. Ігноруємо.\n"
 
 #: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "Подія FOLDER_ADDED %s/%s під час очікування. Ігноруємо.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Подія UNKNOWN %s під час очікування. Ігноруємо.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
-msgstr "Невідомий тип події, %d, під час очікування у режимі ручної витримки. Ігноруємо.\n"
+msgstr ""
+"Невідомий тип події, %d, під час очікування у режимі ручної витримки. "
+"Ігноруємо.\n"
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Не вдалося отримати перелік можливостей?"
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Увімкнено режим відкладеного спуску (інтервал: %ds).\n"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Очікуємо на сигнал SIGUSR1, щоб розпочати захоплення.\n"
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Увімкнено режим ручної витримки (час експонування: %d с).\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Зйомка кадру #%d...\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Знімається кадр #%d/%d...\n"
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
-msgstr "Не вдалося налаштувати захоплення з визначенням витримки вручну, результат — %d."
+msgstr ""
+"Не вдалося налаштувати захоплення з визначенням витримки вручну, результат — "
+"%d."
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Не вдалося завершити захоплення (режим захоплення з витримкою вручну)."
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Не вдалося розпочати захоплення зображень."
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Не вдалося захопити зображення."
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Помилка при зйомці (проблеми з автофокусуванням?)...\n"
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Не вдалося зробити знімок."
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Очікуємо наступний слот захоплення %ld секунд…\n"
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Пробуджено сигналом SIGUSR1…\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "не у стані очікування (%ld секунд запізнення за розкладом)\n"
 
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "ПОМИЛКА: "
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -915,12 +992,12 @@ msgstr ""
 "\n"
 "Переривається...\n"
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Перервано.\n"
 
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -929,21 +1006,26 @@ msgstr ""
 "\n"
 "Скасовується...\n"
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Використовуйте наступний синтаксис a:b=c:d, щоб вважати будь-який USB пристрій визначений як a:b пристроєм c:d. a b c d повинні бути шістнадцятковими числами, що починаються з '0x'.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Використовуйте наступний синтаксис a:b=c:d, щоб вважати будь-який USB "
+"пристрій визначений як a:b пристроєм c:d. a b c d повинні бути "
+"шістнадцятковими числами, що починаються з '0x'.\n"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 скомпільовано без підтримки CDK."
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Операція скасована.\n"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -952,7 +1034,7 @@ msgstr ""
 "*** Помилка: фотоапаратів не знайдено. ***\n"
 "\n"
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -961,7 +1043,7 @@ msgstr ""
 "*** Помилка (%i: '%s') ***       \n"
 "\n"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -977,7 +1059,7 @@ msgstr ""
 "розсилки розробників gphoto <gphoto-devel@lists.sourceforge.net>,\n"
 "запускайте gphoto2 наступним чином:\n"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
@@ -986,393 +1068,398 @@ msgstr ""
 "Будь ласка, переконайтеся, що аргументи взято у лапки належним чином.\n"
 "\n"
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "Вивести повну довідку з використання програми"
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "Вивести коротку довідку з використання програми"
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Увімкнути режим налагодження"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Встановити рівень діагностики [error|debug|data|all]"
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Назва файлу для запису налагоджувальної інформації"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "НАЗВАФАЙЛУ"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Не виводити повідомлення (типово=виводити усі)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Допоміжний скрипт для виклику після отримання даних, захоплення тощо."
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Вказати порт пристрою"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Вказує швидкість передачі послідовного порту"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "ШВИДКІСТЬ"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Вказує модель фотоапарата"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "МОДЕЛЬ"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(лише для фахівців) Перевизначити USB ID"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBID"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Вивести версію та вийти"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Виводить перелік підтримуваних моделей фотоапаратів"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Виводить перелік підтримуваних портів пристроїв"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "Показувати можливості фотоапарата та драйвера у базі даних libgphoto2"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Налаштувати"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Показати дерево параметрів"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Створити дамп усього дерева параметрів"
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Отримати значення параметра конфігурації"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Встановити значення налаштування або індекс у списку варіантів"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Встановити індекс значення налаштування у списку варіантів"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Встановити значення параметра конфігурації"
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Звільнити порт пристрою"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Залишати знімки на фотоапараті після захоплення"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr "Залишати цифрові негативи на фотоапараті після захоплення"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Вилучати зображення з фотоапарата після захоплення"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Очікувати на події від фотоапарата"
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr "COUNT, SECONDS, MILLISECONDS або MATCHSTRING"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Очікувати на події від фотоапарата і отримати нові зображення"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Зробити пробний знімок"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr "Показувати попередній перегляд значками ASCII"
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Встановити значення експонування вручну (у секундах)"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "СЕКУНД"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Встановити кількість кадрів для захоплення (типово=без обмежень)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "КІЛЬКІСТь"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Встановити інтервал між знімками у секундах"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "Скинути інтервал захоплення за сигналом (типове значення — ні)"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Зробити знімок"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Увімкнути захоплення зображення"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Захопити зображення і отримати його"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Захопити відео"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "КІЛЬКІСТЬ або СЕКУНДИ"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Зробити звукозапис"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Зачекати на спуск затвора фотоапарата і отримати дані"
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr "Розпочати захоплення зображень"
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Виводить перелік тек у теці"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Виводить перелік файлів у теці"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Створити каталог"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "НАЗВКАТАЛОГУ"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Вилучити каталог"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Показати кількість файлів"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Отримати файли з вказаного діапазону"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "ДІАПАЗОН"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Отримати всі файли з теки"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Отримати мініатюри з вказаного діапазону"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Отримати всі мініатюри з теки"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Отримати метадані з діапазону"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Отримати всі метадані з теки"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Відвантажити метадані у файл"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Отримати необроблені дані з діапазону"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Отримати всі необроблені дані з теки"
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Отримати звукозаписи з вказаного діапазону"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Отримати всі звукозаписи з теки"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Вилучити файли у вказаному діапазоні"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "Вилучити всі файли у теці (типово з --no-recurse)"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Завантажити файл у камеру"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Вказує назву файлу чи шаблон назв файлів"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "ШАБЛОН_ФАЙЛІВ"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Вказує теку у фотоапараті (типово=\"/\")"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "ТЕКА"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Рекурсивно (типово для завантаження)"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Без рекурсії (типово для вилучення)"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Лише нові файли"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Перезаписувати файли без підтвердження"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Пропустити наявні файли"
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Виводити файл у стандартний вивід"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "Виводити розмір файлу перед даними"
 
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Вивести перелік автоматично знайдених фотоапаратів"
 
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "Вивести дані EXIF зображень JPEG"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
 msgstr "Вивести дані щодо зображення, зокрема ширину, висоту та час захоплення"
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr "Вивести резюме щодо фотоапарата"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Виводить довідку про драйвер фотоапарату"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Про довідку драйвера фотоапарату"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Показати дані щодо носія даних"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "командна оболонка gPhoto"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Загальні ключі"
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Різні ключі (без сортування)"
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "Отримати інформацію про ПЗ та систему (не з фотоапарату))"
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Вказати фотоапарат"
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Фотоапарат та конфігурація ПЗ"
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Захопити зображення з фотоапарату"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Завантаження, відвантаження та маніпуляції з файлами"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1381,7 +1468,7 @@ msgstr ""
 "%s\n"
 "Ідентифікатори зображень повинні бути числами більше нуля."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1390,7 +1477,7 @@ msgstr ""
 "%s\n"
 "Ідентифікатор зображення %i надто великий."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1399,7 +1486,7 @@ msgstr ""
 "%s\n"
 "Діапазони повинні розділятись \",\"."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1408,7 +1495,7 @@ msgstr ""
 "%s\n"
 "Діапазони повинні починатись з цифри."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1417,224 +1504,235 @@ msgstr ""
 "%s\n"
 "Неочікуваний символ '%c'."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
 "Decreasing ranges are not allowed. You specified a range from %i to %i."
 msgstr ""
 "%s\n"
-"Не можна вказувати діапазон з меншого числа. Ви вказали діапазон від %i до %i."
+"Не можна вказувати діапазон з меншого числа. Ви вказали діапазон від %i до "
+"%i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** Помилка (%i: '%s') ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Перейти в каталог в пам'яті фотоапарата"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "каталог"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Перейти в каталог на локальному диску"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Вихід з командної оболонки gPhoto"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Завантажити файл"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[каталог/]назва_файлу"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Відвантажити файл"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Завантажити мініатюру"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Завантажити необроблені дані"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Вилучити"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Створити каталог"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Вилучити каталог"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Довідка з команд"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[команда]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Показати вміст поточного каталогу"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[каталог/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Вивести змінні конфігурації"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Отримати змінну конфігурації"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "назва"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Встановити змінну конфігурації"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "назва=значення"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Встановити індекс змінної налаштування"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "назва=індекс_значення"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Увімкнути захоплення зображення"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Зняти один кадр"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Захопити один кадр і отримати його"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Захопити зображення попереднього перегляду"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Зачекати на подію"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "кількість або тривалість у секундах"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Зачекати на зображення, які слід захопити і отримати дані"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Зачекати на події і зображення, які слід захопити, і отримати дані"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Неправильна команда."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Команди «%s» використовується з аргументом."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Неправильний шлях."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Не вдалося знайти домашній каталог."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Не вдалося знайти локальний каталог «%s»."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Поточний локальний каталог - «%s»"
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Поточний віддалений каталог - «%s»"
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "для set-config треба вказати другий аргумент.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "для set-config-value слід вказати другий аргумент.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "для set-config-index слід вказати другий аргумент.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Команда «%s» не існує. Введіть \"help\", щоб отримати перелік наявних команд."
+msgstr ""
+"Команда «%s» не існує. Введіть \"help\", щоб отримати перелік наявних команд."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Довідка з «%s»:"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Використання:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Опис:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Аргументи у дужках [] є необов'язковими."
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Доступні команди:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
-msgstr "Щоб отримати довідку про певну команду, введіть \"help назва_команди\"."
+msgstr ""
+"Щоб отримати довідку про певну команду, введіть \"help назва_команди\"."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Розпочати захоплення зображень"
 
 #~ msgid "Show info"
 #~ msgstr "Виводить інформацію"
@@ -1669,10 +1767,12 @@ msgstr "Щоб отримати довідку про певну команду,
 
 #~ msgid ""
 #~ "--------------------------------------------------------------------------------\n"
-#~ "[Use double-quotes around arguments]        [Picture numbers begin with one (1)]\n"
+#~ "[Use double-quotes around arguments]        [Picture numbers begin with "
+#~ "one (1)]\n"
 #~ msgstr ""
 #~ "--------------------------------------------------------------------------------\n"
-#~ "[Використовуйте лапки навколо аргументів]    [Номери малюнків починаються з 1  ]\n"
+#~ "[Використовуйте лапки навколо аргументів]    [Номери малюнків починаються "
+#~ "з 1  ]\n"
 
 #~ msgid "[name]"
 #~ msgstr "[назва]"

--- a/po/vi.po
+++ b/po/vi.po
@@ -9,147 +9,147 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.9\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-11-18 22:19+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2015-11-20 07:39+0700\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
 "Language: vi\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Language-Team-Website: <http://translationproject.org/team/vi.html>\n"
 "X-Generator: Gtranslator 2.91.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "Số lượng tập tin nằm trong thư mục “%s”: %i\n"
 
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "Có %d thư mục nằm trong thư mục “%s”.\n"
 
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "Không có tập tin nằm trong thư mục “%s”.\n"
 
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "Có %d tập tin nằm trong thư mục “%s”.\n"
 
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "Thông tin về tập tin “%s” (thư mục “%s”):\n"
 
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "Tập tin:\n"
 
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  Không có gì sẵn dùng cả.\n"
 
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Kiểu MIME:   “%s”\n"
 
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  Cỡ:          %lu byte\n"
 
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  Rộng:        %i điểm ảnh\n"
 
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  Cao:         %i điểm ảnh\n"
 
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  Đã tải về:   %s\n"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "có"
 
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "không"
 
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  Quyền hạn: "
 
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "đọc/xóa"
 
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "đọc"
 
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "xóa"
 
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "không gì cả"
 
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  Giờ:         %s"
 
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "Ảnh mẫu:\n"
 
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "Dữ liệu âm thanh:\n"
 
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Kiểu MIME:  “%s”\n"
 
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "         Cỡ:  %lu byte\n"
 
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  Đã tải về:  %s\n"
@@ -171,47 +171,48 @@ msgstr "Thẻ"
 msgid "Value"
 msgstr "Giá trị"
 
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "Dữ liệu EXIF chứa một ảnh mẫu (%i byte)."
 
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
-msgstr "Trình gphoto2 đã được biên dịch mà không có sự hỗ trợ của thư viện EXIF."
+msgstr ""
+"Trình gphoto2 đã được biên dịch mà không có sự hỗ trợ của thư viện EXIF."
 
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "Số lượng máy ảnh được hỗ trợ: %i\n"
 
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "Máy ảnh được hỗ trợ:\n"
 
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t“%s” (THỬ)\n"
 
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t“%s” (THỬ NGHIỆM)\n"
 
 # Variable: don't translate / Biến: đừng dịch
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t“%s”\n"
 
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "Thiết bị đã tìm thấy: %i\n"
 
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -220,157 +221,172 @@ msgstr ""
 "Đường dẫn                        Mô tả\n"
 "--------------------------------------------------------------\n"
 
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "Mô hình"
 
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "Cổng"
 
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "Khả năng cho máy ảnh             : %s\n"
 
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "Hỗ trợ cổng nối tiếp             : %s\n"
 
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "Hỗ trợ USB                       : %s\n"
 
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "Hỗ trợ tốc độ truyền             :\n"
 
 # Variable: don't translate / Biến: đừng dịch
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                                 : %i\n"
 
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "Tùy chọn chụp                    :\n"
 
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                                 : Ảnh\n"
 
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                                 : Phim\n"
 
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                                 : Âm thanh\n"
 
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                                 : Xem thử\n"
 
 # Variable: don't translate / Biến: đừng dịch
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr "                                 : Chụp bằng bẫy\n"
 
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
-msgstr "                                 : Trình điều khiển không hỗ trợ khả năng chụp\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
+msgstr ""
+"                                 : Trình điều khiển không hỗ trợ khả năng "
+"chụp\n"
 
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "Hỗ trợ cấu hình                  : %s\n"
 
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "Xóa bỏ các tập tin được chọn nằm trên máy ảnh: %s\n"
 
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "Xóa bỏ mọi tập tin trên máy ảnh  : %s\n"
 
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "Hỗ trợ xem trước ảnh (dạng thu nhỏ): %s\n"
 
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "Hỗ trợ tải tập tin lên           : %s\n"
 
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "Cổng phải có dạng như “serial:/dev/ttyS0” hay “usb:”, nhưng mà “%s” còn thiếu dấu hai chấm nên tôi đang đoán bạn có ý gì."
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"Cổng phải có dạng như “serial:/dev/ttyS0” hay “usb:”, nhưng mà “%s” còn "
+"thiếu dấu hai chấm nên tôi đang đoán bạn có ý gì."
 
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "Bạn đã chỉ ra một cổng (“%s”) mà không thể thấy. Hãy chỉ ra một của những cổng được tìm bởi lệnh “gphoto2 --list-ports” và kiểm tra xem lại bạn đã gõ đúng chính tả (tực là có tiền tố “serial:” hay “usb:”)."
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"Bạn đã chỉ ra một cổng (“%s”) mà không thể thấy. Hãy chỉ ra một của những "
+"cổng được tìm bởi lệnh “gphoto2 --list-ports” và kiểm tra xem lại bạn đã gõ "
+"đúng chính tả (tực là có tiền tố “serial:” hay “usb:”)."
 
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "Thông tin về trình điều khiển máy ảnh:"
 
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "Tóm tắt về máy ảnh:"
 
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "Sổ tay máy ảnh:"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "Bạn có thể chỉ ra tốc độ chỉ cho cổng nối tiếp thôi."
 
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "Chuyển sang OS/2 bởi Bart van Leeuwen\n"
 
-#: gphoto2/actions.c:907
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 phiên bản %s\n"
 "\n"
@@ -386,298 +402,325 @@ msgstr ""
 "Phiên bản gphoto2 này có dùng các phiên bản phần mềm\n"
 "và tùy chọn sau:\n"
 
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "Không thể mở tập tin “movie.mjpg”."
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
-msgstr "Đang chụp vào “%s” các khung xem thử dưới dạng phim. Bấm Ctrl-C để hủy bỏ.\n"
+msgstr ""
+"Đang chụp vào “%s” các khung xem thử dưới dạng phim. Bấm Ctrl-C để hủy bỏ.\n"
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr "Đang chụp vào “%s” trong %d giây các khung xem thử dưới dạng phim.\n"
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "Đang chụp vào “%2$s” %1$d khung xem thử dưới dạng phim.\n"
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "Lỗi quay phim… Đang thoát."
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "Lỗi quay phim… Gặp dạng MIME không thể xử lý “%s”."
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Tổ hợp phím Ctrl-C đã được bấm… Đang thoát.\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "Quay phim đã hoàn tất (%d khung hình)\n"
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "Đợi dữ kiện từ máy ảnh. Bấm Ctrl-C để hủy bỏ.\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr "Đang đợi %d khung ảnh từ máy ảnh. Bấm Ctrl-C để hủy bỏ.\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
-msgstr "Đợi trong %d mi-li-giây cho sự kiện từ máy ảnh. Bấm Ctrl-C để hủy bỏ.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgstr ""
+"Đợi trong %d mi-li-giây cho sự kiện từ máy ảnh. Bấm Ctrl-C để hủy bỏ.\n"
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
 msgstr "Đợi (trong %d giây) dữ kiện từ máy ảnh. Bấm Ctrl-C để hủy bỏ.\n"
 
-#: gphoto2/actions.c:1121
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
 msgstr "Đợi %d dữ kiện từ máy ảnh. Bấm Ctrl-C để hủy bỏ.\n"
 
-#: gphoto2/actions.c:1125
-#, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
 msgstr "Đợi sự kiện %s từ máy ảnh. Bấm Ctrl-C để hủy bỏ.\n"
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "đã thấy sự kiện, dừng đợi!\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "đã thấy sự kiện, dừng đợi!\n"
 
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "Không thể đặt thư mục."
 
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "Không thể lấy ảnh."
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "libcanon.so có lỗi không?"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "Không thể xóa bỏ ảnh."
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr "Đang lấy thông tin cất giữ không được hỗ trợ cho máy ảnh này.\n"
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "Đọc-Ghi"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "Chỉ-Đọc"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "Chỉ-đọc có xóa"
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "Không rõ"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "ROM cố định"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "ROM rời"
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "RAM cố định"
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "RAM rời"
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "Chưa xác định"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "Phẳng chung"
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "Phân cấp Chung"
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "Bố cục máy ảnh (DCM)"
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "Đang đè lên mã hiệu sản phẩm/nhà bán USB 0x%x/0x%x bằng 0x%x/0x%x"
 
-#: gphoto2/actions.c:1435
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
-msgstr "LUÔN LUÔN HÃY GỒM NHỮNG DÒNG THEO ĐÂY KHI THÔNG BÁO LỖI CHO HỘP THƯ CHUNG:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
+msgstr ""
+"LUÔN LUÔN HÃY GỒM NHỮNG DÒNG THEO ĐÂY KHI THÔNG BÁO LỖI CHO HỘP THƯ CHUNG:"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s đã được biên dịch với những tùy chọn theo đây:"
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "Không tìm thấy %s trong cây cấu hình."
 
-#: gphoto2/actions.c:1630
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "Việc lấy giá trị của ô điều khiển chữ %s bị lỗi."
 
-#: gphoto2/actions.c:1647
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "Việc lấy giá trị của ô điều khiển phạm vi %s bị lỗi"
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "Việc lấy giá trị của ô điều khiển bật/tắt %s bị lỗi"
 
-#: gphoto2/actions.c:1671
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "Việc lấy giá trị của ô điều khiển ngày/giờ %s bị lỗi"
 
-#: gphoto2/actions.c:1680
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "Dùng “now” như là thời gian hiện tại khi cài đặt.\n"
 
-#: gphoto2/actions.c:1702
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "Việc lấy giá trị của ô điều khiển chọn một %s bị lỗi"
 
-#: gphoto2/actions.c:1746
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "Thuộc tính %s là chỉ-đọc."
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "Việc đặt giá trị của ô điều khiển chữ %s thành %s bị lỗi."
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "Giá trị %s được gửi qua không phải là giá trị với dấu chấm động."
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "Giá trị %f được gửi qua không phải nằm ở trong phạm vi đã ngờ %f - %f."
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "Việc đặt giá trị của ô điều khiển phạm vi %s thành %f bị lỗi."
 
-#: gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "tắt"
 
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "sai"
 
-#: gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "bật"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "đúng"
 
-#: gphoto2/actions.c:1802 gphoto2/actions.c:2039
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "Giá trị đã gửi qua %s không phải là giá trị bật/tắt hợp lệ."
 
-#: gphoto2/actions.c:1808 gphoto2/actions.c:2045
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "Việc đặt giá trị %s của ô điều khiển bật/tắt %s bị lỗi."
 
-#: gphoto2/actions.c:1820
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "ngay"
 
-#: gphoto2/actions.c:1832 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
-msgstr "Giá trị đã gửi qua %s không phải là giờ hợp lệ, cũng không phải là số nguyên."
+msgstr ""
+"Giá trị đã gửi qua %s không phải là giờ hợp lệ, cũng không phải là số nguyên."
 
-#: gphoto2/actions.c:1840 gphoto2/actions.c:2065
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "Việc đặt giờ mới của ô điều khiển ngày/giờ %s thành %s bị lỗi."
 
-#: gphoto2/actions.c:1887 gphoto2/actions.c:1951 gphoto2/actions.c:2095
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "Không tìm thấy tùy chọn %s trong danh sách các tùy chọn."
 
-#: gphoto2/actions.c:1895 gphoto2/actions.c:2103
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "Không thể cấu hình ô điều khiển %s."
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:1970 gphoto2/actions.c:2110
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr "Việc đặt giá trị cấu hình mới %s cho mục nhập cấu hình %s bị lỗi."
 
-#: gphoto2/actions.c:1963
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "Ô điều khiển %s không có chỉ mục các sự chọn sẵn sàng. Hãy dùng “--set-config-value” để thay thế."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"Ô điều khiển %s không có chỉ mục các sự chọn sẵn sàng. Hãy dùng “--set-"
+"config-value” để thay thế."
 
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "Số tập tin sai. Bạn đã chỉ ra %i, nhưng chỉ có %i tập tin sẵn sàng nằm trong “%s” hay các thư mục con của nó. Hãy lấy một số tập tin hợp lệ từ danh sách tập tin trước tiên."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"Số tập tin sai. Bạn đã chỉ ra %i, nhưng chỉ có %i tập tin sẵn sàng nằm trong "
+"“%s” hay các thư mục con của nó. Hãy lấy một số tập tin hợp lệ từ danh sách "
+"tập tin trước tiên."
 
 #: gphoto2/foreach.c:285
 #, c-format
@@ -686,25 +729,33 @@ msgstr "Không có tập tin nằm trong thư mục “%s”."
 
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
-msgstr "Số tập tin sai. Bạn đã chỉ ra %i, nhưng chỉ có 1 tập tin sẵn sàng nằm trong “%s” thôi."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
+msgstr ""
+"Số tập tin sai. Bạn đã chỉ ra %i, nhưng chỉ có 1 tập tin sẵn sàng nằm trong "
+"“%s” thôi."
 
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "Số tập tin sai. Bạn đã chỉ ra %i, nhưng chỉ có %i tập tin sẵn sàng nằm trong “%s”. Hãy lấy một số tập tin hợp lệ từ danh sách tập tin trước tiên."
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"Số tập tin sai. Bạn đã chỉ ra %i, nhưng chỉ có %i tập tin sẵn sàng nằm trong "
+"“%s”. Hãy lấy một số tập tin hợp lệ từ danh sách tập tin trước tiên."
 
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "***  Lỗi  ***              \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "Hãy bấm bất cứ phím nào để tiếp tục.\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "Không đủ bộ nhớ."
@@ -713,206 +764,217 @@ msgstr "Không đủ bộ nhớ."
 msgid "Operation cancelled"
 msgstr "Thao tác bị hủy bỏ"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>Tiếp tục"
 
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>Thôi"
 
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>Lỗi"
 
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "Không thể đặt cấu hình:"
 
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "Thoát"
 
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "Lùi"
 
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "Giờ: "
 
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "Giá trị: "
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "Có"
 
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "Không"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "Chỉ có khả năng đệm bằng số không những số trong tên tập tin với %%n."
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
-msgstr "Bạn không thể sử dụng khả năng đệm bằng số không kiểu “%%n” khi không có giá trị chính xác!"
+msgstr ""
+"Bạn không thể sử dụng khả năng đệm bằng số không kiểu “%%n” khi không có giá "
+"trị chính xác!"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "Máy ảnh đã cung cấp một tên tập tin không có hậu tố: “%s”."
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "Định dạng không hợp lệ “%s” (lỗi tại vị trí %i)."
 
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "Bỏ qua các tập tin sẵn có %s\n"
 
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "Tập tin %s đã có. Ghi đè lên nó không? [y|n] (c|k) "
 
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "Chỉ ra tên tập tin mới không? [y|n] (c|k) "
 
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "Nhập tên tập tin mới: "
 
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "Đang ghi tập tin với tên “%s”\n"
 
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "Không đủ thẩm quyền"
 
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "Không thể bấm chụp."
 
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "Tập tin mới nằm tại vị trí “%s%s%s” trên máy ảnh\n"
 
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "Đang giữ lại tập tin %s%s%s trên máy ảnh\n"
 
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "Đang xóa bỏ tập tin “%s%s%s” trên máy ảnh\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
-msgstr "Sự kiện “FOLDER_ADDED” (thư mục được thêm) %s/%s xảy ra trong khi đợi nên bỏ qua.\n"
+msgstr ""
+"Sự kiện “FOLDER_ADDED” (thư mục được thêm) %s/%s xảy ra trong khi đợi nên bỏ "
+"qua.\n"
 
 #: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr ""
+"Sự kiện “FOLDER_ADDED” (thư mục được thêm) %s/%s xảy ra trong khi đợi nên bỏ "
+"qua.\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "Sự kiện “UNKNOWN” (không rõ) %s xảy ra trong khi đợi nên bỏ qua.\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr "Gặp loại sự kiện không rõ %d trong khi đợi bóng đèn nháy nên bỏ qua.\n"
 
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "Không thể lấy các khả năng?"
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "Chế độ khoảng thời gian được bật (thời gian: %dg).\n"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "Đang đợi SIGUSR1 để chụp.\n"
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "Chế độ bóng đèn được bật (thời gian phơi nắng: %dgy).\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "Đang chụp khung #%d…\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "Đang chụp khung #%d/%d…\n"
 
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "Không thể đặt chụp bóng đèn, kết quả %d."
 
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "Không thể kết thúc chụp (chế độ bóng đèn)."
 
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "Không thể làm sập bẫy chụp ảnh."
 
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "Không thể chụp ảnh."
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "Việc chụp bị lỗi (lỗi tự động lấy nét?)…\n"
 
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "Không thể chụp."
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "Đang đợi khe chụp kế tiếp %ld giây…\n"
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "Do SIGUSR1 kích hoạt…\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "không ngủ (trễ %ld giây)\n"
 
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "LỖI: "
 
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -921,12 +983,12 @@ msgstr ""
 "\n"
 "Đang bãi bỏ…\n"
 
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "Bị bãi bỏ.\n"
 
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -935,21 +997,26 @@ msgstr ""
 "\n"
 "Đang hủy bỏ…\n"
 
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "Hãy sử dụng cú pháp “a:b=c:d” để xử lý thiết bị USB nào được phát hiện như “a:b” thành “c:d” thay thế. “a b c d” nên là số dạng hệ thập lục phân bắt đầu với “0x”.\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"Hãy sử dụng cú pháp “a:b=c:d” để xử lý thiết bị USB nào được phát hiện như "
+"“a:b” thành “c:d” thay thế. “a b c d” nên là số dạng hệ thập lục phân bắt "
+"đầu với “0x”.\n"
 
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "Trình gphoto2 đã được biên dịch không có khả năng hỗ trợ CDK."
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Thao tác bị hủy bỏ.\n"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -958,7 +1025,7 @@ msgstr ""
 "*** Lỗi: không tìm thấy máy ảnh. ***\n"
 "\n"
 
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -967,7 +1034,7 @@ msgstr ""
 "***  Lỗi  (%i: “%s”) ***       \n"
 "\n"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -983,7 +1050,7 @@ msgstr ""
 "nhà phát triển gphoto <gphoto-devel@lists.sourceforge.net>,\n"
 "trước khi gửi thông điệp, hãy chạy gphoto2 như theo sau đây:\n"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
@@ -992,393 +1059,402 @@ msgstr ""
 "Xin hãy chắc chắn là có đủ dấu trích dẫn bao xung quanh các tham số.\n"
 "\n"
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "In ra toàn bộ trợ giúp về cách sử dụng chương trình"
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "In ra trợ giúp ngắn về cách sử dụng chương trình"
 
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "Bật gỡ lỗi"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "Đặt mức gỡ lỗi [error|debug|data|all]"
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "Tên tập tin ghi thông tin gỡ lỗi"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "TÊN_TẬP_TIN"
 
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "Xuất ít thông tin (mặc định là chi tiết)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "Văn lệnh móc vào cần chạy sau khi tải về, chụp, v.v.."
 
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "Đặt cổng thiết bị"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "Đặt tốc độ truyền nối tiếp"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "TỐC-ĐỘ"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "Đặt mô hình máy ảnh"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "MÔ-HÌNH"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "Đè lên mã hiệu USB (chỉ dành cho người có kinh nghiệm)"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBID"
 
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "Hiển thị phiên bản rồi thoát"
 
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "Liệt kê các mô hình máy ảnh được hỗ trợ"
 
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "Liệt kê các thiết bị cổng được hỗ trợ"
 
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
-msgstr "Hiển thị các khả năng máy ảnh/trình điều khiển trong cơ sở dữ liệu libgphoto2"
+msgstr ""
+"Hiển thị các khả năng máy ảnh/trình điều khiển trong cơ sở dữ liệu libgphoto2"
 
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "Cấu hình"
 
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "Liệt kê cây cấu hình"
 
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "Đổ đầy đủ cây cấu hình."
 
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "Lấy giá trị cấu hình"
 
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "Đặt giá trị cấu hình hoặc chỉ mục trong các sự chọn"
 
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "Đặt chỉ mục giá trị cấu hình trong các sự chọn"
 
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "Đặt giá trị cấu hình"
 
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "Đặt lại cổng thiết bị"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "Giữ các ảnh trên máy ảnh sau chụp"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr "Giữ các ảnh dạng RAW trên máy ảnh sau chụp"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "Xóa bỏ các ảnh trên máy ảnh sau chụp"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "Đợi sự kiện từ máy ảnh"
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr "SỐ LƯỢNG, GIÂY, MILI GIÂY hay CHUỖI KHỚP MẪU"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "Đợi (các) sự kiện từ máy ảnh và tải xuống ảnh mới"
 
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "Chụp một ảnh xem thử nhanh"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr "Hiển thị xem thử nhanh kiểu “Ascii Art”"
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "Đặt thời gian phơi sáng bóng đèn, theo giây"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "GIÂY"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "Đặt tổng số khung cần chụp (mặc định là vô hạn)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "SỐ_LƯỢNG"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "Đặt thời gian giữa hai lần chụp tính bằng giây"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
-msgstr "Đặt lại thời gian giữa hai lần chụp khi nhận tin hiệu (mặc định=no không)"
+msgstr ""
+"Đặt lại thời gian giữa hai lần chụp khi nhận tin hiệu (mặc định=no không)"
 
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "Chụp một ảnh"
 
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "Nút bấm chụp của ảnh"
 
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "Chụp một ảnh và tải nó về"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "Quay một phim"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "SỐ_LƯỢNG hay GIÂY"
 
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "Ghi một trích đoạn âm thanh"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "Đợi màn chập được thả trên máy ảnh và tải về"
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr "Bẫy chụp ảnh"
-
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "Liệt kê các thư mục nằm trong thư mục"
 
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "Liệt kê các tập tin nằm trong thư mục"
 
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "Tạo thư mục"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "TÊN_THƯ_MỤC"
 
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "Gỡ bỏ thư mục"
 
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "Hiển thị tổng số tập tin"
 
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "Lấy các tập tin đưa ra trong phạm vi"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "VÙNG"
 
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "Lấy các tập tin từ thư mục"
 
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "Lấy các ảnh mẫu đưa ra trong phạm vi"
 
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "Lấy các ảnh mẫu từ thư mục"
 
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "Lấy siêu dữ liệu đưa ra trong phạm vi"
 
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "Lấy toàn bộ siêu dữ liệu từ thư mục"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "Tải lên siêu dữ liệu về tập tin"
 
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "Lấy dữ liệu thô đưa ra trong phạm vi"
 
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "Lấy toàn bộ dữ liệu thô từ thư mục"
 
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "Lấy dữ liệu âm thanh đưa ra trong phạm vi"
 
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "Lấy toàn bộ dữ liệu âm thanh từ thư mục"
 
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "Xóa bỏ các tập tin đưa ra trong phạm vi"
 
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
-msgstr "Xóa bỏ tất cả các tập tin trong thư mục (tùy chọn --no-recurse được dùng mặc định)"
+msgstr ""
+"Xóa bỏ tất cả các tập tin trong thư mục (tùy chọn --no-recurse được dùng mặc "
+"định)"
 
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "Tải một tập tin lên máy ảnh"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "Chỉ định tên tập tin hay mẫu tên tập tin"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "MẪU_TÊN_TẬP_TIN"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "Chỉ định thư mục máy ảnh (mặc định là “/”)"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "THƯ_MỤC"
 
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "Đệ qui (mặc định khi tải về)"
 
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "Không đệ qui (mặc định khi xóa bỏ)"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "Chỉ xử lý tập tin mới"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "Tự động ghi đè lên tập tin"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "Bỏ qua các tập tin sẵn có"
 
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "Gửi tập tin cho thiết bị xuất chuẩn"
 
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "In kích cỡ tập tin nằm trước dữ liệu"
 
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "Liệt kê các máy ảnh được phát hiện tự động"
 
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "Hiện thông tin EXIF của các ảnh JPEG"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
 msgstr "Hiển thị thông tin ảnh, như là chiều cao, rộng và thời gian chụp ảnh"
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr "Hiện bản tóm tắt máy ảnh"
 
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "Hiện sổ tay trình điều khiển máy ảnh"
 
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "Thông tin về sổ tay trình điều khiển máy ảnh"
 
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "Hiện thông tin lưu trữ"
 
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "Hệ vỏ gPhoto"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "Tùy chọn chung:"
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "Tùy chọn lặt vặt (chưa sắp xếp):"
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "Lấy thông tin về phần mềm và hệ thống chủ (không phải từ máy ảnh):"
 
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "Chỉ định máy ảnh cần dùng:"
 
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "Cấu hình máy ảnh và phần mềm:"
 
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "Chụp ảnh từ hoặc trên máy ảnh"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "Tải xuống/lên và thao tác tập tin:"
 
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1387,7 +1463,7 @@ msgstr ""
 "%s\n"
 "Mã hiệu ảnh phải là số hơn số không."
 
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1396,7 +1472,7 @@ msgstr ""
 "%s\n"
 "Mã hiệu ảnh %i quá cao."
 
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1405,7 +1481,7 @@ msgstr ""
 "%s\n"
 "Phạm vi phải được ngăn cách bằng dấu phẩy “,”."
 
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1414,7 +1490,7 @@ msgstr ""
 "%s\n"
 "Phạm vi phải bắt đầu với một con số."
 
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1423,7 +1499,7 @@ msgstr ""
 "%s\n"
 "Gặp ký tự không cần “%c”."
 
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -1432,215 +1508,225 @@ msgstr ""
 "%s\n"
 "Không cho phép có phạm vi giảm. Bạn đã chỉ ra một phạm vi từ %i đến %i."
 
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "***  Lỗi  (%i: “%s”) ***"
 
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "Chuyển đổi sang một thư mục nằm trên máy ảnh"
 
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "thư mục"
 
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "Chuyển đổi sang một thư mục nằm trên đĩa cục bộ"
 
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "Thoát khỏi hệ vỏ gPhoto"
 
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "Tải về một tập tin"
 
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[thư_mục/]tên_tập_tin"
 
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "Tải lên một tập tin"
 
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "Tải về một ảnh mẫu"
 
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "Tải về dữ liệu thô"
 
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "Xóa bỏ"
 
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "Tạo thư mục"
 
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "Gỡ bỏ thư mục"
 
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "Hiển thị cách sử dụng lệnh"
 
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[lệnh]"
 
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "Liệt kê nội dung của thư mục hiện có"
 
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[thư_mục/]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "Liệt kê các biến cấu hình"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "Lấy biến cấu hình"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "tên"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "Đặt biến cấu hình"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "tên=giá_trị"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "Đặt chỉ mục biến cấu hình"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "tên=chỉ_mục_giá_trị"
 
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "Nút bấm chụp của ảnh"
+
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "Chụp một ảnh riêng lẻ"
 
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "Chụp một ảnh riêng lẻ và tải nó về"
 
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "Chụp một ảnh xem thử"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "Đợi một sự kiện"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "số lượng hoặc giây"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "Đợi chụp ảnh và tải xuống"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "Đợi sự kiện và các ảnh được chụp và tải xuống"
 
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "Lệnh không hợp lệ."
 
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "Lệnh “%s” cần một đối số."
 
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "Đường dẫn không hợp lệ."
 
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "Không tìm thấy thư mục chính."
 
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "Không thể chuyển đổi sang thư mục cục bộ “%s”."
 
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "Thư mục cục bộ bây giờ là “%s”."
 
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "Thư mục máy chủ bây giờ là “%s”."
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "Lệnh đặt cấu hình “set-config” yêu cầu đối số thứ hai.\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "Lệnh đặt giá trị cấu hình “set-config-value” yêu cầu đối số thứ hai.\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "Lệnh đặt chỉ mục cấu hình “set-config-index” yêu cầu đối số thứ hai.\n"
 
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
-msgstr "Không tìm thấy lệnh “%s”. Hãy sử dụng lệnh “help” (trợ giúp) để xem danh sách các lệnh sẵn có."
+msgstr ""
+"Không tìm thấy lệnh “%s”. Hãy sử dụng lệnh “help” (trợ giúp) để xem danh "
+"sách các lệnh sẵn có."
 
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "Trợ giúp về “%s”:"
 
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "Cách dùng:"
 
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "Mô tả:"
 
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* Những đối số nằm trong dấu ngoặc vuông [] là tùy chọn"
 
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "Các lệnh có thể dùng:"
 
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr "Để xem trợ giúp về một lệnh nào đó, hãy gõ “help tên_lệnh”."
+
+#~ msgid "Trigger image capture"
+#~ msgstr "Bẫy chụp ảnh"
 
 #~ msgid "Show info"
 #~ msgstr "Hiện thông tin"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,88 +7,88 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.1\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-01-27 21:10+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2013-03-08 12:37+0800\n"
 "Last-Translator: Ji ZhengYu <zhengyuji@gmail.com>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
 "Language: zh_CN\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 # frontends/command-line/main.c:799
-#: gphoto2/actions.c:168
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "文件夹 “%s” 中文件的数量：%i\n"
 
 # frontends/command-line/actions.c:81
-#: gphoto2/actions.c:189
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "文件夹“%2$s”中有“%1$d”个文件夹。\n"
 
 # frontends/command-line/actions.c:115
-#: gphoto2/actions.c:238
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "文件夹“%s”中没有文件。\n"
 
 # frontends/command-line/actions.c:115
-#: gphoto2/actions.c:241
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "文件夹“%2$s”中有“%1$d”个文件。\n"
 
 # frontends/command-line/actions.c:139
-#: gphoto2/actions.c:263
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "文件“%s”(文件夹“%s”)的信息：\n"
 
 # frontends/command-line/actions.c:141
-#: gphoto2/actions.c:265
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "文件：\n"
 
 # frontends/command-line/actions.c:143 frontends/command-line/actions.c:177
 # frontends/command-line/actions.c:193
-#: gphoto2/actions.c:267 gphoto2/actions.c:299 gphoto2/actions.c:315
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  不可用。\n"
 
 # frontends/command-line/actions.c:148 frontends/command-line/actions.c:180
-#: gphoto2/actions.c:270 gphoto2/actions.c:302
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Mime 类型：  “%s”\n"
 
 # frontends/command-line/actions.c:150 frontends/command-line/actions.c:182
-#: gphoto2/actions.c:272 gphoto2/actions.c:304
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  大小：       %lu 字节\n"
 
 # frontends/command-line/actions.c:152 frontends/command-line/actions.c:184
-#: gphoto2/actions.c:274 gphoto2/actions.c:306
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  宽度：      %i 像素\n"
 
 # frontends/command-line/actions.c:154 frontends/command-line/actions.c:186
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  高度：     %i 像素\n"
 
 # frontends/command-line/actions.c:156 frontends/command-line/actions.c:188
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  已下载： %s\n"
@@ -98,10 +98,10 @@ msgstr "  已下载： %s\n"
 # frontends/command-line/main.c:418 frontends/command-line/main.c:437
 # frontends/command-line/main.c:439 frontends/command-line/main.c:441
 # frontends/command-line/main.c:443
-#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:323
-#: gphoto2/actions.c:676 gphoto2/actions.c:678 gphoto2/actions.c:706
-#: gphoto2/actions.c:709 gphoto2/actions.c:712 gphoto2/actions.c:715
-#: gphoto2/actions.c:718 gphoto2/actions.c:1731 gphoto2/actions.c:1956
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "是"
 
@@ -110,149 +110,149 @@ msgstr "是"
 # frontends/command-line/main.c:418 frontends/command-line/main.c:437
 # frontends/command-line/main.c:439 frontends/command-line/main.c:441
 # frontends/command-line/main.c:443
-#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:323
-#: gphoto2/actions.c:676 gphoto2/actions.c:678 gphoto2/actions.c:706
-#: gphoto2/actions.c:709 gphoto2/actions.c:712 gphoto2/actions.c:715
-#: gphoto2/actions.c:718 gphoto2/actions.c:1725 gphoto2/actions.c:1950
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "否"
 
 # frontends/command-line/actions.c:159
-#: gphoto2/actions.c:281
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  权限："
 
 # frontends/command-line/actions.c:162
-#: gphoto2/actions.c:284
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "读取/删除"
 
 # frontends/command-line/actions.c:164
-#: gphoto2/actions.c:286
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "读取"
 
 # frontends/command-line/actions.c:166
-#: gphoto2/actions.c:288
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "删除"
 
 # frontends/command-line/actions.c:168
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "无"
 
 # frontends/command-line/actions.c:172
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  时间：       %s"
 
 # frontends/command-line/actions.c:175
-#: gphoto2/actions.c:297
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "缩略图：\n"
 
 # frontends/command-line/actions.c:191
-#: gphoto2/actions.c:313
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "音频数据：\n"
 
 # frontends/command-line/actions.c:196
-#: gphoto2/actions.c:318
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Mime 类型： “%s”\n"
 
 # frontends/command-line/actions.c:198
-#: gphoto2/actions.c:320
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  大小：      %lu 字节\n"
 
 # frontends/command-line/actions.c:200
-#: gphoto2/actions.c:322
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  已下载：%s\n"
 
 # frontends/command-line/actions.c:322
-#: gphoto2/actions.c:498
+#: gphoto2/actions.c:504
 msgid "Could not parse EXIF data."
 msgstr "无法解析 EXIF 数据。"
 
 # frontends/command-line/actions.c:326
-#: gphoto2/actions.c:502
+#: gphoto2/actions.c:508
 #, c-format
 msgid "EXIF tags:"
 msgstr "EXIF 标记："
 
 # frontends/command-line/actions.c:329
-#: gphoto2/actions.c:505
+#: gphoto2/actions.c:511
 msgid "Tag"
 msgstr "标记"
 
 # frontends/command-line/actions.c:331
-#: gphoto2/actions.c:507
+#: gphoto2/actions.c:513
 msgid "Value"
 msgstr "值"
 
 # frontends/command-line/actions.c:346
-#: gphoto2/actions.c:528
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "EXIF 数据中含有一幅缩略图 (%i 字节)。"
 
 # frontends/command-line/actions.c:355
-#: gphoto2/actions.c:537
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 编译时未包含对 EXIF 的支持。"
 
 # frontends/command-line/main.c:464
-#: gphoto2/actions.c:555
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "所支持的相机数：%i\n"
 
 # frontends/command-line/main.c:465
-#: gphoto2/actions.c:556
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "已支持相机：\n"
 
 # frontends/command-line/main.c:476
-#: gphoto2/actions.c:569
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t“%s” (测试中)\n"
 
 # frontends/command-line/main.c:479
-#: gphoto2/actions.c:572
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t“%s” (实验项)\n"
 
 # frontends/command-line/main.c:483
-#: gphoto2/actions.c:577
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t“%s”\n"
 
 # frontends/command-line/main.c:548
-#: gphoto2/actions.c:621
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "找到设备：%i\n"
 
 # frontends/command-line/main.c:549
-#: gphoto2/actions.c:622
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -262,175 +262,193 @@ msgstr ""
 "--------------------------------------------------------------\n"
 
 # frontends/command-line/main.c:384 frontends/command-line/main.c:389
-#: gphoto2/actions.c:655 gphoto2/actions.c:660
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
 # frontends/command-line/main.c:384
-#: gphoto2/actions.c:655
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "型号"
 
 # frontends/command-line/main.c:384
-#: gphoto2/actions.c:655
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "端口"
 
 # frontends/command-line/main.c:385
-#: gphoto2/actions.c:656
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
 # frontends/command-line/main.c:413
-#: gphoto2/actions.c:674
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "相机功能             ：%s\n"
 
 # frontends/command-line/main.c:415
-#: gphoto2/actions.c:675
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "串口支持             ：%s\n"
 
 # frontends/command-line/main.c:417
-#: gphoto2/actions.c:677
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB 支持             ：%s\n"
 
 # frontends/command-line/main.c:420
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "支持的传输速度       ：\n"
 
 # frontends/command-line/main.c:423
-#: gphoto2/actions.c:682
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                     ：%i\n"
 
 # frontends/command-line/main.c:427
-#: gphoto2/actions.c:685
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "捕获选项             ：\n"
 
 # frontends/command-line/main.c:429
-#: gphoto2/actions.c:687
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                     ：图像\n"
 
 # frontends/command-line/main.c:431
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                     ：视频\n"
 
 # frontends/command-line/main.c:433
-#: gphoto2/actions.c:695
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                     ：音频\n"
 
 # frontends/command-line/main.c:435
-#: gphoto2/actions.c:699
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                     ：预览\n"
 
+# frontends/command-line/main.c:423
+#: gphoto2/actions.c:696
+#, fuzzy, c-format
+msgid "                                 : Trigger Capture\n"
+msgstr "                     ：%i\n"
+
 # frontends/command-line/main.c:435
-#: gphoto2/actions.c:703
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
 msgstr "                     ：设备不支持捕获功能\n"
 
 # frontends/command-line/main.c:436
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "支持配置             ：%s\n"
 
 # frontends/command-line/main.c:438
-#: gphoto2/actions.c:707
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "删除相机中的所选文件  ：%s\n"
 
 # frontends/command-line/main.c:438
-#: gphoto2/actions.c:710
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "删除相机中的所有文件   ：%s\n"
 
 # frontends/command-line/main.c:440
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "支持文件预览 (缩略图)：%s\n"
 
 # frontends/command-line/main.c:442
-#: gphoto2/actions.c:716
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "文件上传支持         ：%s\n"
 
 # frontends/command-line/main.c:586
-#: gphoto2/actions.c:733
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "端口必须是类似“serial:/dev/ttyS0”或“usb:”的形式，但“%s”缺少冒号，所以我将猜测您的意图。"
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"端口必须是类似“serial:/dev/ttyS0”或“usb:”的形式，但“%s”缺少冒号，所以我将猜测"
+"您的意图。"
 
 # frontends/command-line/main.c:1318
-#: gphoto2/actions.c:767
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "无法找到您指定的端口 (“%s”)。请指定一个由“gphoto2 --list-ports”列出的端口并确信拼写正确 (例如，带有前缀“serial:”或“usb:”)。"
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"无法找到您指定的端口 (“%s”)。请指定一个由“gphoto2 --list-ports”列出的端口并确"
+"信拼写正确 (例如，带有前缀“serial:”或“usb:”)。"
 
 # frontends/command-line/main.c:243
-#: gphoto2/actions.c:800
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "关于相机驱动程序："
 
 # frontends/command-line/main.c:1180
-#: gphoto2/actions.c:813
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "相机概要："
 
 # frontends/command-line/main.c:1192
-#: gphoto2/actions.c:826
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "相机手册："
 
-#: gphoto2/actions.c:843
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "您只能为串口指定速度。"
 
 # frontends/command-line/options.c:197
-#: gphoto2/actions.c:893
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "由 Bart van Leeuwen 移植到 OS/2\n"
 
-#: gphoto2/actions.c:897
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
@@ -443,286 +461,331 @@ msgstr ""
 "这个版本的 gphoto2 使用下列软件版本和选项：\n"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/actions.c:997
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "无法打开\"movie.mjpg\"。"
 
-#: gphoto2/actions.c:1004
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
 msgstr "保存预览窗口内容为影片 \"%s\"。按 Ctrl-C 退出。\n"
 
-#: gphoto2/actions.c:1008
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr "将预览窗口的内容保存为 %2$d 秒的影片 \"%1$s\"。\n"
 
-#: gphoto2/actions.c:1013
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "将 %d 个预览窗口的内容保存为影片 \"%s\"。\n"
 
-#: gphoto2/actions.c:1023
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "影片保存错误... 退出。"
 
-#: gphoto2/actions.c:1028
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "影片保存错误... 无法处理的 MIME 类型 \"%s\"。"
 
-#: gphoto2/actions.c:1035
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "按下了 Ctrl-C ... 退出。\n"
 
-#: gphoto2/actions.c:1049
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "视频捕获完成 ( %d 帧)\n"
 
-#: gphoto2/actions.c:1079
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "等待来自相机的事件。按 Ctrl-C 退出。\n"
 
-#: gphoto2/actions.c:1085
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr "等待来自相机的 %d 帧。按 Ctrl-C 退出。\n"
 
-#: gphoto2/actions.c:1090
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
 msgstr "等待相机事件 %d 毫秒。按 Ctrl-C 退出。\n"
 
-#: gphoto2/actions.c:1095
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
 msgstr "等待相机事件 %d 秒。按 Ctrl-C 退出。\n"
 
-#: gphoto2/actions.c:1099
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
 msgstr "等待相机事件 %d 秒。按 Ctrl-C 退出。\n"
 
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
+msgstr "等待相机事件 %d 秒。按 Ctrl-C 退出。\n"
+
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
+#, c-format
+msgid "event found, stopping wait!\n"
+msgstr ""
+
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/actions.c:1163 gphoto2/main.c:746
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "无法设置文件夹。"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/actions.c:1169 gphoto2/main.c:753
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "无法获得图像。"
 
-#: gphoto2/actions.c:1176 gphoto2/main.c:760
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "libcanno.so 太多错误？"
 
 # frontends/command-line/shell.c:522
-#: gphoto2/actions.c:1186 gphoto2/main.c:772
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "无法删除图像。"
 
-#: gphoto2/actions.c:1210
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr "正在获取此相机不支持的内存卡信息。\n"
 
-#: gphoto2/actions.c:1225
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "读/写模式"
 
-#: gphoto2/actions.c:1228
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "只读模式"
 
-#: gphoto2/actions.c:1231
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "允许删除的只读模式"
 
-#: gphoto2/actions.c:1234 gphoto2/actions.c:1244
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "未知"
 
-#: gphoto2/actions.c:1247
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "固态 ROM"
 
-#: gphoto2/actions.c:1250
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "可移动 ROM"
 
-#: gphoto2/actions.c:1253
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "固态 RAM"
 
-#: gphoto2/actions.c:1256
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "可移动 RAM"
 
-#: gphoto2/actions.c:1266
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "未定义"
 
-#: gphoto2/actions.c:1269
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "正常(不分级)"
 
-#: gphoto2/actions.c:1272
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "正常(分级)"
 
-#: gphoto2/actions.c:1275
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "相机设计(DCIM)"
 
-#: gphoto2/actions.c:1313
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "正以 0x%3$x/0x%4$x 覆盖 USB 生产商/产品 id 0x%1$x/0x%2$x"
 
-#: gphoto2/actions.c:1371
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
 msgstr "在将调试信息发送到邮件列表的时候总是包含下列行："
 
-#: gphoto2/actions.c:1386
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "%s 编译时带有以下选项:"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/actions.c:1517
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "未在配置树中找到 %s。"
 
-#: gphoto2/actions.c:1566
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "取得 text 控件 %s 的值出错。"
 
-#: gphoto2/actions.c:1583
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "取得 range 控件 %s 的值出错。"
 
-#: gphoto2/actions.c:1595
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "取得 toggle 控件 %s 的值出错。"
 
-#: gphoto2/actions.c:1607
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "取得 date/time 控件 %s 的值出错。"
 
-#: gphoto2/actions.c:1637
+#: gphoto2/actions.c:1731
+msgid "Use 'now' as the current time when setting.\n"
+msgstr ""
+
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "取得 radio 控件 %s 的值出错。"
 
-#: gphoto2/actions.c:1681
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "属性 %s 只读。"
 
-#: gphoto2/actions.c:1695 gphoto2/actions.c:1920
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "将 text 控件的值从 %s 改为 %s 出错。"
 
-#: gphoto2/actions.c:1705 gphoto2/actions.c:1930
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "传递的值 %s 不是一个浮点值。"
 
-#: gphoto2/actions.c:1710 gphoto2/actions.c:1935
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "传递的值 %f 不在所要的范围 %f - %f 内。"
 
-#: gphoto2/actions.c:1716 gphoto2/actions.c:1941
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "将 range 控件的值从 %s 改为 %f 出错。"
 
-#: gphoto2/actions.c:1725 gphoto2/actions.c:1950
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "关"
 
 # frontends/command-line/actions.c:331
-#: gphoto2/actions.c:1726 gphoto2/actions.c:1951
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "错误"
 
 # camlibs/polaroid/pdc700.c:169 camlibs/polaroid/pdc700.c:170
-#: gphoto2/actions.c:1731 gphoto2/actions.c:1956
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "开"
 
-#: gphoto2/actions.c:1732 gphoto2/actions.c:1957
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "正确"
 
-#: gphoto2/actions.c:1737 gphoto2/actions.c:1962
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "传递的值 %s 不是一个有效的布尔值。"
 
-#: gphoto2/actions.c:1743 gphoto2/actions.c:1968
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "设定 toggle 控件 %2$s 的值为 %1$s 出错。"
 
-#: gphoto2/actions.c:1756 gphoto2/actions.c:1981
+# frontends/command-line/actions.c:157 frontends/command-line/actions.c:189
+# frontends/command-line/actions.c:201 frontends/command-line/main.c:416
+# frontends/command-line/main.c:418 frontends/command-line/main.c:437
+# frontends/command-line/main.c:439 frontends/command-line/main.c:441
+# frontends/command-line/main.c:443
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
+#, fuzzy
+msgid "now"
+msgstr "否"
+
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "传递的值 %s 既不是一个有效的时间也不是一个整数。"
 
-#: gphoto2/actions.c:1763 gphoto2/actions.c:1988
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "将 date/time 控件的时间变量从 %s 改为 %s 出错。"
 
-#: gphoto2/actions.c:1810 gphoto2/actions.c:1874 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "所选的 %s 在选择列表中未找到。"
 
-#: gphoto2/actions.c:1818 gphoto2/actions.c:2026
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "控件 %s 不可配置。"
 
-#: gphoto2/actions.c:1825 gphoto2/actions.c:1893 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr "为配置选项 %2$s 设置新的值 %1$s 出错。"
 
-#: gphoto2/actions.c:1886
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
 msgstr "%s 控件无索引选择列表。用 --set-config-value 代替。 "
 
 # frontends/command-line/foreach.c:207
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "错误的文件编号。您给出 %1$i，但在“%3$s”和它的子目录中只有 %2$i 个文件。请首先从文件列表中获取一个合法的文件编号。"
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"错误的文件编号。您给出 %1$i，但在“%3$s”和它的子目录中只有 %2$i 个文件。请首先"
+"从文件列表中获取一个合法的文件编号。"
 
 # frontends/command-line/actions.c:111 frontends/command-line/foreach.c:228
 #: gphoto2/foreach.c:285
@@ -733,27 +796,33 @@ msgstr "文件夹“%s”中没有文件。"
 # frontends/command-line/foreach.c:233
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
 msgstr "错误的文件编号。您给出 %i，但在“%s”中只有一个文件。"
 
 # frontends/command-line/foreach.c:240
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "错误的文件编号。您给出 %1$i，但在“%3$s”中只有 %2$i 个文件。请首先从文件列表中获取一个合法的文件编号。"
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"错误的文件编号。您给出 %1$i，但在“%3$s”中只有 %2$i 个文件。请首先从文件列表中"
+"获取一个合法的文件编号。"
 
 # frontends/command-line/main.c:1753
-#: gphoto2/gp-params.c:62
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** 错误 ***       \n"
 
-#: gphoto2/gp-params.c:237
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "请按任意键继续。\n"
 
-#: gphoto2/gp-params.c:259
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "没有足够内存。"
@@ -765,37 +834,37 @@ msgid "Operation cancelled"
 msgstr "操作已取消"
 
 # frontends/command-line/gphoto2-cmd-config.c:65
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>继续"
 
 # frontends/command-line/gphoto2-cmd-config.c:65
-#: gphoto2/gphoto2-cmd-config.c:55
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>取消"
 
 # frontends/command-line/gphoto2-cmd-config.c:71
-#: gphoto2/gphoto2-cmd-config.c:61
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>错误"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "无法设置配置："
 
 # frontends/command-line/gphoto2-cmd-config.c:117
-#: gphoto2/gphoto2-cmd-config.c:107
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "退出"
 
 # frontends/command-line/gphoto2-cmd-config.c:119
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "退回"
 
 # frontends/command-line/gphoto2-cmd-config.c:263
-#: gphoto2/gphoto2-cmd-config.c:254
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "时间："
 
@@ -803,196 +872,207 @@ msgstr "时间："
 # frontends/command-line/gphoto2-cmd-config.c:350
 # frontends/command-line/gphoto2-cmd-config.c:410
 # frontends/command-line/gphoto2-cmd-config.c:473
-#: gphoto2/gphoto2-cmd-config.c:313 gphoto2/gphoto2-cmd-config.c:341
-#: gphoto2/gphoto2-cmd-config.c:400 gphoto2/gphoto2-cmd-config.c:463
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "值："
 
 # camlibs/minolta/dimagev/dimagev.c:300 camlibs/minolta/dimagev/dimagev.c:302
 # camlibs/minolta/dimagev/dimagev.c:306 camlibs/minolta/dimagev/dimagev.c:309
 # frontends/command-line/gphoto2-cmd-config.c:372
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "是"
 
 # camlibs/minolta/dimagev/dimagev.c:300 camlibs/minolta/dimagev/dimagev.c:302
 # camlibs/minolta/dimagev/dimagev.c:306 camlibs/minolta/dimagev/dimagev.c:309
 # frontends/command-line/gphoto2-cmd-config.c:372
-#: gphoto2/gphoto2-cmd-config.c:362
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "否"
 
-#: gphoto2/main.c:209
+#: gphoto2/main.c:220
 #, fuzzy, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "文件名中的零填充值只可能带 %%n。"
 
-#: gphoto2/main.c:218
+#: gphoto2/main.c:229
 #, fuzzy, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "您无法使用一个不精确的 %%n 零填充值！"
 
-#: gphoto2/main.c:251
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "由照相机 (“%s”) 提供的文件名不含有后缀！"
 
-#: gphoto2/main.c:306
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "无效的格式“%s” (错误发生在 %i 字节)。"
 
+# frontends/command-line/main.c:884
+#: gphoto2/main.c:386 gphoto2/main.c:592
+#, fuzzy, c-format
+msgid "Skip existing file %s\n"
+msgstr "正在将文件另存为 %s\n"
+
 # frontends/command-line/main.c:859
-#: gphoto2/main.c:356
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "文件 %s 存在。覆盖？[y|n] "
 
 # frontends/command-line/main.c:870
-#: gphoto2/main.c:368
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "给出新文件名？[y|n]"
 
 # frontends/command-line/main.c:879
-#: gphoto2/main.c:380
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "输入新文件名："
 
 # frontends/command-line/main.c:884
-#: gphoto2/main.c:386
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "正在将文件另存为 %s\n"
 
 # frontends/command-line/actions.c:159
-#: gphoto2/main.c:545
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "权限不够"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:707
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "无法开启捕获。"
 
 # frontends/command-line/main.c:1122
-#: gphoto2/main.c:737
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "新文件在相机中 %s%s%s 处\n"
 
 # frontends/command-line/main.c:1122
-#: gphoto2/main.c:767
-#, c-format
-msgid "Deleting file %s%s%s on the camera\n"
-msgstr "删除相机中的文件 %s%s%s \n"
-
-# frontends/command-line/main.c:1122
-#: gphoto2/main.c:777
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "保存文件 %s%s%s于相机中 \n"
 
-#: gphoto2/main.c:810
+# frontends/command-line/main.c:1122
+#: gphoto2/main.c:868
+#, c-format
+msgid "Deleting file %s%s%s on the camera\n"
+msgstr "删除相机中的文件 %s%s%s \n"
+
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "等待期间出现 FOLDER_ADDED %s/%s 目录添加事件，忽略...\n"
 
-#: gphoto2/main.c:820
+#: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "等待期间出现 FOLDER_ADDED %s/%s 目录添加事件，忽略...\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "等待期间出现 UNKNOW %s 未知事件，忽略...\n"
 
-#: gphoto2/main.c:826
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr "B 门等待期间出现未知事件，类型 %d，忽略...\n"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:844
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "无法取得功能？"
 
-#: gphoto2/main.c:852
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "允许T 门曝光(间隔: %d 秒)。\n"
 
-#: gphoto2/main.c:855
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "挂起等待 SIGUSR1 信号来捕获。\n"
 
-#: gphoto2/main.c:861
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "允许B 门曝光(曝光时间： %d 秒)。\n"
 
-#: gphoto2/main.c:874
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "正在捕获帧 #%d...\n"
 
-#: gphoto2/main.c:876
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "正在捕获帧 #%d/%d...\n"
 
 # frontends/command-line/actions.c:322
-#: gphoto2/main.c:886
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "无法中止捕获(B 门曝光)，返回 %d。"
 
 # frontends/command-line/actions.c:322
-#: gphoto2/main.c:900
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "无法中止捕获(B 门曝光)。"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:911
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "无法开启图像捕获。"
 
 # frontends/command-line/actions.c:322
-#: gphoto2/main.c:917
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "无法捕获图像。"
 
-#: gphoto2/main.c:924
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "捕获失败(自动对焦问题？)...\n"
 
 # frontends/command-line/actions.c:322
-#: gphoto2/main.c:935
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "无法捕获。"
 
-#: gphoto2/main.c:966
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "等待下一次捕获接口 %ld 秒...\n"
 
-#: gphoto2/main.c:975 gphoto2/main.c:1016
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "由 SIGUSR1 信号唤醒...\n"
 
-#: gphoto2/main.c:988
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "目前不休眠(进程安排 %ld 秒后)\n"
 
 # frontends/command-line/main.c:1614
-#: gphoto2/main.c:1120
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "错误："
 
 # frontends/command-line/main.c:1637
-#: gphoto2/main.c:1143
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -1002,13 +1082,13 @@ msgstr ""
 "正在中断...\n"
 
 # frontends/command-line/main.c:1643
-#: gphoto2/main.c:1149
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "已中断。\n"
 
 # frontends/command-line/main.c:1648
-#: gphoto2/main.c:1154
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -1018,23 +1098,27 @@ msgstr ""
 "正在取消...\n"
 
 # frontends/command-line/main.c:637
-#: gphoto2/main.c:1301
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "使用诸如 a:b=c:d 的形式将探测为 a:b 的 USB 设备处理为 c:d。a b c d 应为以“0x”开始的十六进制数。\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"使用诸如 a:b=c:d 的形式将探测为 a:b 的 USB 设备处理为 c:d。a b c d 应为"
+"以“0x”开始的十六进制数。\n"
 
 # frontends/command-line/actions.c:355
-#: gphoto2/main.c:1469
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 编译时没有包含对 CDK 的支持。"
 
 # frontends/command-line/main.c:1750
-#: gphoto2/main.c:1704
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "操作已取消。\n"
 
-#: gphoto2/main.c:1708
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -1044,7 +1128,7 @@ msgstr ""
 "\n"
 
 # frontends/command-line/main.c:1753
-#: gphoto2/main.c:1710
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -1054,7 +1138,7 @@ msgstr ""
 "\n"
 
 # frontends/command-line/main.c:1759
-#: gphoto2/main.c:1715
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -1071,436 +1155,468 @@ msgstr ""
 "请按以下方式运行 gphoto2：\n"
 "\n"
 
-#: gphoto2/main.c:1736
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
 "\n"
 msgstr "请确保参数用引号括起。\n"
 
-#: gphoto2/main.c:1803
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "打印有关程序用法的全部帮助信息"
 
-#: gphoto2/main.c:1805
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "打印有关程序用法的简短帮助信息"
 
 # frontends/command-line/main.c:187
-#: gphoto2/main.c:1807
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "开始调试"
 
-#: gphoto2/main.c:1809
+#: gphoto2/main.c:1984
+msgid "Set debug level [error|debug|data|all]"
+msgstr ""
+
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "将要写入调试信息的文件名"
 
-#: gphoto2/main.c:1809 gphoto2/main.c:1814 gphoto2/main.c:1820
-#: gphoto2/main.c:1942
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "文件名"
 
 # frontends/command-line/main.c:189
-#: gphoto2/main.c:1811
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "最少信息输出 (默认为大量)"
 
-#: gphoto2/main.c:1813
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "下载、捕获等操作结束后的所调用的脚本。"
 
 # frontends/command-line/main.c:203
-#: gphoto2/main.c:1820
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "指定设备端口"
 
 # frontends/command-line/main.c:204
-#: gphoto2/main.c:1822
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "指定串行传输速度"
 
-#: gphoto2/main.c:1822
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "速度"
 
 # frontends/command-line/main.c:205
-#: gphoto2/main.c:1824
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "指定相机型号"
 
-#: gphoto2/main.c:1824
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "型号"
 
 # frontends/command-line/main.c:207
-#: gphoto2/main.c:1826
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(仅适于专家) 覆盖 USB ID"
 
-#: gphoto2/main.c:1826
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBIDs"
 
 # frontends/command-line/main.c:193
-#: gphoto2/main.c:1832
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "显示版本号并退出"
 
 # frontends/command-line/main.c:195
-#: gphoto2/main.c:1834
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "列举支持的相机型号"
 
 # frontends/command-line/main.c:197
-#: gphoto2/main.c:1836
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "列举支持的端口设备"
 
 # frontends/command-line/main.c:210
-#: gphoto2/main.c:1838
-msgid "Display camera/driver abilities"
+#: gphoto2/main.c:2015
+#, fuzzy
+msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "显示相机/设备的功能"
 
 # frontends/command-line/main.c:231
-#: gphoto2/main.c:1845
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "配置"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:1848
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "列出配置树"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:1850
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "列出所有配置"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:1852
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "获取配置值："
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:1854
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "在选项中设置配置值或索引号"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:1856
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "在选项中设置配置值索引"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:1858
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "设置配置值"
 
-#: gphoto2/main.c:1864
+# frontends/command-line/main.c:203
+#: gphoto2/main.c:2037
+#, fuzzy
+msgid "Reset device port"
+msgstr "指定设备端口"
+
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "捕获后将图像留在相机中"
 
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:2045
+#, fuzzy
+msgid "Keep RAW images on camera after capturing"
+msgstr "捕获后将图像留在相机中"
+
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "捕获后将图像从相机中删除"
 
-#: gphoto2/main.c:1868
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "等待来自相机的事件"
 
-#: gphoto2/main.c:1868 gphoto2/main.c:1870 gphoto2/main.c:1877
-#: gphoto2/main.c:1893
-msgid "COUNT"
-msgstr "数目"
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
+msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
+msgstr ""
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "等待相机事件并下载新图片"
 
 # frontends/command-line/main.c:233
-#: gphoto2/main.c:1873
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "获取一个快速预览"
 
-#: gphoto2/main.c:1875
+#: gphoto2/main.c:2057
+msgid "Show a quick preview as Ascii Art"
+msgstr ""
+
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "设定B 门曝光时间(以秒为单位)"
 
-#: gphoto2/main.c:1875 gphoto2/main.c:1879
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "秒"
 
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "设置要捕捉的帧数(默认为全部)"
 
-#: gphoto2/main.c:1879
+#: gphoto2/main.c:2061
+msgid "COUNT"
+msgstr "数目"
+
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "设置捕捉间隔(以秒为单位)"
 
-#: gphoto2/main.c:1881
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "重置信号的捕捉间隔(默认为不重置)"
 
 # frontends/command-line/main.c:234
-#: gphoto2/main.c:1883
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "捕捉一幅图像"
 
 # frontends/command-line/main.c:234
-#: gphoto2/main.c:1885
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "引发图像捕捉"
 
 # frontends/command-line/main.c:234
-#: gphoto2/main.c:1887
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "捕捉一幅图像并下载"
 
 # frontends/command-line/main.c:235
-#: gphoto2/main.c:1889
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "拍摄一段电影"
 
-#: gphoto2/main.c:1889
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "COUNT 或 SECONDS"
 
 # frontends/command-line/main.c:236
-#: gphoto2/main.c:1891
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "捕捉一个音频片段"
 
-#: gphoto2/main.c:1893
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "等待松开相机上的快门再下载"
 
-# frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:1895
-msgid "Trigger image capture"
-msgstr "开启图像捕获。"
-
 # frontends/command-line/main.c:214
-#: gphoto2/main.c:1901
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "列出文件夹中的文件夹"
 
 # frontends/command-line/main.c:215
-#: gphoto2/main.c:1903
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "列出文件夹中的文件"
 
 # frontends/command-line/main.c:216
-#: gphoto2/main.c:1905
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "创建目录"
 
-#: gphoto2/main.c:1905 gphoto2/main.c:1907
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "目录名"
 
 # frontends/command-line/main.c:217
-#: gphoto2/main.c:1907
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "删除目录"
 
 # frontends/command-line/main.c:218
-#: gphoto2/main.c:1909
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "显示文件的数量"
 
 # frontends/command-line/main.c:219
-#: gphoto2/main.c:1911
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "获取给定范围的文件"
 
-#: gphoto2/main.c:1911 gphoto2/main.c:1915 gphoto2/main.c:1920
-#: gphoto2/main.c:1927 gphoto2/main.c:1933 gphoto2/main.c:1938
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "范围"
 
 # frontends/command-line/main.c:220
-#: gphoto2/main.c:1913
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "从文件夹中获取所有文件"
 
 # frontends/command-line/main.c:221
-#: gphoto2/main.c:1915
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "获取给定范围的缩略图"
 
 # frontends/command-line/main.c:222
-#: gphoto2/main.c:1918
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "从文件夹中获取所有缩略图"
 
 # frontends/command-line/main.c:223
-#: gphoto2/main.c:1920
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "获取给定范围的元数据"
 
 # frontends/command-line/main.c:224
-#: gphoto2/main.c:1922
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "从文件夹中获取所有元数据"
 
-#: gphoto2/main.c:1924
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "上传文件的元数据"
 
 # frontends/command-line/main.c:223
-#: gphoto2/main.c:1927
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "获取给定范围的原始数据"
 
 # frontends/command-line/main.c:224
-#: gphoto2/main.c:1930
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "从文件夹中获取所有原始数据"
 
 # frontends/command-line/main.c:225
-#: gphoto2/main.c:1933
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "获取给定范围的音频数据"
 
 # frontends/command-line/main.c:226
-#: gphoto2/main.c:1936
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "从文件夹中获取所有音频数据"
 
 # frontends/command-line/main.c:227
-#: gphoto2/main.c:1938
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "删除给定范围中的文件"
 
 # frontends/command-line/main.c:228
-#: gphoto2/main.c:1940
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "删除文件夹中的所有文件(默认选项 --no-recurse)"
 
 # frontends/command-line/main.c:229
-#: gphoto2/main.c:1942
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "将一个文件上载到相机"
 
 # frontends/command-line/main.c:206
-#: gphoto2/main.c:1944
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "指定文件名或是文件名匹配模式"
 
-#: gphoto2/main.c:1944
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "FILENAME_PATTERN"
 
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
 # frontends/command-line/main.c:211
-#: gphoto2/main.c:1946
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "指定相机文件夹 (默认为 “/”)"
 
-#: gphoto2/main.c:1946
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "文件夹"
 
 # frontends/command-line/main.c:212
-#: gphoto2/main.c:1948
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "递归 (下载时默认)"
 
 # frontends/command-line/main.c:213
-#: gphoto2/main.c:1950
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "不递归 (删除时默认)"
 
-#: gphoto2/main.c:1952
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "仅处理新文件"
 
-#: gphoto2/main.c:1954
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "覆盖文件而不询问"
 
+#: gphoto2/main.c:2140
+msgid "Skip existing files"
+msgstr ""
+
 # frontends/command-line/main.c:198
-#: gphoto2/main.c:1960
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "将文件发送到标准输出"
 
 # frontends/command-line/main.c:199
-#: gphoto2/main.c:1962
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "在数据前面打印文件大小"
 
 # frontends/command-line/main.c:200
-#: gphoto2/main.c:1964
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "列举可以自动检测的相机"
 
 # frontends/command-line/main.c:238 frontends/command-line/shell.c:127
-#: gphoto2/main.c:1968 gphoto2/shell.c:138
-msgid "Show EXIF information"
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
+#, fuzzy
+msgid "Show EXIF information of JPEG images"
 msgstr "显示 EXIF 信息"
 
-# frontends/command-line/main.c:240 frontends/command-line/shell.c:123
-#: gphoto2/main.c:1971 gphoto2/shell.c:132
-msgid "Show info"
-msgstr "显示信息"
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
+msgid "Show image information, like width, height, and capture time"
+msgstr ""
 
-#: gphoto2/main.c:1973
-msgid "Show summary"
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
+#, fuzzy
+msgid "Show camera summary"
 msgstr "显示概要"
 
 # frontends/command-line/main.c:242
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "显示相机驱动程序手册"
 
 # frontends/command-line/main.c:243
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "关于相机驱动程序手册"
 
 # frontends/command-line/main.c:238 frontends/command-line/shell.c:127
-#: gphoto2/main.c:1979
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "显示内存卡信息"
 
 # frontends/command-line/main.c:244
-#: gphoto2/main.c:1981
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "gPhoto shell"
 
-#: gphoto2/main.c:1987
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "一般选项"
 
-#: gphoto2/main.c:1989
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "杂项(未排序)"
 
-#: gphoto2/main.c:1991
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "获取软件和主系统的信息(不来自相机)"
 
 # frontends/command-line/main.c:205
-#: gphoto2/main.c:1993
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "指定要用的相机"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:1995
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "相机和软件配置"
 
 # frontends/command-line/shell.c:112
-#: gphoto2/main.c:1997
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "从相机中捕捉一幅图像"
 
-#: gphoto2/main.c:1999
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "正在下载/上传/操作文件"
 
 # frontends/command-line/range.c:122 frontends/command-line/range.c:176
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1510,7 +1626,7 @@ msgstr ""
 "图像 IDs 必须是一个大于零的数。"
 
 # frontends/command-line/range.c:128 frontends/command-line/range.c:182
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1520,7 +1636,7 @@ msgstr ""
 "图像 ID %i 太大。"
 
 # frontends/command-line/range.c:144
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1530,7 +1646,7 @@ msgstr ""
 "范围必须由“,”分隔。"
 
 # frontends/command-line/range.c:158
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1540,7 +1656,7 @@ msgstr ""
 "范围应以数字开头。"
 
 # frontends/command-line/range.c:198
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1550,7 +1666,7 @@ msgstr ""
 "意外字符“%c”。"
 
 # frontends/command-line/range.c:221
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -1560,253 +1676,267 @@ msgstr ""
 "不允许缩小范围。您指定了一个从 %i 到 %i 的范围。"
 
 # frontends/command-line/shell.c:73
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** 错误 (%i:“%s”) ***"
 
 # frontends/command-line/shell.c:112
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "进入相机中的目录"
 
 # frontends/command-line/shell.c:113 frontends/command-line/shell.c:115
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "目录"
 
 # frontends/command-line/shell.c:114
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "进入本地驱动器中的目录"
 
 # frontends/command-line/shell.c:116 frontends/command-line/shell.c:134
 # frontends/command-line/shell.c:135
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "退出 gPhoto shell"
 
 # frontends/command-line/shell.c:117
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "下载一个文件"
 
 # frontends/command-line/shell.c:117 frontends/command-line/shell.c:120
 # frontends/command-line/shell.c:122 frontends/command-line/shell.c:124
 # frontends/command-line/shell.c:125 frontends/command-line/shell.c:128
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[目录/]文件"
 
 # frontends/command-line/shell.c:117
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "上传一个文件"
 
 # frontends/command-line/shell.c:119
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "下载一幅缩略图"
 
 # frontends/command-line/shell.c:121
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "下载原始数据"
 
 # frontends/command-line/shell.c:125
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "删除"
 
 # frontends/command-line/main.c:216
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "创建目录"
 
 # frontends/command-line/main.c:217
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "删除目录"
 
 # frontends/command-line/shell.c:130 frontends/command-line/shell.c:136
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "显示命令用法"
 
 # frontends/command-line/shell.c:131 frontends/command-line/shell.c:136
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[命令]"
 
 # frontends/command-line/shell.c:132
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "列出当前目录的内容"
 
 # frontends/command-line/shell.c:133
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[目录]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "列出配置变量"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "获取配置变量"
 
 # frontends/command-line/main.c:216 frontends/command-line/main.c:217
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "名称"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "设置配置变量"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "名称＝值"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "设置配置变量索引"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "名称＝值索引"
 
 # frontends/command-line/main.c:234
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "引发图像捕捉"
+
+# frontends/command-line/main.c:234
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "捕捉单幅图像"
 
 # frontends/command-line/main.c:234
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "捕捉单幅图像并下载"
 
 # frontends/command-line/main.c:234
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "捕捉上一幅图像"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "等待事件..."
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "次数或是秒数"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "等待捕获图像并下载"
 
 # frontends/command-line/main.c:234
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "等待事件及捕捉图像并下载"
 
 # frontends/command-line/shell.c:414
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "非法命令。"
 
 # frontends/command-line/shell.c:423
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "命令“%s”需要一个参数。"
 
 # frontends/command-line/shell.c:476
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "非法路径。"
 
 # frontends/command-line/shell.c:522
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "无法找到家目录。"
 
 # frontends/command-line/shell.c:530
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "无法进入本地目录“%s”。"
 
 # frontends/command-line/shell.c:533
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "本地目录为“%s”。"
 
 # frontends/command-line/shell.c:564
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "远程目录为“%s”。"
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config 需要一个附加的参数。\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "set-config-value 需要附带参数。\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "set-config-index 需要附带参数。\n"
 
 # frontends/command-line/shell.c:743
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
 msgstr "未找到“%s”命令。用“help”获取可用的命令列表。"
 
 # frontends/command-line/shell.c:750
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "关于“%s”的求助信息："
 
 # frontends/command-line/shell.c:752
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "用法："
 
 # frontends/command-line/shell.c:756
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "描述："
 
 # frontends/command-line/shell.c:758
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "所有出现在方括号 [] 中的参数是可选的"
 
 # frontends/command-line/shell.c:779
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "可用的命令："
 
 # frontends/command-line/shell.c:784
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr "为得到特定命令的求助信息，输入“help 命令名”。"
+
+# frontends/command-line/gphoto2-cmd-config.c:73
+#~ msgid "Trigger image capture"
+#~ msgstr "开启图像捕获。"
+
+# frontends/command-line/main.c:240 frontends/command-line/shell.c:123
+#~ msgid "Show info"
+#~ msgstr "显示信息"
 
 # frontends/command-line/actions.c:146
 #~ msgid "  Name:        '%s'\n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gphoto2 2.5.9\n"
 "Report-Msgid-Bugs-To: gphoto-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2015-11-18 22:19+0100\n"
+"POT-Creation-Date: 2021-05-10 10:28-0400\n"
 "PO-Revision-Date: 2018-06-23 18:06+0800\n"
 "Last-Translator: Yi-Jyun Pan <pan93412@gmail.com>\n"
 "Language-Team: Chinese (traditional) <zh-l10n@linux.org.tw>\n"
@@ -20,76 +20,76 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 # frontends/command-line/main.c:799
-#: gphoto2/actions.c:174
+#: gphoto2/actions.c:180
 #, c-format
 msgid "Number of files in folder '%s': %i\n"
 msgstr "資料夾「%s」中檔案的數量: %i\n"
 
 # frontends/command-line/actions.c:81
-#: gphoto2/actions.c:195
+#: gphoto2/actions.c:201
 #, c-format
 msgid "There is %d folder in folder '%s'.\n"
 msgid_plural "There are %d folders in folder '%s'.\n"
 msgstr[0] "資料夾「%2$s」中有 %1$d 個資料夾。\n"
 
 # frontends/command-line/actions.c:115
-#: gphoto2/actions.c:244
+#: gphoto2/actions.c:250
 #, c-format
 msgid "There is no file in folder '%s'.\n"
 msgstr "資料夾「%s」中沒有檔案。\n"
 
 # frontends/command-line/actions.c:115
-#: gphoto2/actions.c:247
+#: gphoto2/actions.c:253
 #, c-format
 msgid "There is %d file in folder '%s'.\n"
 msgid_plural "There are %d files in folder '%s'.\n"
 msgstr[0] "資料夾「%2$s」中有 %1$d 個檔案。\n"
 
 # frontends/command-line/actions.c:139
-#: gphoto2/actions.c:269
+#: gphoto2/actions.c:275
 #, c-format
 msgid "Information on file '%s' (folder '%s'):\n"
 msgstr "關於檔案「%s」(資料夾「%s」)的資訊: \n"
 
 # frontends/command-line/actions.c:141
-#: gphoto2/actions.c:271
+#: gphoto2/actions.c:277
 #, c-format
 msgid "File:\n"
 msgstr "檔案: \n"
 
 # frontends/command-line/actions.c:143 frontends/command-line/actions.c:177
 # frontends/command-line/actions.c:193
-#: gphoto2/actions.c:273 gphoto2/actions.c:305 gphoto2/actions.c:321
+#: gphoto2/actions.c:279 gphoto2/actions.c:311 gphoto2/actions.c:327
 #, c-format
 msgid "  None available.\n"
 msgstr "  不可用。\n"
 
 # frontends/command-line/actions.c:148 frontends/command-line/actions.c:180
-#: gphoto2/actions.c:276 gphoto2/actions.c:308
+#: gphoto2/actions.c:282 gphoto2/actions.c:314
 #, c-format
 msgid "  Mime type:   '%s'\n"
 msgstr "  Mime 類型:  「%s」\n"
 
 # frontends/command-line/actions.c:150 frontends/command-line/actions.c:182
-#: gphoto2/actions.c:278 gphoto2/actions.c:310
+#: gphoto2/actions.c:284 gphoto2/actions.c:316
 #, c-format
 msgid "  Size:        %lu byte(s)\n"
 msgstr "  大小：       %lu 位元組\n"
 
 # frontends/command-line/actions.c:152 frontends/command-line/actions.c:184
-#: gphoto2/actions.c:280 gphoto2/actions.c:312
+#: gphoto2/actions.c:286 gphoto2/actions.c:318
 #, c-format
 msgid "  Width:       %i pixel(s)\n"
 msgstr "  寬度:       %i 像素\n"
 
 # frontends/command-line/actions.c:154 frontends/command-line/actions.c:186
-#: gphoto2/actions.c:282 gphoto2/actions.c:314
+#: gphoto2/actions.c:288 gphoto2/actions.c:320
 #, c-format
 msgid "  Height:      %i pixel(s)\n"
 msgstr "  高度:      %i 像素\n"
 
 # frontends/command-line/actions.c:156 frontends/command-line/actions.c:188
-#: gphoto2/actions.c:284 gphoto2/actions.c:316
+#: gphoto2/actions.c:290 gphoto2/actions.c:322
 #, c-format
 msgid "  Downloaded:  %s\n"
 msgstr "  已下載:  %s\n"
@@ -99,10 +99,10 @@ msgstr "  已下載:  %s\n"
 # frontends/command-line/main.c:418 frontends/command-line/main.c:437
 # frontends/command-line/main.c:439 frontends/command-line/main.c:441
 # frontends/command-line/main.c:443
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "yes"
 msgstr "是"
 
@@ -111,75 +111,75 @@ msgstr "是"
 # frontends/command-line/main.c:418 frontends/command-line/main.c:437
 # frontends/command-line/main.c:439 frontends/command-line/main.c:441
 # frontends/command-line/main.c:443
-#: gphoto2/actions.c:285 gphoto2/actions.c:317 gphoto2/actions.c:329
-#: gphoto2/actions.c:682 gphoto2/actions.c:684 gphoto2/actions.c:716
-#: gphoto2/actions.c:719 gphoto2/actions.c:722 gphoto2/actions.c:725
-#: gphoto2/actions.c:728 gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:291 gphoto2/actions.c:323 gphoto2/actions.c:335
+#: gphoto2/actions.c:669 gphoto2/actions.c:671 gphoto2/actions.c:703
+#: gphoto2/actions.c:706 gphoto2/actions.c:709 gphoto2/actions.c:712
+#: gphoto2/actions.c:715 gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "no"
 msgstr "否"
 
 # frontends/command-line/actions.c:159
-#: gphoto2/actions.c:287
+#: gphoto2/actions.c:293
 #, c-format
 msgid "  Permissions: "
 msgstr "  存取權限: "
 
 # frontends/command-line/actions.c:162
-#: gphoto2/actions.c:290
+#: gphoto2/actions.c:296
 #, c-format
 msgid "read/delete"
 msgstr "讀取/刪除"
 
 # frontends/command-line/actions.c:164
-#: gphoto2/actions.c:292
+#: gphoto2/actions.c:298
 #, c-format
 msgid "read"
 msgstr "讀取"
 
 # frontends/command-line/actions.c:166
-#: gphoto2/actions.c:294
+#: gphoto2/actions.c:300
 #, c-format
 msgid "delete"
 msgstr "刪除"
 
 # frontends/command-line/actions.c:168
-#: gphoto2/actions.c:296
+#: gphoto2/actions.c:302
 #, c-format
 msgid "none"
 msgstr "無"
 
 # frontends/command-line/actions.c:172
-#: gphoto2/actions.c:300
+#: gphoto2/actions.c:306
 #, c-format
 msgid "  Time:        %s"
 msgstr "  時間:        %s"
 
 # frontends/command-line/actions.c:175
-#: gphoto2/actions.c:303
+#: gphoto2/actions.c:309
 #, c-format
 msgid "Thumbnail:\n"
 msgstr "縮圖: \n"
 
 # frontends/command-line/actions.c:191
-#: gphoto2/actions.c:319
+#: gphoto2/actions.c:325
 #, c-format
 msgid "Audio data:\n"
 msgstr "音訊資料: \n"
 
 # frontends/command-line/actions.c:196
-#: gphoto2/actions.c:324
+#: gphoto2/actions.c:330
 #, c-format
 msgid "  Mime type:  '%s'\n"
 msgstr "  Mime 類型: 「%s」\n"
 
 # frontends/command-line/actions.c:198
-#: gphoto2/actions.c:326
+#: gphoto2/actions.c:332
 #, c-format
 msgid "  Size:       %lu byte(s)\n"
 msgstr "  大小：      %lu 位元組\n"
 
 # frontends/command-line/actions.c:200
-#: gphoto2/actions.c:328
+#: gphoto2/actions.c:334
 #, c-format
 msgid "  Downloaded: %s\n"
 msgstr "  已下載: %s\n"
@@ -206,54 +206,54 @@ msgid "Value"
 msgstr "值"
 
 # frontends/command-line/actions.c:346
-#: gphoto2/actions.c:534
+#: gphoto2/actions.c:521
 #, c-format
 msgid "EXIF data contains a thumbnail (%i bytes)."
 msgstr "EXIF 資料含有一幅縮圖 (%i 位元組)。"
 
 # frontends/command-line/actions.c:355
-#: gphoto2/actions.c:543
+#: gphoto2/actions.c:530
 msgid "gphoto2 has been compiled without EXIF support."
 msgstr "gphoto2 編譯時沒有包含對 EXIF 的支援。"
 
 # frontends/command-line/main.c:464
-#: gphoto2/actions.c:561
+#: gphoto2/actions.c:548
 #, c-format
 msgid "Number of supported cameras: %i\n"
 msgstr "支援相機數量         : %i\n"
 
 # frontends/command-line/main.c:465
-#: gphoto2/actions.c:562
+#: gphoto2/actions.c:549
 #, c-format
 msgid "Supported cameras:\n"
 msgstr "已支援相機: \n"
 
 # frontends/command-line/main.c:476
-#: gphoto2/actions.c:575
+#: gphoto2/actions.c:562
 #, c-format
 msgid "\t\"%s\" (TESTING)\n"
 msgstr "\t\"%s\" (正在測試)\n"
 
 # frontends/command-line/main.c:479
-#: gphoto2/actions.c:578
+#: gphoto2/actions.c:565
 #, c-format
 msgid "\t\"%s\" (EXPERIMENTAL)\n"
 msgstr "\t\"%s\" (正在試用)\n"
 
 # frontends/command-line/main.c:483
-#: gphoto2/actions.c:583
+#: gphoto2/actions.c:570
 #, c-format
 msgid "\t\"%s\"\n"
 msgstr "\t\"%s\"\n"
 
 # frontends/command-line/main.c:548
-#: gphoto2/actions.c:627
+#: gphoto2/actions.c:614
 #, c-format
 msgid "Devices found: %i\n"
 msgstr "找到裝置: %i\n"
 
 # frontends/command-line/main.c:549
-#: gphoto2/actions.c:628
+#: gphoto2/actions.c:615
 #, c-format
 msgid ""
 "Path                             Description\n"
@@ -263,181 +263,193 @@ msgstr ""
 "--------------------------------------------------------------\n"
 
 # frontends/command-line/main.c:384 frontends/command-line/main.c:389
-#: gphoto2/actions.c:661 gphoto2/actions.c:666
+#: gphoto2/actions.c:648 gphoto2/actions.c:653
 #, c-format
 msgid "%-30s %-16s\n"
 msgstr "%-30s %-16s\n"
 
 # frontends/command-line/main.c:384
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Model"
 msgstr "型號"
 
 # frontends/command-line/main.c:384
-#: gphoto2/actions.c:661
+#: gphoto2/actions.c:648
 msgid "Port"
 msgstr "輸出入埠"
 
 # frontends/command-line/main.c:385
-#: gphoto2/actions.c:662
+#: gphoto2/actions.c:649
 #, c-format
 msgid "----------------------------------------------------------\n"
 msgstr "----------------------------------------------------------\n"
 
 # frontends/command-line/main.c:413
-#: gphoto2/actions.c:680
+#: gphoto2/actions.c:667
 #, c-format
 msgid "Abilities for camera             : %s\n"
 msgstr "相機功能             : %s\n"
 
 # frontends/command-line/main.c:415
-#: gphoto2/actions.c:681
+#: gphoto2/actions.c:668
 #, c-format
 msgid "Serial port support              : %s\n"
 msgstr "輸出入埠支援             : %s\n"
 
 # frontends/command-line/main.c:417
-#: gphoto2/actions.c:683
+#: gphoto2/actions.c:670
 #, c-format
 msgid "USB support                      : %s\n"
 msgstr "USB 支援             : %s\n"
 
 # frontends/command-line/main.c:420
-#: gphoto2/actions.c:686
+#: gphoto2/actions.c:673
 #, c-format
 msgid "Transfer speeds supported        :\n"
 msgstr "支援的傳輸速度       : \n"
 
 # frontends/command-line/main.c:423
-#: gphoto2/actions.c:688
+#: gphoto2/actions.c:675
 #, c-format
 msgid "                                 : %i\n"
 msgstr "                     : %i\n"
 
 # frontends/command-line/main.c:427
-#: gphoto2/actions.c:691
+#: gphoto2/actions.c:678
 #, c-format
 msgid "Capture choices                  :\n"
 msgstr "擷取選項             : \n"
 
 # frontends/command-line/main.c:429
-#: gphoto2/actions.c:693
+#: gphoto2/actions.c:680
 #, c-format
 msgid "                                 : Image\n"
 msgstr "                     : 圖像\n"
 
 # frontends/command-line/main.c:431
-#: gphoto2/actions.c:697
+#: gphoto2/actions.c:684
 #, c-format
 msgid "                                 : Video\n"
 msgstr "                     : 視訊\n"
 
 # frontends/command-line/main.c:433
-#: gphoto2/actions.c:701
+#: gphoto2/actions.c:688
 #, c-format
 msgid "                                 : Audio\n"
 msgstr "                     : 音訊\n"
 
 # frontends/command-line/main.c:435
-#: gphoto2/actions.c:705
+#: gphoto2/actions.c:692
 #, c-format
 msgid "                                 : Preview\n"
 msgstr "                     : 預覽\n"
 
 # frontends/command-line/main.c:423
-#: gphoto2/actions.c:709
+#: gphoto2/actions.c:696
 #, c-format
 msgid "                                 : Trigger Capture\n"
 msgstr "                     : 觸發擷取\n"
 
 # frontends/command-line/main.c:435
-#: gphoto2/actions.c:713
+#: gphoto2/actions.c:700
 #, c-format
-msgid "                                 : Capture not supported by the driver\n"
+msgid ""
+"                                 : Capture not supported by the driver\n"
 msgstr "                     : 驅動程式不支援擷取\n"
 
 # frontends/command-line/main.c:436
-#: gphoto2/actions.c:715
+#: gphoto2/actions.c:702
 #, c-format
 msgid "Configuration support            : %s\n"
 msgstr "支援配置             : %s\n"
 
 # frontends/command-line/main.c:438
-#: gphoto2/actions.c:717
+#: gphoto2/actions.c:704
 #, c-format
 msgid "Delete selected files on camera  : %s\n"
 msgstr "刪除相機內所選檔案   : %s\n"
 
 # frontends/command-line/main.c:438
-#: gphoto2/actions.c:720
+#: gphoto2/actions.c:707
 #, c-format
 msgid "Delete all files on camera       : %s\n"
 msgstr "刪除相機內所有檔案   : %s\n"
 
 # frontends/command-line/main.c:440
-#: gphoto2/actions.c:723
+#: gphoto2/actions.c:710
 #, c-format
 msgid "File preview (thumbnail) support : %s\n"
 msgstr "支援檔案預覽 (縮圖): %s\n"
 
 # frontends/command-line/main.c:442
-#: gphoto2/actions.c:726
+#: gphoto2/actions.c:713
 #, c-format
 msgid "File upload support              : %s\n"
 msgstr "檔案上載支援         : %s\n"
 
 # frontends/command-line/main.c:586
-#: gphoto2/actions.c:743
+#: gphoto2/actions.c:730
 #, c-format
-msgid "Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a colon so I am going to guess what you mean."
-msgstr "輸出入埠必須是類似「serial:/dev/ttyS0」或「usb:」的形式，但「%s」缺少冒號，所以我將猜測您的意思。"
+msgid ""
+"Ports must look like 'serial:/dev/ttyS0' or 'usb:', but '%s' is missing a "
+"colon so I am going to guess what you mean."
+msgstr ""
+"輸出入埠必須是類似「serial:/dev/ttyS0」或「usb:」的形式，但「%s」缺少冒號，所"
+"以我將猜測您的意思。"
 
 # frontends/command-line/main.c:1318
-#: gphoto2/actions.c:777
+#: gphoto2/actions.c:764
 #, c-format
-msgid "The port you specified ('%s') can not be found. Please specify one of the ports found by 'gphoto2 --list-ports' and make sure the spelling is correct (i.e. with prefix 'serial:' or 'usb:')."
-msgstr "無法找到您指定的輸出入埠 (「%s」)。請指定一個由「gphoto2 --list-ports」列出的輸出入埠並確信拼寫正確 (例如，帶有前置文字「serial:」或「usb:」)。"
+msgid ""
+"The port you specified ('%s') can not be found. Please specify one of the "
+"ports found by 'gphoto2 --list-ports' and make sure the spelling is correct "
+"(i.e. with prefix 'serial:' or 'usb:')."
+msgstr ""
+"無法找到您指定的輸出入埠 (「%s」)。請指定一個由「gphoto2 --list-ports」列出的"
+"輸出入埠並確信拼寫正確 (例如，帶有前置文字「serial:」或「usb:」)。"
 
 # frontends/command-line/main.c:243
-#: gphoto2/actions.c:810
+#: gphoto2/actions.c:797
 #, c-format
 msgid "About the camera driver:"
 msgstr "關於相機驅動程序:"
 
 # frontends/command-line/main.c:1180
-#: gphoto2/actions.c:823
+#: gphoto2/actions.c:810
 #, c-format
 msgid "Camera summary:"
 msgstr "相機概要:"
 
 # frontends/command-line/main.c:1192
-#: gphoto2/actions.c:836
+#: gphoto2/actions.c:823
 #, c-format
 msgid "Camera manual:"
 msgstr "相機手冊:"
 
-#: gphoto2/actions.c:853
+#: gphoto2/actions.c:840
 #, c-format
 msgid "You can only specify speeds for serial ports."
 msgstr "您只能為輸出入埠指定速度。"
 
 # frontends/command-line/options.c:197
-#: gphoto2/actions.c:903
+#: gphoto2/actions.c:890
 msgid "OS/2 port by Bart van Leeuwen\n"
 msgstr "由 Bart van Leeuwen 移植到 OS/2\n"
 
-#: gphoto2/actions.c:907
-#, c-format
+#: gphoto2/actions.c:894
+#, fuzzy, c-format
 msgid ""
 "gphoto2 %s\n"
 "\n"
-"Copyright (c) 2000-%d Lutz Mueller and others\n"
+"Copyright (c) 2000-%d Marcus Meissner and others\n"
 "%s\n"
 "gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may\n"
 "redistribute copies of gphoto2 under the terms of the GNU General Public\n"
-"License. For more information about these matters, see the files named COPYING.\n"
+"License. For more information about these matters, see the files named "
+"COPYING.\n"
 "\n"
-"This version of gphoto2 is using the following software versions and options:\n"
+"This version of gphoto2 is using the following software versions and "
+"options:\n"
 msgstr ""
 "gphoto2 %s\n"
 "\n"
@@ -450,260 +462,274 @@ msgstr ""
 "這個版本的 gphoto2 使用了下列軟體版本和選項：\n"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/actions.c:1020
+#: gphoto2/actions.c:1015
 msgid "Could not open 'movie.mjpg'."
 msgstr "無法開啟 movie.mjpg 。"
 
-#: gphoto2/actions.c:1027
+#: gphoto2/actions.c:1022
 #, c-format
 msgid "Capturing preview frames as movie to '%s'. Press Ctrl-C to abort.\n"
 msgstr "擷取預覽影格為 %s 電影。按下 Ctrl-C 以放棄。\n"
 
-#: gphoto2/actions.c:1031
+#: gphoto2/actions.c:1026
 #, c-format
 msgid "Capturing preview frames as movie to '%s' for %d seconds.\n"
 msgstr "擷取預覽影格 %2$d 秒為 %1$s 電影。\n"
 
-#: gphoto2/actions.c:1036
+#: gphoto2/actions.c:1031
 #, c-format
 msgid "Capturing %d preview frames as movie to '%s'.\n"
 msgstr "擷取 %d 預覽影格為 %s 電影。\n"
 
-#: gphoto2/actions.c:1046
+#: gphoto2/actions.c:1047
 msgid "Movie capture error... Exiting."
 msgstr "電影擷取錯誤…離開中。"
 
-#: gphoto2/actions.c:1051
+#: gphoto2/actions.c:1053
 #, c-format
 msgid "Movie capture error... Unhandled MIME type '%s'."
 msgstr "電影擷取錯誤…無法處理的 MIME 型態 %s。"
 
-#: gphoto2/actions.c:1058
+#: gphoto2/actions.c:1060
 #, c-format
 msgid "Ctrl-C pressed ... Exiting.\n"
 msgstr "Ctrl-C 已按下…離開中。\n"
 
-#: gphoto2/actions.c:1072
+#: gphoto2/actions.c:1074
 #, c-format
 msgid "Movie capture finished (%d frames)\n"
 msgstr "電影擷取完成 (%d 影格)\n"
 
-#: gphoto2/actions.c:1102
+#: gphoto2/actions.c:1106
 #, c-format
 msgid "Waiting for events from camera. Press Ctrl-C to abort.\n"
 msgstr "等待來自相機的事件。按下 Ctrl-C 以放棄。\n"
 
-#: gphoto2/actions.c:1108
+#: gphoto2/actions.c:1112
 #, c-format
 msgid "Waiting for %d frames from the camera. Press Ctrl-C to abort.\n"
 msgstr "等待來自相機的 %d 影格。按下 Ctrl-C 以放棄。\n"
 
-#: gphoto2/actions.c:1113
+#: gphoto2/actions.c:1117
 #, c-format
-msgid "Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
+msgid ""
+"Waiting for %d milliseconds for events from camera. Press Ctrl-C to abort.\n"
 msgstr "等待來自相機的 %d 毫秒事件。按下 Ctrl-C 以放棄。\n"
 
-#: gphoto2/actions.c:1118
+#: gphoto2/actions.c:1122
 #, c-format
 msgid "Waiting for %d seconds for events from camera. Press Ctrl-C to abort.\n"
 msgstr "等待來自相機的 %d 秒事件。按下 Ctrl-C 以放棄。\n"
 
-#: gphoto2/actions.c:1121
+#: gphoto2/actions.c:1125
 #, c-format
 msgid "Waiting for %d events from camera. Press Ctrl-C to abort.\n"
 msgstr "等待來自相機的 %d 事件。按下 Ctrl-C 以放棄。\n"
 
-#: gphoto2/actions.c:1125
-#, c-format
-msgid "Waiting for %s event from camera. Press Ctrl-C to abort.\n"
+#: gphoto2/actions.c:1129
+#, fuzzy, c-format
+msgid "Waiting for '%s' event from camera. Press Ctrl-C to abort.\n"
 msgstr "等待來自相機的 %s 事件。按下 Ctrl-C 以放棄。\n"
 
-#: gphoto2/actions.c:1169 gphoto2/actions.c:1183 gphoto2/actions.c:1199
-#: gphoto2/actions.c:1237 gphoto2/actions.c:1245
+#: gphoto2/actions.c:1144
+#, c-format
+msgid "SIGUSR1 signal received, triggering capture!\n"
+msgstr ""
+
+#: gphoto2/actions.c:1155
+#, fuzzy, c-format
+msgid "SIGUSR2 signal received, stopping wait!\n"
+msgstr "已找到事件，停止等待！\n"
+
+#: gphoto2/actions.c:1193 gphoto2/actions.c:1204 gphoto2/actions.c:1211
+#: gphoto2/actions.c:1227 gphoto2/actions.c:1265 gphoto2/actions.c:1273
+#: gphoto2/actions.c:1281
 #, c-format
 msgid "event found, stopping wait!\n"
 msgstr "已找到事件，停止等待！\n"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/actions.c:1209 gphoto2/main.c:834
+#: gphoto2/actions.c:1237 gphoto2/main.c:839
 msgid "Could not set folder."
 msgstr "無法設定資料夾。"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/actions.c:1215 gphoto2/main.c:849
+#: gphoto2/actions.c:1243 gphoto2/main.c:854
 msgid "Could not get image."
 msgstr "無法取得圖像。"
 
-#: gphoto2/actions.c:1222 gphoto2/main.c:856
+#: gphoto2/actions.c:1250 gphoto2/main.c:861
 msgid "Buggy libcanon.so?"
 msgstr "有錯誤的 libcanon.so？"
 
-#: gphoto2/actions.c:1232 gphoto2/main.c:868
+#: gphoto2/actions.c:1260 gphoto2/main.c:873
 msgid "Could not delete image."
 msgstr "無法刪除圖像。"
 
-#: gphoto2/actions.c:1264
+#: gphoto2/actions.c:1300
 #, c-format
 msgid "Getting storage information not supported for this camera.\n"
 msgstr "不支援提取這個相機的貯藏體資訊。\n"
 
-#: gphoto2/actions.c:1279
+#: gphoto2/actions.c:1315
 #, c-format
 msgid "Read-Write"
 msgstr "可讀可寫"
 
-#: gphoto2/actions.c:1282
+#: gphoto2/actions.c:1318
 #, c-format
 msgid "Read-Only"
 msgstr "唯讀"
 
-#: gphoto2/actions.c:1285
+#: gphoto2/actions.c:1321
 #, c-format
 msgid "Read-only with delete"
 msgstr "唯讀與刪除"
 
-#: gphoto2/actions.c:1288 gphoto2/actions.c:1298
+#: gphoto2/actions.c:1324 gphoto2/actions.c:1334
 #, c-format
 msgid "Unknown"
 msgstr "不明"
 
-#: gphoto2/actions.c:1301
+#: gphoto2/actions.c:1337
 #, c-format
 msgid "Fixed ROM"
 msgstr "固定的唯讀記憶體"
 
-#: gphoto2/actions.c:1304
+#: gphoto2/actions.c:1340
 #, c-format
 msgid "Removable ROM"
 msgstr "可移除的唯讀記憶體"
 
-#: gphoto2/actions.c:1307
+#: gphoto2/actions.c:1343
 #, c-format
 msgid "Fixed RAM"
 msgstr "固定的記憶體"
 
-#: gphoto2/actions.c:1310
+#: gphoto2/actions.c:1346
 #, c-format
 msgid "Removable RAM"
 msgstr "可移除的記憶體"
 
-#: gphoto2/actions.c:1320
+#: gphoto2/actions.c:1356
 #, c-format
 msgid "Undefined"
 msgstr "未定義"
 
-#: gphoto2/actions.c:1323
+#: gphoto2/actions.c:1359
 #, c-format
 msgid "Generic Flat"
 msgstr "通用扁平式"
 
-#: gphoto2/actions.c:1326
+#: gphoto2/actions.c:1362
 #, c-format
 msgid "Generic Hierarchical"
 msgstr "通用階層式"
 
-#: gphoto2/actions.c:1329
+#: gphoto2/actions.c:1365
 #, c-format
 msgid "Camera layout (DCIM)"
 msgstr "相機版面配置 (DCIM)"
 
-#: gphoto2/actions.c:1367
+#: gphoto2/actions.c:1406
 #, c-format
 msgid "Overriding USB vendor/product id 0x%x/0x%x with 0x%x/0x%x"
 msgstr "將 USB 供應商/產品 id 0x%x/0x%x 以 0x%x/0x%x 覆寫"
 
-#: gphoto2/actions.c:1435
-msgid "ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE MAILING LIST:"
+#: gphoto2/actions.c:1474
+msgid ""
+"ALWAYS INCLUDE THE FOLLOWING LINES WHEN SENDING DEBUG MESSAGES TO THE "
+"MAILING LIST:"
 msgstr "在將除錯資訊發送到郵遞論壇的時候總是包含下述各列:"
 
-#: gphoto2/actions.c:1450
+#: gphoto2/actions.c:1489
 #, c-format
 msgid "%s has been compiled with the following options:"
 msgstr "已經利用下列選項編譯 %s:"
 
-#: gphoto2/actions.c:1581
+#: gphoto2/actions.c:1629
 #, c-format
 msgid "%s not found in configuration tree."
 msgstr "在樹狀設定圖中無法找到 %s。"
 
-#: gphoto2/actions.c:1630
+#: gphoto2/actions.c:1681
 #, c-format
 msgid "Failed to retrieve value of text widget %s."
 msgstr "從文字視窗元件 %s 中取值時失敗。"
 
-#: gphoto2/actions.c:1647
+#: gphoto2/actions.c:1698
 #, c-format
 msgid "Failed to retrieve values of range widget %s."
 msgstr "從範圍視窗元件 %s 中取值時失敗。"
 
-#: gphoto2/actions.c:1659
+#: gphoto2/actions.c:1710
 #, c-format
 msgid "Failed to retrieve values of toggle widget %s."
 msgstr "從切換視窗元件 %s 中取值時失敗。"
 
-#: gphoto2/actions.c:1671
+#: gphoto2/actions.c:1722
 #, c-format
 msgid "Failed to retrieve values of date/time widget %s."
 msgstr "從日期/時間視窗元件 %s 中取值時失敗。"
 
-#: gphoto2/actions.c:1680
+#: gphoto2/actions.c:1731
 msgid "Use 'now' as the current time when setting.\n"
 msgstr "使用 now 於設定時做為目前時間。\n"
 
-#: gphoto2/actions.c:1702
+#: gphoto2/actions.c:1753
 #, c-format
 msgid "Failed to retrieve values of radio widget %s."
 msgstr "從單選視窗元件 %s 中取值時失敗。"
 
-#: gphoto2/actions.c:1746
+#: gphoto2/actions.c:1799
 #, c-format
 msgid "Property %s is read only."
 msgstr "內容 %s 唯讀。"
 
-#: gphoto2/actions.c:1760 gphoto2/actions.c:1997
+#: gphoto2/actions.c:1813 gphoto2/actions.c:2056
 #, c-format
 msgid "Failed to set the value of text widget %s to %s."
 msgstr "將文字視窗元件 %s 值設為 %s 時失敗。"
 
-#: gphoto2/actions.c:1770 gphoto2/actions.c:2007
+#: gphoto2/actions.c:1823 gphoto2/actions.c:2066
 #, c-format
 msgid "The passed value %s is not a floating point value."
 msgstr "所傳遞的值 %s 並非一個浮點值。"
 
-#: gphoto2/actions.c:1775 gphoto2/actions.c:2012
+#: gphoto2/actions.c:1828 gphoto2/actions.c:2071
 #, c-format
 msgid "The passed value %f is not within the expected range %f - %f."
 msgstr "所傳遞的值 %f 並非位於預期的範圍 %f - %f 之中。"
 
-#: gphoto2/actions.c:1781 gphoto2/actions.c:2018
+#: gphoto2/actions.c:1834 gphoto2/actions.c:2077
 #, c-format
 msgid "Failed to set the value of range widget %s to %f."
 msgstr "將範圍視窗元件 %s 值設為 %f 時失敗。"
 
-#: gphoto2/actions.c:1790 gphoto2/actions.c:2027
+#: gphoto2/actions.c:1843 gphoto2/actions.c:2086
 msgid "off"
 msgstr "關"
 
 # frontends/command-line/actions.c:331
-#: gphoto2/actions.c:1791 gphoto2/actions.c:2028
+#: gphoto2/actions.c:1844 gphoto2/actions.c:2087
 msgid "false"
 msgstr "假"
 
 # camlibs/polaroid/pdc700.c:169 camlibs/polaroid/pdc700.c:170
-#: gphoto2/actions.c:1796 gphoto2/actions.c:2033
+#: gphoto2/actions.c:1849 gphoto2/actions.c:2092
 msgid "on"
 msgstr "開"
 
-#: gphoto2/actions.c:1797 gphoto2/actions.c:2034
+#: gphoto2/actions.c:1850 gphoto2/actions.c:2093
 msgid "true"
 msgstr "真"
 
-#: gphoto2/actions.c:1802 gphoto2/actions.c:2039
+#: gphoto2/actions.c:1855 gphoto2/actions.c:2098
 #, c-format
 msgid "The passed value %s is not a valid toggle value."
 msgstr "所傳遞的值 %s 並非一個有效的切換值。"
 
-#: gphoto2/actions.c:1808 gphoto2/actions.c:2045
+#: gphoto2/actions.c:1861 gphoto2/actions.c:2104
 #, c-format
 msgid "Failed to set values %s of toggle widget %s."
 msgstr "將切換視窗元件 %s 值設為 %s 時失敗。"
@@ -713,45 +739,52 @@ msgstr "將切換視窗元件 %s 值設為 %s 時失敗。"
 # frontends/command-line/main.c:418 frontends/command-line/main.c:437
 # frontends/command-line/main.c:439 frontends/command-line/main.c:441
 # frontends/command-line/main.c:443
-#: gphoto2/actions.c:1820
+#: gphoto2/actions.c:1873 gphoto2/actions.c:2111
 msgid "now"
 msgstr "現在"
 
-#: gphoto2/actions.c:1832 gphoto2/actions.c:2058
+#: gphoto2/actions.c:1885 gphoto2/actions.c:2119
 #, c-format
 msgid "The passed value %s is neither a valid time nor an integer."
 msgstr "所傳遞的值 %s 並非一個有效的時間，亦非一個整數。"
 
-#: gphoto2/actions.c:1840 gphoto2/actions.c:2065
+#: gphoto2/actions.c:1893 gphoto2/actions.c:2126
 #, c-format
 msgid "Failed to set new time of date/time widget %s to %s."
 msgstr "將日期/時間視窗元件 %s 值設為 %s 時失敗。"
 
-#: gphoto2/actions.c:1887 gphoto2/actions.c:1951 gphoto2/actions.c:2095
+#: gphoto2/actions.c:1940 gphoto2/actions.c:2007 gphoto2/actions.c:2156
 #, c-format
 msgid "Choice %s not found within list of choices."
 msgstr "在選擇清單之內找不到選項 %s。"
 
-#: gphoto2/actions.c:1895 gphoto2/actions.c:2103
+#: gphoto2/actions.c:1948 gphoto2/actions.c:2164
 #, c-format
 msgid "The %s widget is not configurable."
 msgstr "視窗元件 %s 不可設定。"
 
-#: gphoto2/actions.c:1902 gphoto2/actions.c:1970 gphoto2/actions.c:2110
+#: gphoto2/actions.c:1958 gphoto2/actions.c:2029 gphoto2/actions.c:2174
 #, c-format
 msgid "Failed to set new configuration value %s for configuration entry %s."
 msgstr "將單選視窗元件 %s 值設為 %s 時失敗。"
 
-#: gphoto2/actions.c:1963
+#: gphoto2/actions.c:2019
 #, c-format
-msgid "The %s widget has no indexed list of choices. Use --set-config-value instead."
-msgstr "%s 視窗元件沒有任何索引過的選擇清單。使用 --set-config-value 做為替代。"
+msgid ""
+"The %s widget has no indexed list of choices. Use --set-config-value instead."
+msgstr ""
+"%s 視窗元件沒有任何索引過的選擇清單。使用 --set-config-value 做為替代。"
 
 # frontends/command-line/foreach.c:207
 #: gphoto2/foreach.c:260
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s' or its subfolders. Please obtain a valid file number from a file listing first."
-msgstr "錯誤的檔案編號。您指定 %1$i，但在「%3$s」和它的子目錄中只有 %2$i 個檔案。請首先從檔案列表中獲取一個合法的檔案編號。"
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s' or its subfolders. Please obtain a valid file number from a file "
+"listing first."
+msgstr ""
+"錯誤的檔案編號。您指定 %1$i，但在「%3$s」和它的子目錄中只有 %2$i 個檔案。請首"
+"先從檔案列表中獲取一個合法的檔案編號。"
 
 # frontends/command-line/actions.c:111 frontends/command-line/foreach.c:228
 #: gphoto2/foreach.c:285
@@ -762,27 +795,33 @@ msgstr "資料夾「%s」中沒有檔案。"
 # frontends/command-line/foreach.c:233
 #: gphoto2/foreach.c:291
 #, c-format
-msgid "Bad file number. You specified %i, but there is only 1 file available in '%s'."
+msgid ""
+"Bad file number. You specified %i, but there is only 1 file available in "
+"'%s'."
 msgstr "錯誤的檔案編號。您指定 %i，但在「%s」中只有一個檔案。"
 
 # frontends/command-line/foreach.c:240
 #: gphoto2/foreach.c:299
 #, c-format
-msgid "Bad file number. You specified %i, but there are only %i files available in '%s'. Please obtain a valid file number from a file listing first."
-msgstr "錯誤的檔案編號。您指定 %1$i，但在「%3$s」中只有 %2$i 個檔案。請先從檔案列表中獲取一個合法的檔案編號。"
+msgid ""
+"Bad file number. You specified %i, but there are only %i files available in "
+"'%s'. Please obtain a valid file number from a file listing first."
+msgstr ""
+"錯誤的檔案編號。您指定 %1$i，但在「%3$s」中只有 %2$i 個檔案。請先從檔案列表中"
+"獲取一個合法的檔案編號。"
 
 # frontends/command-line/main.c:1753
-#: gphoto2/gp-params.c:66
+#: gphoto2/gp-params.c:70
 #, c-format
 msgid "*** Error ***              \n"
 msgstr "*** 錯誤 ***               \n"
 
-#: gphoto2/gp-params.c:241
+#: gphoto2/gp-params.c:243
 #, c-format
 msgid "Press any key to continue.\n"
 msgstr "按任何鍵以繼續。\n"
 
-#: gphoto2/gp-params.c:263
+#: gphoto2/gp-params.c:266
 #, c-format
 msgid "Not enough memory."
 msgstr "記憶體不足。"
@@ -794,37 +833,37 @@ msgid "Operation cancelled"
 msgstr "操作已取消"
 
 # frontends/command-line/gphoto2-cmd-config.c:65
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B/24>Continue"
 msgstr "</B/24>繼續"
 
 # frontends/command-line/gphoto2-cmd-config.c:65
-#: gphoto2/gphoto2-cmd-config.c:57
+#: gphoto2/gphoto2-cmd-config.c:63
 msgid "</B16>Cancel"
 msgstr "</B16>取消"
 
 # frontends/command-line/gphoto2-cmd-config.c:71
-#: gphoto2/gphoto2-cmd-config.c:63
+#: gphoto2/gphoto2-cmd-config.c:69
 msgid "<C></5>Error"
 msgstr "<C></5>錯誤"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/gphoto2-cmd-config.c:65
+#: gphoto2/gphoto2-cmd-config.c:71
 msgid "Could not set configuration:"
 msgstr "無法設定配置:"
 
 # frontends/command-line/gphoto2-cmd-config.c:117
-#: gphoto2/gphoto2-cmd-config.c:109
+#: gphoto2/gphoto2-cmd-config.c:115
 msgid "Exit"
 msgstr "離開"
 
 # frontends/command-line/gphoto2-cmd-config.c:119
-#: gphoto2/gphoto2-cmd-config.c:111
+#: gphoto2/gphoto2-cmd-config.c:117
 msgid "Back"
 msgstr "退回"
 
 # frontends/command-line/gphoto2-cmd-config.c:263
-#: gphoto2/gphoto2-cmd-config.c:256
+#: gphoto2/gphoto2-cmd-config.c:262
 msgid "Time: "
 msgstr "時間: "
 
@@ -832,202 +871,207 @@ msgstr "時間: "
 # frontends/command-line/gphoto2-cmd-config.c:350
 # frontends/command-line/gphoto2-cmd-config.c:410
 # frontends/command-line/gphoto2-cmd-config.c:473
-#: gphoto2/gphoto2-cmd-config.c:315 gphoto2/gphoto2-cmd-config.c:343
-#: gphoto2/gphoto2-cmd-config.c:402 gphoto2/gphoto2-cmd-config.c:465
+#: gphoto2/gphoto2-cmd-config.c:321 gphoto2/gphoto2-cmd-config.c:349
+#: gphoto2/gphoto2-cmd-config.c:409 gphoto2/gphoto2-cmd-config.c:472
 msgid "Value: "
 msgstr "值: "
 
 # camlibs/minolta/dimagev/dimagev.c:300 camlibs/minolta/dimagev/dimagev.c:302
 # camlibs/minolta/dimagev/dimagev.c:306 camlibs/minolta/dimagev/dimagev.c:309
 # frontends/command-line/gphoto2-cmd-config.c:372
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "Yes"
 msgstr "是"
 
 # camlibs/minolta/dimagev/dimagev.c:300 camlibs/minolta/dimagev/dimagev.c:302
 # camlibs/minolta/dimagev/dimagev.c:306 camlibs/minolta/dimagev/dimagev.c:309
 # frontends/command-line/gphoto2-cmd-config.c:372
-#: gphoto2/gphoto2-cmd-config.c:364
+#: gphoto2/gphoto2-cmd-config.c:371
 msgid "No"
 msgstr "否"
 
-#: gphoto2/main.c:224
+#: gphoto2/main.c:220
 #, c-format
 msgid "Zero padding numbers in file names is only possible with %%n."
 msgstr "檔案名稱中含有加零的數字只有與 %%n 時才可能。"
 
-#: gphoto2/main.c:233
+#: gphoto2/main.c:229
 #, c-format
 msgid "You cannot use %%n zero padding without a precision value!"
 msgstr "您不能使用 %%n 加零而不與永久值一起使用！"
 
-#: gphoto2/main.c:266
+#: gphoto2/main.c:262
 #, c-format
 msgid "The filename provided by the camera ('%s') does not contain a suffix!"
 msgstr "由相機 (「%s」) 提供的檔案名不含有後置文字！"
 
-#: gphoto2/main.c:335
+#: gphoto2/main.c:331
 #, c-format
 msgid "Invalid format '%s' (error at position %i)."
 msgstr "無效的格式「%s」(錯誤發生在 %i 位元組)。"
 
 # frontends/command-line/main.c:884
-#: gphoto2/main.c:390 gphoto2/main.c:595
+#: gphoto2/main.c:386 gphoto2/main.c:592
 #, c-format
 msgid "Skip existing file %s\n"
 msgstr "跳過已存在的檔案 %s\n"
 
 # frontends/command-line/main.c:859
-#: gphoto2/main.c:402
+#: gphoto2/main.c:398
 #, c-format
 msgid "File %s exists. Overwrite? [y|n] "
 msgstr "檔案 %s 存在。要覆蓋？[y|n] "
 
 # frontends/command-line/main.c:870
-#: gphoto2/main.c:414
+#: gphoto2/main.c:410
 #, c-format
 msgid "Specify new filename? [y|n] "
 msgstr "指定新檔案名？[y|n]"
 
 # frontends/command-line/main.c:879
-#: gphoto2/main.c:426
+#: gphoto2/main.c:422
 #, c-format
 msgid "Enter new filename: "
 msgstr "輸入新檔案名: "
 
 # frontends/command-line/main.c:884
-#: gphoto2/main.c:432
+#: gphoto2/main.c:428
 #, c-format
 msgid "Saving file as %s\n"
 msgstr "正在將檔案另存為 %s\n"
 
 # frontends/command-line/actions.c:159
-#: gphoto2/main.c:633
+#: gphoto2/main.c:630
 msgid "Permission denied"
 msgstr "權限被拒"
 
 # frontends/command-line/actions.c:322
-#: gphoto2/main.c:795
+#: gphoto2/main.c:800
 msgid "Could not trigger capture."
 msgstr "無法觸發擷取。"
 
 # frontends/command-line/main.c:1122
-#: gphoto2/main.c:825
+#: gphoto2/main.c:830
 #, c-format
 msgid "New file is in location %s%s%s on the camera\n"
 msgstr "新檔案在相機中 %s%s%s 處\n"
 
 # frontends/command-line/main.c:1122
-#: gphoto2/main.c:842 gphoto2/main.c:873
+#: gphoto2/main.c:847 gphoto2/main.c:878
 #, c-format
 msgid "Keeping file %s%s%s on the camera\n"
 msgstr "保持檔案 %s%s%s 於相機\n"
 
 # frontends/command-line/main.c:1122
-#: gphoto2/main.c:863
+#: gphoto2/main.c:868
 #, c-format
 msgid "Deleting file %s%s%s on the camera\n"
 msgstr "刪除相機中 %s%s%s 檔案\n"
 
-#: gphoto2/main.c:906
+#: gphoto2/main.c:911
 #, c-format
 msgid "Event FOLDER_ADDED %s/%s during wait, ignoring.\n"
 msgstr "事件 FOLDER_ADDED %s/%s 於等待期間，將它忽略。\n"
 
 #: gphoto2/main.c:916
+#, fuzzy, c-format
+msgid "Event FILE_CHANGED %s/%s during wait, ignoring.\n"
+msgstr "事件 FOLDER_ADDED %s/%s 於等待期間，將它忽略。\n"
+
+#: gphoto2/main.c:926
 #, c-format
 msgid "Event UNKNOWN %s during wait, ignoring.\n"
 msgstr "事件不明 %s 於等待期間，將它忽略。\n"
 
-#: gphoto2/main.c:922
+#: gphoto2/main.c:932
 #, c-format
 msgid "Unknown event type %d during bulb wait, ignoring.\n"
 msgstr "於燈泡等待期間發生不明事件類型 %d，將它忽略。\n"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:940
+#: gphoto2/main.c:950
 msgid "Could not get capabilities?"
 msgstr "無法獲得能力？"
 
-#: gphoto2/main.c:948
+#: gphoto2/main.c:958
 #, c-format
 msgid "Time-lapse mode enabled (interval: %ds).\n"
 msgstr "開啟曠時模式 (間隔: %d 秒)。\n"
 
-#: gphoto2/main.c:951
+#: gphoto2/main.c:961
 #, c-format
 msgid "Standing by waiting for SIGUSR1 to capture.\n"
 msgstr "待命以擷取 SIGUSR1。\n"
 
-#: gphoto2/main.c:957
+#: gphoto2/main.c:967
 #, c-format
 msgid "Bulb mode enabled (exposure time: %ds).\n"
 msgstr "燈泡模式已啟用 (曝光時間：%ds)。\n"
 
-#: gphoto2/main.c:970
+#: gphoto2/main.c:975
 #, c-format
 msgid "Capturing frame #%d...\n"
 msgstr "擷取影格 #%d 中…\n"
 
-#: gphoto2/main.c:972
+#: gphoto2/main.c:977
 #, c-format
 msgid "Capturing frame #%d/%d...\n"
 msgstr "擷取影格 #%d/%d 中…\n"
 
 # frontends/command-line/actions.c:322
-#: gphoto2/main.c:982
+#: gphoto2/main.c:987
 #, c-format
 msgid "Could not set bulb capture, result %d."
 msgstr "無法設定燈泡擷取，結果 %d。"
 
 # frontends/command-line/actions.c:322
-#: gphoto2/main.c:996
+#: gphoto2/main.c:1001
 msgid "Could not end capture (bulb mode)."
 msgstr "無法結束擷取 (燈泡模式)。"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:1009
+#: gphoto2/main.c:1014
 msgid "Could not trigger image capture."
 msgstr "無法觸發圖像擷取。"
 
 # frontends/command-line/actions.c:322
-#: gphoto2/main.c:1016
+#: gphoto2/main.c:1021
 msgid "Could not capture image."
 msgstr "無法擷取圖像。"
 
-#: gphoto2/main.c:1023
+#: gphoto2/main.c:1028
 #, c-format
 msgid "Capture failed (auto-focus problem?)...\n"
 msgstr "擷取失敗 (自動對焦的問題？)…\n"
 
 # frontends/command-line/actions.c:322
-#: gphoto2/main.c:1034
+#: gphoto2/main.c:1039
 msgid "Could not capture."
 msgstr "無法擷取。"
 
-#: gphoto2/main.c:1066
+#: gphoto2/main.c:1074
 #, c-format
 msgid "Waiting for next capture slot %ld seconds...\n"
 msgstr "等待下一個擷取插槽 %ld 秒…\n"
 
-#: gphoto2/main.c:1075 gphoto2/main.c:1116
+#: gphoto2/main.c:1083 gphoto2/main.c:1125
 #, c-format
 msgid "Awakened by SIGUSR1...\n"
 msgstr "被 SIGUSR1 所喚醒…\n"
 
-#: gphoto2/main.c:1088
+#: gphoto2/main.c:1096
 #, c-format
 msgid "not sleeping (%ld seconds behind schedule)\n"
 msgstr "無法暫停 (排程之後 %ld 秒)\n"
 
 # frontends/command-line/main.c:1614
-#: gphoto2/main.c:1231
+#: gphoto2/main.c:1240
 #, c-format
 msgid "ERROR: "
 msgstr "錯誤: "
 
 # frontends/command-line/main.c:1637
-#: gphoto2/main.c:1254
+#: gphoto2/main.c:1263
 #, c-format
 msgid ""
 "\n"
@@ -1037,13 +1081,13 @@ msgstr ""
 "正在中斷…\n"
 
 # frontends/command-line/main.c:1643
-#: gphoto2/main.c:1260
+#: gphoto2/main.c:1269
 #, c-format
 msgid "Aborted.\n"
 msgstr "已中斷。\n"
 
 # frontends/command-line/main.c:1648
-#: gphoto2/main.c:1265
+#: gphoto2/main.c:1274
 #, c-format
 msgid ""
 "\n"
@@ -1053,23 +1097,27 @@ msgstr ""
 "正在取消…\n"
 
 # frontends/command-line/main.c:637
-#: gphoto2/main.c:1416
+#: gphoto2/main.c:1426
 #, c-format
-msgid "Use the following syntax a:b=c:d to treat any USB device detected as a:b as c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
-msgstr "使用諸如 a:b=c:d 的形式將偵測為 a:b 的 USB 設備處理為 c:d。a b c d 應為以「0x」開始的十六進制數。\n"
+msgid ""
+"Use the following syntax a:b=c:d to treat any USB device detected as a:b as "
+"c:d instead. a b c d should be hexadecimal numbers beginning with '0x'.\n"
+msgstr ""
+"使用諸如 a:b=c:d 的形式將偵測為 a:b 的 USB 設備處理為 c:d。a b c d 應為以"
+"「0x」開始的十六進制數。\n"
 
 # frontends/command-line/actions.c:355
-#: gphoto2/main.c:1596
+#: gphoto2/main.c:1609
 msgid "gphoto2 has been compiled without support for CDK."
 msgstr "gphoto2 編譯時沒有包含對 CDK 的支援。"
 
 # frontends/command-line/main.c:1750
-#: gphoto2/main.c:1866
+#: gphoto2/main.c:1879
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "操作已取消。\n"
 
-#: gphoto2/main.c:1870
+#: gphoto2/main.c:1883
 #, c-format
 msgid ""
 "*** Error: No camera found. ***\n"
@@ -1079,7 +1127,7 @@ msgstr ""
 "\n"
 
 # frontends/command-line/main.c:1753
-#: gphoto2/main.c:1872
+#: gphoto2/main.c:1885
 #, c-format
 msgid ""
 "*** Error (%i: '%s') ***       \n"
@@ -1089,7 +1137,7 @@ msgstr ""
 "\n"
 
 # frontends/command-line/main.c:1759
-#: gphoto2/main.c:1877
+#: gphoto2/main.c:1890
 #, c-format
 msgid ""
 "For debugging messages, please use the --debug option.\n"
@@ -1106,7 +1154,7 @@ msgstr ""
 "請按以下方式執行 gphoto2:\n"
 "\n"
 
-#: gphoto2/main.c:1898
+#: gphoto2/main.c:1911
 #, c-format
 msgid ""
 "Please make sure there is sufficient quoting around the arguments.\n"
@@ -1115,451 +1163,456 @@ msgstr ""
 "請確定引數外圍有足夠的引號。\n"
 "\n"
 
-#: gphoto2/main.c:1965
+#: gphoto2/main.c:1978
 msgid "Print complete help message on program usage"
 msgstr "印出程式用法的完整說明訊息"
 
-#: gphoto2/main.c:1967
+#: gphoto2/main.c:1980
 msgid "Print short message on program usage"
 msgstr "列印程式用法的簡短訊息"
 
 # frontends/command-line/main.c:187
-#: gphoto2/main.c:1969
+#: gphoto2/main.c:1982
 msgid "Turn on debugging"
 msgstr "開始除錯"
 
-#: gphoto2/main.c:1971
+#: gphoto2/main.c:1984
 msgid "Set debug level [error|debug|data|all]"
 msgstr "設定除錯層級 [error|debug|data|all]"
 
-#: gphoto2/main.c:1973
+#: gphoto2/main.c:1986
 msgid "Name of file to write debug info to"
 msgstr "要寫入除錯資訊的檔案名稱"
 
-#: gphoto2/main.c:1973 gphoto2/main.c:1978 gphoto2/main.c:1984
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:1986 gphoto2/main.c:1991 gphoto2/main.c:1997
+#: gphoto2/main.c:2124
 msgid "FILENAME"
 msgstr "檔名"
 
 # frontends/command-line/main.c:189
-#: gphoto2/main.c:1975
+#: gphoto2/main.c:1988
 msgid "Quiet output (default=verbose)"
 msgstr "少量輸出 (預設為大量)"
 
-#: gphoto2/main.c:1977
+#: gphoto2/main.c:1990
 msgid "Hook script to call after downloads, captures, etc."
 msgstr "下載、擷取等等之後所呼叫的攔截指令稿"
 
 # frontends/command-line/main.c:203
-#: gphoto2/main.c:1984
+#: gphoto2/main.c:1997
 msgid "Specify device port"
 msgstr "指定裝置通訊埠"
 
 # frontends/command-line/main.c:204
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "Specify serial transfer speed"
 msgstr "指定串行傳輸速度"
 
-#: gphoto2/main.c:1986
+#: gphoto2/main.c:1999
 msgid "SPEED"
 msgstr "速度"
 
 # frontends/command-line/main.c:205
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "Specify camera model"
 msgstr "指定相機型號"
 
-#: gphoto2/main.c:1988
+#: gphoto2/main.c:2001
 msgid "MODEL"
 msgstr "式樣"
 
 # frontends/command-line/main.c:207
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "(expert only) Override USB IDs"
 msgstr "(僅適於專家) 覆寫 USB ID"
 
-#: gphoto2/main.c:1990
+#: gphoto2/main.c:2003
 msgid "USBIDs"
 msgstr "USBIDs"
 
 # frontends/command-line/main.c:193
-#: gphoto2/main.c:1996
+#: gphoto2/main.c:2009
 msgid "Display version and exit"
 msgstr "顯示版本號並離開"
 
 # frontends/command-line/main.c:195
-#: gphoto2/main.c:1998
+#: gphoto2/main.c:2011
 msgid "List supported camera models"
 msgstr "列舉支援的相機型號"
 
 # frontends/command-line/main.c:197
-#: gphoto2/main.c:2000
+#: gphoto2/main.c:2013
 msgid "List supported port devices"
 msgstr "列舉支援的輸出入埠設備"
 
 # frontends/command-line/main.c:210
-#: gphoto2/main.c:2002
+#: gphoto2/main.c:2015
 msgid "Display the camera/driver abilities in the libgphoto2 database"
 msgstr "顯示 libgphoto2 資料庫中的相機/驅動程式性能"
 
 # frontends/command-line/main.c:231
-#: gphoto2/main.c:2009
+#: gphoto2/main.c:2022
 msgid "Configure"
 msgstr "配置"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:2012
+#: gphoto2/main.c:2025
 msgid "List configuration tree"
 msgstr "列出樹狀配置圖"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:2014
+#: gphoto2/main.c:2027
 msgid "Dump full configuration tree"
 msgstr "傾印全部組態樹"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:2016
+#: gphoto2/main.c:2029
 msgid "Get configuration value"
 msgstr "取得設定值"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:2018
+#: gphoto2/main.c:2031
 msgid "Set configuration value or index in choices"
 msgstr "設定所選組態值或索引"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:2020
+#: gphoto2/main.c:2033
 msgid "Set configuration value index in choices"
 msgstr "設定所選組態值索引"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:2022
+#: gphoto2/main.c:2035
 msgid "Set configuration value"
 msgstr "設置組態值"
 
 # frontends/command-line/main.c:203
-#: gphoto2/main.c:2024
+#: gphoto2/main.c:2037
 msgid "Reset device port"
 msgstr "重置裝置通訊埠"
 
-#: gphoto2/main.c:2030
+#: gphoto2/main.c:2043
 msgid "Keep images on camera after capturing"
 msgstr "擷取之後將圖像保留於相機"
 
-#: gphoto2/main.c:2032
+#: gphoto2/main.c:2045
 msgid "Keep RAW images on camera after capturing"
 msgstr "擷取之後將 RAW 圖像保留於相機"
 
-#: gphoto2/main.c:2034
+#: gphoto2/main.c:2047
 msgid "Remove images from camera after capturing"
 msgstr "擷取之後從相機移除圖像"
 
-#: gphoto2/main.c:2036
+#: gphoto2/main.c:2049
 msgid "Wait for event(s) from camera"
 msgstr "等待來自相機的事件"
 
-#: gphoto2/main.c:2036 gphoto2/main.c:2038 gphoto2/main.c:2064
+#: gphoto2/main.c:2049 gphoto2/main.c:2051 gphoto2/main.c:2077
 msgid "COUNT, SECONDS, MILLISECONDS or MATCHSTRING"
 msgstr "數量、秒數、毫秒或匹配字串"
 
-#: gphoto2/main.c:2038
+#: gphoto2/main.c:2051
 msgid "Wait for event(s) from the camera and download new images"
 msgstr "等待來自相機的事件並下載新圖像"
 
 # frontends/command-line/main.c:233
-#: gphoto2/main.c:2041
+#: gphoto2/main.c:2054
 msgid "Capture a quick preview"
 msgstr "擷取一個快速預覽"
 
-#: gphoto2/main.c:2044
+#: gphoto2/main.c:2057
 msgid "Show a quick preview as Ascii Art"
 msgstr "以字元圖片方式顯示快速預覽"
 
-#: gphoto2/main.c:2046
+#: gphoto2/main.c:2059
 msgid "Set bulb exposure time in seconds"
 msgstr "設定燈泡曝光時間的秒數"
 
-#: gphoto2/main.c:2046 gphoto2/main.c:2050
+#: gphoto2/main.c:2059 gphoto2/main.c:2063
 msgid "SECONDS"
 msgstr "秒"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "Set number of frames to capture (default=infinite)"
 msgstr "設定要擷取的影格數目 (預設=無限)"
 
-#: gphoto2/main.c:2048
+#: gphoto2/main.c:2061
 msgid "COUNT"
 msgstr "計數"
 
-#: gphoto2/main.c:2050
+#: gphoto2/main.c:2063
 msgid "Set capture interval in seconds"
 msgstr "設定以秒為單位的擷取間隔"
 
-#: gphoto2/main.c:2052
+#: gphoto2/main.c:2065
 msgid "Reset capture interval on signal (default=no)"
 msgstr "信號時重置擷取間隔 (預設=no)"
 
 # frontends/command-line/main.c:234
-#: gphoto2/main.c:2054
+#: gphoto2/main.c:2067
 msgid "Capture an image"
 msgstr "擷取一幅圖像"
 
 # frontends/command-line/main.c:234
-#: gphoto2/main.c:2056
+#: gphoto2/main.c:2069
 msgid "Trigger capture of an image"
 msgstr "觸發圖像的擷取"
 
 # frontends/command-line/main.c:234
-#: gphoto2/main.c:2058
+#: gphoto2/main.c:2071
 msgid "Capture an image and download it"
 msgstr "擷取圖像並下載它"
 
 # frontends/command-line/main.c:235
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "Capture a movie"
 msgstr "拍攝一段電影"
 
-#: gphoto2/main.c:2060
+#: gphoto2/main.c:2073
 msgid "COUNT or SECONDS"
 msgstr "計數或秒"
 
 # frontends/command-line/main.c:236
-#: gphoto2/main.c:2062
+#: gphoto2/main.c:2075
 msgid "Capture an audio clip"
 msgstr "擷取一個音訊片段"
 
-#: gphoto2/main.c:2064
+#: gphoto2/main.c:2077
 msgid "Wait for shutter release on the camera and download"
 msgstr "等待相機所釋出的照片並下載"
 
-#: gphoto2/main.c:2066
-msgid "Trigger image capture"
-msgstr "觸發圖像擷取"
-
 # frontends/command-line/main.c:214
-#: gphoto2/main.c:2072
+#: gphoto2/main.c:2083
 msgid "List folders in folder"
 msgstr "列出資料夾中的資料夾"
 
 # frontends/command-line/main.c:215
-#: gphoto2/main.c:2074
+#: gphoto2/main.c:2085
 msgid "List files in folder"
 msgstr "列出資料夾中的檔案"
 
 # frontends/command-line/main.c:216
-#: gphoto2/main.c:2076
+#: gphoto2/main.c:2087
 msgid "Create a directory"
 msgstr "建立目錄"
 
-#: gphoto2/main.c:2076 gphoto2/main.c:2078
+#: gphoto2/main.c:2087 gphoto2/main.c:2089
 msgid "DIRNAME"
 msgstr "目錄名稱"
 
 # frontends/command-line/main.c:217
-#: gphoto2/main.c:2078
+#: gphoto2/main.c:2089
 msgid "Remove a directory"
 msgstr "刪除目錄"
 
 # frontends/command-line/main.c:218
-#: gphoto2/main.c:2080
+#: gphoto2/main.c:2091
 msgid "Display number of files"
 msgstr "顯示檔案的數量"
 
 # frontends/command-line/main.c:219
-#: gphoto2/main.c:2082
+#: gphoto2/main.c:2093
 msgid "Get files given in range"
 msgstr "獲取給定範圍的檔案"
 
-#: gphoto2/main.c:2082 gphoto2/main.c:2086 gphoto2/main.c:2091
-#: gphoto2/main.c:2098 gphoto2/main.c:2104 gphoto2/main.c:2109
+#: gphoto2/main.c:2093 gphoto2/main.c:2097 gphoto2/main.c:2102
+#: gphoto2/main.c:2109 gphoto2/main.c:2115 gphoto2/main.c:2120
 msgid "RANGE"
 msgstr "範圍"
 
 # frontends/command-line/main.c:220
-#: gphoto2/main.c:2084
+#: gphoto2/main.c:2095
 msgid "Get all files from folder"
 msgstr "從資料夾中獲取所有檔案"
 
 # frontends/command-line/main.c:221
-#: gphoto2/main.c:2086
+#: gphoto2/main.c:2097
 msgid "Get thumbnails given in range"
 msgstr "獲取給定範圍的縮圖"
 
 # frontends/command-line/main.c:222
-#: gphoto2/main.c:2089
+#: gphoto2/main.c:2100
 msgid "Get all thumbnails from folder"
 msgstr "從資料夾中獲取所有縮圖"
 
 # frontends/command-line/main.c:223
-#: gphoto2/main.c:2091
+#: gphoto2/main.c:2102
 msgid "Get metadata given in range"
 msgstr "獲取給定範圍的後設資料"
 
 # frontends/command-line/main.c:224
-#: gphoto2/main.c:2093
+#: gphoto2/main.c:2104
 msgid "Get all metadata from folder"
 msgstr "從資料夾中獲取所有後設資料"
 
-#: gphoto2/main.c:2095
+#: gphoto2/main.c:2106
 msgid "Upload metadata for file"
 msgstr "將檔案的後設資料上傳"
 
 # frontends/command-line/main.c:223
-#: gphoto2/main.c:2098
+#: gphoto2/main.c:2109
 msgid "Get raw data given in range"
 msgstr "獲取給定範圍的原始資料"
 
 # frontends/command-line/main.c:224
-#: gphoto2/main.c:2101
+#: gphoto2/main.c:2112
 msgid "Get all raw data from folder"
 msgstr "從資料夾中獲取所有原始資料"
 
 # frontends/command-line/main.c:225
-#: gphoto2/main.c:2104
+#: gphoto2/main.c:2115
 msgid "Get audio data given in range"
 msgstr "獲取給定範圍的音訊資料"
 
 # frontends/command-line/main.c:226
-#: gphoto2/main.c:2107
+#: gphoto2/main.c:2118
 msgid "Get all audio data from folder"
 msgstr "從資料夾中獲取所有音訊資料"
 
 # frontends/command-line/main.c:227
-#: gphoto2/main.c:2109
+#: gphoto2/main.c:2120
 msgid "Delete files given in range"
 msgstr "刪除給定範圍中的檔案"
 
 # frontends/command-line/main.c:228
-#: gphoto2/main.c:2111
+#: gphoto2/main.c:2122
 msgid "Delete all files in folder (--no-recurse by default)"
 msgstr "刪除資料夾中所有檔案 (預設 --no-recurse)"
 
 # frontends/command-line/main.c:229
-#: gphoto2/main.c:2113
+#: gphoto2/main.c:2124
 msgid "Upload a file to camera"
 msgstr "將一個檔案上載到相機"
 
 # frontends/command-line/main.c:206
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "Specify a filename or filename pattern"
 msgstr "指定檔名或檔名胚騰"
 
-#: gphoto2/main.c:2115
+#: gphoto2/main.c:2126
 msgid "FILENAME_PATTERN"
 msgstr "檔名胚騰"
 
+#: gphoto2/main.c:2128
+#, c-format
+msgid "Specify the number a filename %%n will starts with (default 1)"
+msgstr ""
+
+#: gphoto2/main.c:2128
+msgid "NUMBER"
+msgstr ""
+
 # frontends/command-line/main.c:211
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "Specify camera folder (default=\"/\")"
 msgstr "指定相機資料夾 (預設為「/」)"
 
-#: gphoto2/main.c:2117
+#: gphoto2/main.c:2130
 msgid "FOLDER"
 msgstr "資料夾"
 
 # frontends/command-line/main.c:212
-#: gphoto2/main.c:2119
+#: gphoto2/main.c:2132
 msgid "Recursion (default for download)"
 msgstr "遞迴 (下載時預設)"
 
 # frontends/command-line/main.c:213
-#: gphoto2/main.c:2121
+#: gphoto2/main.c:2134
 msgid "No recursion (default for deletion)"
 msgstr "不遞迴 (刪除時預設)"
 
-#: gphoto2/main.c:2123
+#: gphoto2/main.c:2136
 msgid "Process new files only"
 msgstr "只處理新的檔案"
 
-#: gphoto2/main.c:2125
+#: gphoto2/main.c:2138
 msgid "Overwrite files without asking"
 msgstr "在不詢問的情況下覆寫檔案"
 
-#: gphoto2/main.c:2127
+#: gphoto2/main.c:2140
 msgid "Skip existing files"
 msgstr "跳過已存在的檔案"
 
 # frontends/command-line/main.c:198
-#: gphoto2/main.c:2133
+#: gphoto2/main.c:2146
 msgid "Send file to stdout"
 msgstr "將檔案發送到標準輸出"
 
 # frontends/command-line/main.c:199
-#: gphoto2/main.c:2135
+#: gphoto2/main.c:2148
 msgid "Print filesize before data"
 msgstr "在資料前面列印檔案大小"
 
 # frontends/command-line/main.c:200
-#: gphoto2/main.c:2137
+#: gphoto2/main.c:2150
 msgid "List auto-detected cameras"
 msgstr "列舉可以自動檢測的相機"
 
 # frontends/command-line/main.c:238 frontends/command-line/shell.c:127
-#: gphoto2/main.c:2141 gphoto2/shell.c:138
+#: gphoto2/main.c:2154 gphoto2/shell.c:143
 msgid "Show EXIF information of JPEG images"
 msgstr "顯示 JPEG 圖像的 EXIF 資訊"
 
-#: gphoto2/main.c:2144 gphoto2/shell.c:132
+#: gphoto2/main.c:2157 gphoto2/shell.c:137
 msgid "Show image information, like width, height, and capture time"
 msgstr "顯示圖像資訊，像是寬度、高度和拍攝時間"
 
-#: gphoto2/main.c:2146
+#: gphoto2/main.c:2159 gphoto2/shell.c:150
 msgid "Show camera summary"
 msgstr "顯示相機概要"
 
 # frontends/command-line/main.c:242
-#: gphoto2/main.c:2148
+#: gphoto2/main.c:2161
 msgid "Show camera driver manual"
 msgstr "顯示相機驅動程序手冊"
 
 # frontends/command-line/main.c:243
-#: gphoto2/main.c:2150
+#: gphoto2/main.c:2163
 msgid "About the camera driver manual"
 msgstr "關於相機驅動程序手冊"
 
 # frontends/command-line/main.c:238 frontends/command-line/shell.c:127
-#: gphoto2/main.c:2152
+#: gphoto2/main.c:2165 gphoto2/shell.c:151
 msgid "Show storage information"
 msgstr "顯示貯藏體資訊"
 
 # frontends/command-line/main.c:244
-#: gphoto2/main.c:2154
+#: gphoto2/main.c:2167
 msgid "gPhoto shell"
 msgstr "gPhoto shell"
 
-#: gphoto2/main.c:2160
+#: gphoto2/main.c:2173
 msgid "Common options"
 msgstr "共同選項"
 
-#: gphoto2/main.c:2162
+#: gphoto2/main.c:2175
 msgid "Miscellaneous options (unsorted)"
 msgstr "雜項選項 (未分類)"
 
-#: gphoto2/main.c:2164
+#: gphoto2/main.c:2177
 msgid "Get information on software and host system (not from the camera)"
 msgstr "提取關於軟體和主機系統的資訊 (並非從相機)"
 
 # frontends/command-line/main.c:205
-#: gphoto2/main.c:2166
+#: gphoto2/main.c:2179
 msgid "Specify the camera to use"
 msgstr "指定要使用的相機"
 
 # frontends/command-line/gphoto2-cmd-config.c:73
-#: gphoto2/main.c:2168
+#: gphoto2/main.c:2181
 msgid "Camera and software configuration"
 msgstr "相機和軟體組態"
 
 # frontends/command-line/shell.c:112
-#: gphoto2/main.c:2170
+#: gphoto2/main.c:2183
 msgid "Capture an image from or on the camera"
 msgstr "擷取來自相機或在相機之上的圖像"
 
-#: gphoto2/main.c:2172
+#: gphoto2/main.c:2185
 msgid "Downloading, uploading and manipulating files"
 msgstr "下載、上傳和操控檔案"
 
 # frontends/command-line/range.c:122 frontends/command-line/range.c:176
-#: gphoto2/range.c:104 gphoto2/range.c:158
+#: gphoto2/range.c:106 gphoto2/range.c:160
 #, c-format
 msgid ""
 "%s\n"
@@ -1569,7 +1622,7 @@ msgstr ""
 "圖像 IDs 必須是一個大於零的數。"
 
 # frontends/command-line/range.c:128 frontends/command-line/range.c:182
-#: gphoto2/range.c:110 gphoto2/range.c:164
+#: gphoto2/range.c:112 gphoto2/range.c:166
 #, c-format
 msgid ""
 "%s\n"
@@ -1579,7 +1632,7 @@ msgstr ""
 "圖像 ID %i 太大。"
 
 # frontends/command-line/range.c:144
-#: gphoto2/range.c:126
+#: gphoto2/range.c:128
 #, c-format
 msgid ""
 "%s\n"
@@ -1589,7 +1642,7 @@ msgstr ""
 "範圍必須由「,」分隔。"
 
 # frontends/command-line/range.c:158
-#: gphoto2/range.c:140
+#: gphoto2/range.c:142
 #, c-format
 msgid ""
 "%s\n"
@@ -1599,7 +1652,7 @@ msgstr ""
 "範圍應以數字開頭。"
 
 # frontends/command-line/range.c:198
-#: gphoto2/range.c:180
+#: gphoto2/range.c:182
 #, c-format
 msgid ""
 "%s\n"
@@ -1609,7 +1662,7 @@ msgstr ""
 "未預期字元「%c」。"
 
 # frontends/command-line/range.c:221
-#: gphoto2/range.c:204
+#: gphoto2/range.c:206
 #, c-format
 msgid ""
 "%s\n"
@@ -1619,249 +1672,258 @@ msgstr ""
 "不允許縮小範圍。您指定了一個從 %i 到 %i 的範圍。"
 
 # frontends/command-line/shell.c:73
-#: gphoto2/shell.c:65
+#: gphoto2/shell.c:67
 #, c-format
 msgid "*** Error (%i: '%s') ***"
 msgstr "*** 錯誤 (%i: 「%s」) ***"
 
 # frontends/command-line/shell.c:112
-#: gphoto2/shell.c:121
+#: gphoto2/shell.c:126
 msgid "Change to a directory on the camera"
 msgstr "進入相機中的目錄"
 
 # frontends/command-line/shell.c:113 frontends/command-line/shell.c:115
-#: gphoto2/shell.c:122 gphoto2/shell.c:124 gphoto2/shell.c:135
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:127 gphoto2/shell.c:129 gphoto2/shell.c:140
+#: gphoto2/shell.c:141
 msgid "directory"
 msgstr "目錄"
 
 # frontends/command-line/shell.c:114
-#: gphoto2/shell.c:123
+#: gphoto2/shell.c:128
 msgid "Change to a directory on the local drive"
 msgstr "進入本機儲存裝置中的目錄"
 
 # frontends/command-line/shell.c:116 frontends/command-line/shell.c:134
 # frontends/command-line/shell.c:135
-#: gphoto2/shell.c:125 gphoto2/shell.c:156 gphoto2/shell.c:157
+#: gphoto2/shell.c:130 gphoto2/shell.c:164 gphoto2/shell.c:165
 msgid "Exit the gPhoto shell"
 msgstr "離開 gPhoto shell"
 
 # frontends/command-line/shell.c:117
-#: gphoto2/shell.c:126
+#: gphoto2/shell.c:131
 msgid "Download a file"
 msgstr "下載一個檔案"
 
 # frontends/command-line/shell.c:117 frontends/command-line/shell.c:120
 # frontends/command-line/shell.c:122 frontends/command-line/shell.c:124
 # frontends/command-line/shell.c:125 frontends/command-line/shell.c:128
-#: gphoto2/shell.c:126 gphoto2/shell.c:127 gphoto2/shell.c:129
-#: gphoto2/shell.c:131 gphoto2/shell.c:133 gphoto2/shell.c:134
-#: gphoto2/shell.c:139
+#: gphoto2/shell.c:131 gphoto2/shell.c:132 gphoto2/shell.c:134
+#: gphoto2/shell.c:136 gphoto2/shell.c:138 gphoto2/shell.c:139
+#: gphoto2/shell.c:144
 msgid "[directory/]filename"
 msgstr "[目錄/]檔案"
 
 # frontends/command-line/shell.c:117
-#: gphoto2/shell.c:127
+#: gphoto2/shell.c:132
 msgid "Upload a file"
 msgstr "上傳一個檔案"
 
 # frontends/command-line/shell.c:119
-#: gphoto2/shell.c:128
+#: gphoto2/shell.c:133
 msgid "Download a thumbnail"
 msgstr "下載一張縮圖"
 
 # frontends/command-line/shell.c:121
-#: gphoto2/shell.c:130
+#: gphoto2/shell.c:135
 msgid "Download raw data"
 msgstr "下載原始資料"
 
 # frontends/command-line/shell.c:125
-#: gphoto2/shell.c:134
+#: gphoto2/shell.c:139
 msgid "Delete"
 msgstr "刪除"
 
 # frontends/command-line/main.c:216
-#: gphoto2/shell.c:135
+#: gphoto2/shell.c:140
 msgid "Create Directory"
 msgstr "建立目錄"
 
 # frontends/command-line/main.c:217
-#: gphoto2/shell.c:136
+#: gphoto2/shell.c:141
 msgid "Remove Directory"
 msgstr "移除目錄"
 
 # frontends/command-line/shell.c:130 frontends/command-line/shell.c:136
-#: gphoto2/shell.c:141 gphoto2/shell.c:158
+#: gphoto2/shell.c:146 gphoto2/shell.c:166
 msgid "Displays command usage"
 msgstr "顯示命令用法"
 
 # frontends/command-line/shell.c:131 frontends/command-line/shell.c:136
-#: gphoto2/shell.c:142 gphoto2/shell.c:158
+#: gphoto2/shell.c:147 gphoto2/shell.c:166
 msgid "[command]"
 msgstr "[命令]"
 
 # frontends/command-line/shell.c:132
-#: gphoto2/shell.c:143
+#: gphoto2/shell.c:148
 msgid "List the contents of the current directory"
 msgstr "列出目前目錄的內容"
 
 # frontends/command-line/shell.c:133
-#: gphoto2/shell.c:144
+#: gphoto2/shell.c:149
 msgid "[directory/]"
 msgstr "[目錄]"
 
-#: gphoto2/shell.c:145
+#: gphoto2/shell.c:152
 msgid "List configuration variables"
 msgstr "表列組態變數"
 
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "Get configuration variable"
 msgstr "取得組態變數"
 
 # frontends/command-line/main.c:216 frontends/command-line/main.c:217
-#: gphoto2/shell.c:146
+#: gphoto2/shell.c:153
 msgid "name"
 msgstr "名稱"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "Set configuration variable"
 msgstr "設置組態變數"
 
-#: gphoto2/shell.c:147 gphoto2/shell.c:149
+#: gphoto2/shell.c:154 gphoto2/shell.c:156
 msgid "name=value"
 msgstr "名稱=值"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "Set configuration variable index"
 msgstr "設定組態變數索引"
 
-#: gphoto2/shell.c:148
+#: gphoto2/shell.c:155
 msgid "name=valueindex"
 msgstr "name=值索引"
 
 # frontends/command-line/main.c:234
-#: gphoto2/shell.c:150
+#: gphoto2/shell.c:157
+#, fuzzy
+msgid "Triggers the capture of a single image"
+msgstr "觸發圖像的擷取"
+
+# frontends/command-line/main.c:234
+#: gphoto2/shell.c:158
 msgid "Capture a single image"
 msgstr "擷取單一圖像"
 
 # frontends/command-line/main.c:234
-#: gphoto2/shell.c:151
+#: gphoto2/shell.c:159
 msgid "Capture a single image and download it"
 msgstr "擷取單一圖像並下載它"
 
 # frontends/command-line/main.c:234
-#: gphoto2/shell.c:152
+#: gphoto2/shell.c:160
 msgid "Capture a preview image"
 msgstr "擷取預覽圖像"
 
-#: gphoto2/shell.c:153
+#: gphoto2/shell.c:161
 msgid "Wait for an event"
 msgstr "等待一個事件"
 
-#: gphoto2/shell.c:153 gphoto2/shell.c:154 gphoto2/shell.c:155
+#: gphoto2/shell.c:161 gphoto2/shell.c:162 gphoto2/shell.c:163
 msgid "count or seconds"
 msgstr "計數或秒"
 
-#: gphoto2/shell.c:154
+#: gphoto2/shell.c:162
 msgid "Wait for images to be captured and download it"
 msgstr "等待要擷取且下載的圖像"
 
-#: gphoto2/shell.c:155
+#: gphoto2/shell.c:163
 msgid "Wait for events and images to be captured and download it"
 msgstr "等待事件與圖像以擷取並下載它"
 
 # frontends/command-line/shell.c:414
-#: gphoto2/shell.c:480
+#: gphoto2/shell.c:488
 msgid "Invalid command."
 msgstr "不正確命令。"
 
 # frontends/command-line/shell.c:423
-#: gphoto2/shell.c:489
+#: gphoto2/shell.c:497
 #, c-format
 msgid "The command '%s' requires an argument."
 msgstr "命令「%s」需要一個引數。"
 
 # frontends/command-line/shell.c:476
-#: gphoto2/shell.c:542
+#: gphoto2/shell.c:550
 msgid "Invalid path."
 msgstr "不正確路徑。"
 
 # frontends/command-line/shell.c:522
-#: gphoto2/shell.c:588
+#: gphoto2/shell.c:596
 msgid "Could not find home directory."
 msgstr "無法找到家目錄。"
 
 # frontends/command-line/shell.c:530
-#: gphoto2/shell.c:597
+#: gphoto2/shell.c:605
 #, c-format
 msgid "Could not change to local directory '%s'."
 msgstr "無法進入本地目錄「%s」。"
 
 # frontends/command-line/shell.c:533
-#: gphoto2/shell.c:600
+#: gphoto2/shell.c:608
 #, c-format
 msgid "Local directory now '%s'."
 msgstr "本地目錄為「%s」。"
 
 # frontends/command-line/shell.c:564
-#: gphoto2/shell.c:638
+#: gphoto2/shell.c:646
 #, c-format
 msgid "Remote directory now '%s'."
 msgstr "遠端目錄為「%s」。"
 
-#: gphoto2/shell.c:854
+#: gphoto2/shell.c:874
 #, c-format
 msgid "set-config needs a second argument.\n"
 msgstr "set-config 需要第二引數。\n"
 
-#: gphoto2/shell.c:875
+#: gphoto2/shell.c:895
 #, c-format
 msgid "set-config-value needs a second argument.\n"
 msgstr "set-config-value 需要第二個引數。\n"
 
-#: gphoto2/shell.c:896
+#: gphoto2/shell.c:916
 #, c-format
 msgid "set-config-index needs a second argument.\n"
 msgstr "set-config-index 需要第二個引數。\n"
 
 # frontends/command-line/shell.c:743
-#: gphoto2/shell.c:948
+#: gphoto2/shell.c:979
 #, c-format
 msgid "Command '%s' not found. Use 'help' to get a list of available commands."
 msgstr "未找到「%s」命令。用「help」獲取可用的命令列表。"
 
 # frontends/command-line/shell.c:750
-#: gphoto2/shell.c:955
+#: gphoto2/shell.c:986
 #, c-format
 msgid "Help on \"%s\":"
 msgstr "關於「%s」的求助資訊:"
 
 # frontends/command-line/shell.c:752
-#: gphoto2/shell.c:957
+#: gphoto2/shell.c:988
 #, c-format
 msgid "Usage:"
 msgstr "用法:"
 
 # frontends/command-line/shell.c:756
-#: gphoto2/shell.c:960
+#: gphoto2/shell.c:991
 #, c-format
 msgid "Description:"
 msgstr "描述:"
 
 # frontends/command-line/shell.c:758
-#: gphoto2/shell.c:962
+#: gphoto2/shell.c:993
 #, c-format
 msgid "* Arguments in brackets [] are optional"
 msgstr "* 出現在方括號 [] 中的引數是可選的"
 
 # frontends/command-line/shell.c:779
-#: gphoto2/shell.c:983
+#: gphoto2/shell.c:1014
 #, c-format
 msgid "Available commands:"
 msgstr "可用的命令:"
 
 # frontends/command-line/shell.c:784
-#: gphoto2/shell.c:988
+#: gphoto2/shell.c:1019
 #, c-format
 msgid "To get help on a particular command, type in 'help command-name'."
 msgstr "為得到特定命令的求助資訊，輸入「help 命令名」。"
+
+#~ msgid "Trigger image capture"
+#~ msgstr "觸發圖像擷取"


### PR DESCRIPTION
I wanted a simple key value format to use gphoto2 as a cli with shell and other scripting languages without creating a language binding to libgphoto2.

```
Johns-Air:gphoto2 john$ ./gphoto2 --list-files --parsable
FILENAME=/store_00010001/DCIM/100NC1V3/DSC_7616.JPG PERMS=rd FILESIZE=6092682 IMGWIDTH=5232 IMGHEIGHT=3488 FILETYPE=image/jpeg FILEMTIME=1619885302
FILENAME=/store_00010001/DCIM/100NC1V3/DSC_7641.JPG PERMS=rd FILESIZE=6237827 IMGWIDTH=5232 IMGHEIGHT=3488 FILETYPE=image/jpeg FILEMTIME=1619888132
FILENAME=/store_00010001/DCIM/100NC1V3/DSC_7642.JPG PERMS=rd FILESIZE=6180582 IMGWIDTH=5232 IMGHEIGHT=3488 FILETYPE=image/jpeg FILEMTIME=1619888132
FILENAME=/store_00010001/DCIM/100NC1V3/DSC_7664.JPG PERMS=rd FILESIZE=6088643 IMGWIDTH=5232 IMGHEIGHT=3488 FILETYPE=image/jpeg FILEMTIME=1620059960
FILENAME=/store_00010001/DCIM/100NC1V3/DSC_7665.JPG PERMS=rd FILESIZE=6685728 IMGWIDTH=5232 IMGHEIGHT=3488 FILETYPE=image/jpeg FILEMTIME=1620060472
```

This PR also adds mtime to the current --list-files output.

Unfortunate that all the po files get updated with a source file change.  I guess that's just the way it works?