### PR TITLE
Match prototypes of callbacks with libgphoto

### DIFF
--- a/gphoto2/main.c
+++ b/gphoto2/main.c
@@ -1198,7 +1198,7 @@ thread_func (void *data)
 	pthread_cleanup_pop (1);
 }
 
-static pthread_t
+static unsigned int
 start_timeout_func (Camera *camera, unsigned int timeout,
 		    CameraTimeoutFunc func, void __unused__ *data)
 {
@@ -1215,14 +1215,14 @@ start_timeout_func (Camera *camera, unsigned int timeout,
 
 	pthread_create (&tid, NULL, thread_func, td);
 
-	return (tid);
+	return (unsigned int)tid;
 }
 
 static void
-stop_timeout_func (Camera __unused__ *camera, pthread_t id,
+stop_timeout_func (Camera __unused__ *camera, unsigned int id,
 		   void __unused__ *data)
 {
-	pthread_t tid = id;
+	pthread_t tid = (pthread_t)id;
 
 	pthread_cancel (tid);
 	pthread_join (tid, NULL);


### PR DESCRIPTION
In https://github.com/gphoto/gphoto2/pull/535/commits/ccc4c1f092bd21ebc713f4d7b9be85be49f92f1e we tried to fix by using pthread_t but it also needs to make changes in libgphoto and these changes can be invasive, therefore lets revert to older types and to fix musl problem fix it via type casts