### PR TITLE
Fix misc. source comment typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,7 +39,7 @@
 2009-06-21  Marcus Meissner  <marcus@jet.franken.de>
 
 	* main.c,action.c,shell.c: 
-	  Added seperate --set-config-index and --set-config-value functions
+	  Added separate --set-config-index and --set-config-value functions
 	  for menu choice settings.
 
 	* main.c: Save files with current umask, not 0600.

--- a/NEWS
+++ b/NEWS
@@ -165,7 +165,7 @@ gphoto2 2.4.10
 
  * --capture-movie (optional arguments: frames, or seconds)
    now loops over preview capture as fast as possible
-   and writes the frames continously.
+   and writes the frames continuously.
 
    The resulting file is "MotionJPEG" and can be postprocessed
    or displayed (by mplayer).

--- a/contrib/README
+++ b/contrib/README
@@ -12,7 +12,7 @@ You can see a list of contributions with a short summary below.
 
 multi-capture/
    Alesan's scripts and stuff which captures from four cameras
-   simultanously.
+   simultaneously.
 
 simple-mtpupload/
    Marcus script to upload MP3s +metadata to a MTP player.

--- a/gphoto2/main.c
+++ b/gphoto2/main.c
@@ -1104,7 +1104,7 @@ capture_generic (CameraCaptureType type, const char __unused__ *name, int downlo
 			else if (!capture_now) {
 				/*
 				 * In the case of a (huge) time-sync while gphoto is running,
-				 * gphoto could percieve an extremely large amount of time and
+				 * gphoto could perceive an extremely large amount of time and
 				 * stay "behind schedule" quite forever. That's why I reduce the
 				 * difference of time with the following loop.
 				 * [alesan]
@@ -2302,7 +2302,7 @@ main (int argc, char **argv, char **envp)
 	poptResetContext (ctx);
 	while ((cb_params.p.r >= GP_OK) && (poptGetNextOpt (ctx) >= 0));
 	/* Load default values for --filename and --hook-script if not
-	 * explicitely specified
+	 * explicitly specified
 	 */
 	if (!gp_params.filename) {
 		char buf[256];
@@ -2525,7 +2525,7 @@ main (int argc, char **argv, char **envp)
 
 	/*
 	 * Recursion is too dangerous for deletion. Only turn it on if
-	 * explicitely specified.
+	 * explicitly specified.
 	 */
 	cb_params.type = CALLBACK_PARAMS_TYPE_QUERY;
 	cb_params.p.q.found = 0;

--- a/gphoto2/spawnve.c
+++ b/gphoto2/spawnve.c
@@ -69,7 +69,7 @@ spawnve(const char *filename, char *const argv[], char *const envp[])
       }
       return 0;
     } else {
-      /* some error occured */
+      /* some error occurred */
       fprintf(stderr, "error waiting for child\n");
       return -1;
     }


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po`